### PR TITLE
Pass locale args to JS setup when in-context checkout is enabled.

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -100,12 +100,14 @@ class WC_Gateway_PPEC_Cart_Handler {
 		<?php
 		if ( $settings->enableInContextCheckout && $settings->getActiveApiCredentials()->get_payer_id() ) {
 			$payer_id = $settings->getActiveApiCredentials()->get_payer_id();
+			$setup_args = array(
+				'button' => array( 'woo_pp_ec_button', 'woo_pp_ppc_button' ),
+				'locale' => $settings->get_paypal_locale(),
+			);
 			?>
 			<script type="text/javascript">
 				window.paypalCheckoutReady = function() {
-					paypal.checkout.setup( '<?php echo $payer_id; ?>', {
-						button: [ 'woo_pp_ec_button', 'woo_pp_ppc_button' ]
-					});
+					paypal.checkout.setup( <?php echo json_encode( $payer_id ); ?>, <?php echo json_encode( $setup_args ); ?> );
 				}
 			</script>
 			<?php
@@ -123,6 +125,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		if ( $settings->enabled && $settings->enableInContextCheckout && $settings->getActiveApiCredentials()->get_payer_id() ) {
 			wp_enqueue_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
 		}
+
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -29,6 +29,12 @@ class WC_Gateway_PPEC_Settings {
 		'ipsPrivateKey',
 	);
 
+	protected $_supportedLocale = array(
+		'da_DK', 'de_DE', 'en_AU', 'en_GB', 'en_US', 'es_ES', 'fr_CA', 'fr_FR',
+		'he_IL', 'id_ID', 'it_IT', 'ja_JP', 'nl_NL', 'no_NO', 'pl_PL', 'pt_BR',
+		'pt_PT', 'ru_RU', 'sv_SE', 'th_TH', 'tr_TR', 'zh_CN', 'zh_HK', 'zh_TW',
+	);
+
 	const PaymentActionSale          = 'Sale';
 	const PaymentActionAuthorization = 'Authorization';
 
@@ -388,5 +394,14 @@ class WC_Gateway_PPEC_Settings {
 			&&
 			0 !== $decimals
 		);
+	}
+
+	public function get_paypal_locale() {
+		$locale = get_locale();
+		if ( ! in_array( $locale, $this->_supportedLocale ) ) {
+			$locale = 'en_US';
+		}
+
+		return $locale;
 	}
 }


### PR DESCRIPTION
Resolves #49.
