### PR TITLE
Set PayPal Guest Checkout to enabled by default

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -148,7 +148,7 @@ class WC_Gateway_PPEC_Settings {
 			$params['LOGOIMG'] = $this->logo_image_url;
 		}
 
-		if ( false === apply_filters( 'woocommerce_paypal_express_checkout_allow_guests', true ) ) {
+		if ( apply_filters( 'woocommerce_paypal_express_checkout_allow_guests', true ) ) {
 			$params['SOLUTIONTYPE'] = 'Sole';
 		}
 


### PR DESCRIPTION
Extends to the changes from #166 to the checkout page.  

Fixes #176 

@gedex 