### PR TITLE
Fix fatal error caused by passing empty() a non-variables.

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -228,14 +228,17 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$settings = wc_gateway_ppec()->settings->load_settings( true );
 		$creds    = $settings->get_active_api_credentials();
 
-		if ( ! empty( $creds->get_username() ) ) {
+		$username = $creds->get_username();
+		$password = $creds->get_password();
 
-			if ( empty( $creds->get_password() ) ) {
+		if ( ! empty( $username ) ) {
+
+			if ( empty( $password ) ) {
 				WC_Admin_Settings::add_error( sprintf( __( 'Error: You must enter a %s API password.' ), __( $settings->get_environment(), 'woocommerce-gateway-paypal-express-checkout' ) ) );
 				return false;
 			}
 
-			if ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Signature' ) && ! empty( $creds->get_signature() ) ) {
+			if ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Signature' ) && $creds->get_signature() ) {
 
 				try {
 
@@ -250,7 +253,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 					WC_Admin_Settings::add_error( sprintf( __( 'An error occurred while trying to validate your %s API credentials.  Unable to verify that your API credentials are correct.', 'woocommerce-gateway-paypal-express-checkout' ), __( $settings->get_environment(), 'woocommerce-gateway-paypal-express-checkout' ) ) );
 				}
 
-			} elseif ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Certificate' ) && ! empty( $creds->get_certificate() ) ) {
+			} elseif ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Certificate' ) && $creds->get_certificate() ) {
 
 				$cert = @openssl_x509_read( $creds->get_certificate() );
 

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -4,8 +4,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$needs_creds         = empty( $this->get_option( 'api_username' ) );
-$needs_sandbox_creds = empty( $this->get_option( 'sandbox_api_username' ) );
+$api_username         = $this->get_option( 'api_username' );
+$sandbox_api_username = $this->get_option( 'sandbox_api_username' );
+
+$needs_creds         = empty( $api_username );
+$needs_sandbox_creds = empty( $sandbox_api_username );
 $enable_ips          = wc_gateway_ppec()->ips->is_supported();
 
 if ( $enable_ips && $needs_creds ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes, akeda, dwainm, royho, allendav, slash1andy,
 Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, store, sales, sell, shop, shopping, cart, checkout, configurable, paypal
 Requires at least: 4.4
 Tested up to: 4.4
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -84,6 +84,9 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 3. Checkout with PayPal directly from the Cart.
 
 == Changelog ==
+
+= 1.1.1 =
+* Fixed fatal error prior to PHP 5.5 caused by passing empty() a non-variables
 
 = 1.1.0 =
 * Improved flow after express checkout by removing billing and shipping fields and simply allowing shipping method selection.

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Express Checkout Gateway
  * Plugin URI: https://www.woothemes.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: A payment gateway for PayPal Express Checkout (https://www.paypal.com/us/webapps/mpp/express-checkout).
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Copyright: © 2016 WooCommerce / PayPal.
@@ -36,7 +36,7 @@ function wc_gateway_ppec() {
 	if ( ! isset( $plugin ) ) {
 		require_once( 'includes/class-wc-gateway-ppec-plugin.php' );
 
-		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.1.0' );
+		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.1.1' );
 	}
 
 	return $plugin;


### PR DESCRIPTION
This affects PHP version prior to 5.5. See note in
http://us3.php.net/empty.

Resolves #163.
