### PR TITLE
Fix fatal error because wc_get_order is not ready.

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -106,7 +106,6 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 
 	public function process_payment( $order_id ) {
 
-		$order = wc_get_order( $order_id );
 		$checkout = wc_gateway_ppec()->checkout;
 
 		// Check the session.  Are we going to just complete an existing payment, or are we going to
@@ -118,7 +117,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 				! $session->payerID ) {
 			// Redirect them over to PayPal.
 			try {
-				$redirect_url = $checkout->startCheckoutFromCheckout( $order_id, 'paypal_credit' == $this->id );
+				$redirect_url = $checkout->startCheckoutFromCheckout( $order_id, 'ppec_cards' === $this->id );
 				$settings     = wc_gateway_ppec()->settings->loadSettings();
 				if ( $settings->enableInContextCheckout && $settings->getActiveApiCredentials()->get_payer_id() ) {
 					$redirect_url = 'javascript:woo_pp_checkout_callback("' . urlencode( $redirect_url ) . '");';

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -246,14 +246,7 @@ class WC_Gateway_PPEC_Plugin {
 			exit;
 		}
 
-		// If the buyer clicked on the "Check Out with PayPal" button, we need to wait for the cart
-		// totals to be available.  Unfortunately that doesn't happen until
-		// woocommerce_before_cart_totals executes, and there is already output sent to the browser by
-		// this point.  So, to get around this issue, we'll enable output buffering to prevent WP from
-		// sending anything back to the browser.
-		if ( isset( $_GET['startcheckout'] ) && 'true' == $_GET['startcheckout'] ) {
-			ob_start();
-		}
+
 
 		// Also start buffering if we're on an admin page and the merchant is trying to use Easy Signup.
 		$is_ips_signup = isset( $_GET['ips-signup'] ) && 'true' == $_GET['ips-signup'];
@@ -262,97 +255,6 @@ class WC_Gateway_PPEC_Plugin {
 			ob_start();
 		}
 
-		if ( isset( $_GET['woo-paypal-return'] ) && 'true' == $_GET['woo-paypal-return'] ) {
-			// call get ec and do ec
-			// Make sure we have our token and payer ID
-			if ( array_key_exists( 'token', $_GET ) && array_key_exists( 'PayerID', $_GET ) &&
-					! empty( $_GET['token'] ) && ! empty( $_GET['PayerID'] ) ) {
-				$token = $_GET['token'];
-				$payer_id = $_GET['PayerID'];
-			} else {
-				// If the token and payer ID aren't there, just ignore this request
-				return;
-			}
 
-			try {
-				$checkout_details = $this->checkout->getCheckoutDetails( $token );
-			} catch( PayPal_API_Exception $e ) {
-				wc_add_notice( __( 'Sorry, an error occurred while trying to retrieve your information from PayPal.  Please try again.', 'woocommerce-gateway-paypal-express-checkout' ), 'error' );
-				return;
-			} catch( PayPal_Missing_Session_Exception $e ) {
-				wc_add_notice( __( 'Your PayPal checkout session has expired.  Please check out again.', 'woocommerce-gateway-paypal-express-checkout' ), 'error' );
-				return;
-			}
-
-			$session = WC()->session->paypal;
-			if ( ! $session || ! is_a( $session, 'WC_Gateway_PPEC_Session_Data' ) ||
-					$session->expiry_time < time() || $token != $session->token ) {
-				wc_add_notice( __( 'Your PayPal checkout session has expired.  Please check out again.', 'woocommerce-gateway-paypal-express-checkout' ), 'error' );
-				return;
-			}
-
-			$session->checkout_completed = true;
-			$session->payerID = $payer_id;
-
-			WC()->session->paypal = $session;
-
-			if ( $session->using_ppc ) {
-				WC()->session->chosen_payment_method = 'paypal_credit';
-			} else {
-				WC()->session->chosen_payment_method = 'paypal';
-			}
-
-			if ( 'order' == $session->leftFrom && $session->order_id ) {
-				// Try to complete the payment now.
-				try {
-					$order_id        = $session->order_id;
-					$payment_details = $this->checkout->completePayment( $order_id, $session->token, $session->payerID );
-					$transaction_id  = $payment_details->payments[0]->transaction_id;
-
-					// TODO: Handle things like eChecks, giropay, etc.
-					$order = wc_get_order( $order_id );
-					$order->payment_complete( $transaction_id );
-					$order->add_order_note( sprintf( __( 'PayPal transaction completed; transaction ID = %s', 'woocommerce-gateway-paypal-express-checkout' ), $transaction_id ) );
-					$order->reduce_order_stock();
-					WC()->cart->empty_cart();
-					unset( WC()->session->paypal );
-
-					wp_safe_redirect( $order->get_checkout_order_received_url() );
-					exit;
-				} catch( PayPal_Missing_Session_Exception $e ) {
-					// For some reason, our session data is missing.  Generally, if we've made it this far,
-					// this shouldn't happen.
-					wc_add_notice( __( 'Sorry, an error occurred while trying to process your payment.  Please try again.', 'woocommerce-gateway-paypal-express-checkout' ), 'error' );
-				} catch( PayPal_API_Exception $e ) {
-					// Did we get a 10486 or 10422 back from PayPal?  If so, this means we need to send the buyer back over to
-					// PayPal to have them pick out a new funding method.
-					$need_to_redirect_back = false;
-					foreach ( $e->errors as $error ) {
-						if ( '10486' == $error->error_code || '10422' == $error->error_code ) {
-							$need_to_redirect_back = true;
-						}
-					}
-
-					if ( $need_to_redirect_back ) {
-						$settings = new WC_Gateway_PPEC_Settings();
-						$session->checkout_completed = false;
-						$session->leftFrom = 'order';
-						$session->order_id = $order_id;
-						WC()->session->paypal = $session;
-						wp_safe_redirect( $settings->getPayPalRedirectUrl( $session->token, true ) );
-						exit;
-					} else {
-						$final_output = '<ul>';
-						foreach ( $e->errors as $error ) {
-							// These strings are located in lib/class-exception.php
-							$final_output .= '<li>' . __( $error->maptoBuyerFriendlyError(), 'woocommerce-gateway-paypal-express-checkout' ) . '</li>';
-						}
-						$final_output .= '</ul>';
-						wc_add_notice( __( 'Payment error:', 'woocommerce-gateway-paypal-express-checkout' ) . $final_output, 'error' );
-						return;
-					}
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
Moved the logic to check if returned from PayPal into `wp`.

Fixes #42 
