### PR TITLE
Disable PayPal credit if country of base location is not US.

### DIFF
--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -15,6 +15,7 @@ class WC_Gateway_PPEC_Admin_Handler {
 	public function __construct() {
 		add_action( 'woocommerce_update_options_general', array( $this, 'force_zero_decimal' ) );
 		add_action( 'admin_notices', array( $this, 'show_decimal_warning' ) );
+		add_action( 'admin_notices', array( $this, 'maybe_show_unsupported_paypal_credit' ) );
 
 		add_filter( 'woocommerce_get_sections_checkout', array( $this, 'filter_checkout_sections' ) );
 	}
@@ -43,6 +44,19 @@ class WC_Gateway_PPEC_Admin_Handler {
 			</div>
 			<?php
 			delete_option( 'wc_gateway_ppce_display_decimal_msg' );
+		}
+	}
+
+	public function maybe_show_unsupported_paypal_credit() {
+		$ppc_enabled = wc_gateway_ppec()->settings->ppcEnabled;
+		if ( $ppc_enabled && 'US' !== WC()->countries->get_base_country() ) {
+			?>
+			<div class="notice notice-warning fade">
+				<p>
+					<strong><?php _e( 'NOTE: PayPal Credit is not supported on your base location.', 'woocommerce-gateway-paypal-express-checkout' ); ?></strong>
+				</p>
+			</div>
+			<?php
 		}
 	}
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -84,7 +84,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				</a>
 			</span>
 
-			<?php if ( $settings->ppcEnabled ) : ?>
+			<?php if ( $settings->ppcEnabled && 'US' === WC()->countries->get_base_country() ) : ?>
 				<?php
 				$redirect = add_query_arg( array( 'use-ppc' => 'true' ), $redirect );
 				?>

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -40,6 +40,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		add_action( 'woocommerce_before_checkout_process', array( $this, 'before_checkout_process' ) );
 		add_action( 'woocommerce_checkout_process', array( $this, 'checkout_process' ) );
 		add_action( 'woocommerce_after_checkout_form', array( $this, 'after_checkout_form' ) );
+		add_action( 'woocommerce_available_payment_gateways', array( $this, 'maybe_disable_paypal_credit' ) );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
@@ -235,6 +236,22 @@ class WC_Gateway_PPEC_Checkout_Handler {
 				wp_enqueue_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
 			}
 		}
+	}
+
+	/**
+	 * If base location is not US, disable PayPal Credit.
+	 *
+	 * @since 1.0.0
+	 * @param array $gateways Available gateways
+	 *
+	 * @return array Available gateways
+	 */
+	public function maybe_disable_paypal_credit( $gateways ) {
+		if ( isset( $gateways['ppec_cards'] ) && 'US' !== WC()->countries->get_base_country() ) {
+			unset( $gateways['ppec_cards'] );
+		}
+
+		return $gateways;
 	}
 
 	public function enablePayPalCredit( $enable = true ) {


### PR DESCRIPTION
Resolves #15.
