### PR TITLE
Disable cart and mini cart direct checkout buttons when shipping is needed

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -60,10 +60,13 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * Display paypal button on the cart page
 	 */
 	public function display_paypal_button() {
+
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 		$settings = wc_gateway_ppec()->settings;
 
-		if ( ! isset( $gateways['ppec_paypal'] ) ) {
+		// issues/179 don't allow buttons to show on cart page as we need
+		// billing details on checkout page to calculate shipping costs
+		if ( ! isset( $gateways['ppec_paypal'] ) || WC()->cart->needs_shipping() ) {
 			return;
 		}
 		?>
@@ -86,10 +89,12 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * Display paypal button on the cart widget
 	 */
 	public function display_mini_paypal_button() {
-		$gateways = WC()->payment_gateways->get_available_payment_gateways();
-		$settings = wc_gateway_ppec()->settings;
 
-		if ( ! isset( $gateways['ppec_paypal'] ) ) {
+		$gateways = WC()->payment_gateways->get_available_payment_gateways();
+
+		// issues/179 don't allow buttons to show on cart page as we need
+		// billing details on checkout page to calculate shipping costs
+		if ( ! isset( $gateways['ppec_paypal'] ) || WC()->cart->needs_shipping() ) {
 			return;
 		}
 		?>

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,9 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 
 == Changelog ==
 
+= 1.1.3 =
+* Fix - Guest users can checkout without giving shipping information when required.
+
 = 1.1.2 =
 * Fix - Make sure translations are loaded properly.
 * Fix - Added IPN (Instant Payment Notification) handler.

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Express Checkout Gateway
  * Plugin URI: https://www.woothemes.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: A payment gateway for PayPal Express Checkout (https://www.paypal.com/us/webapps/mpp/express-checkout).
- * Version: 1.1.2
+ * Version: 1.1.3
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Copyright: © 2016 WooCommerce / PayPal.
@@ -36,7 +36,7 @@ function wc_gateway_ppec() {
 	if ( ! isset( $plugin ) ) {
 		require_once( 'includes/class-wc-gateway-ppec-plugin.php' );
 
-		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.1.2' );
+		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.1.3' );
 	}
 
 	return $plugin;


### PR DESCRIPTION
This will ensure that the user has to go to checkout page and enter billing details. fixes #179