### PR TITLE
Fixed uncaught exception and simplify error message retrieval.

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -96,7 +96,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 					'redirect' => $checkout->start_checkout_from_checkout( $order_id ),
 				);
 			} catch ( PayPal_API_Exception $e ) {
-				wc_gateway_ppec_format_paypal_api_exception( $e->errors );
+				wc_add_notice( $e->getMessage(), 'error' );
 			}
 		} else {
 			try {
@@ -148,7 +148,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 						'redirect' => wc_gateway_ppec()->settings->get_paypal_redirect_url( $session->token, true ),
 					);
 				} else {
-					wc_gateway_ppec_format_paypal_api_exception( $e->errors );
+					wc_add_notice( $e->getMessage(), 'error' );
 				}
 			}
 		}
@@ -363,7 +363,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 					return true;
 
 				} catch ( PayPal_API_Exception $e ) {
-					return $e->to_wp_error( 'paypal_refund_error' );
+					return new WP_Error( 'paypal_refund_error', $e->getMessage() );
 				}
 			}
 		}
@@ -382,7 +382,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 					return true;
 
 				} catch ( PayPal_API_Exception $e ) {
-					return $e->to_wp_error( 'paypal_refund_error' );
+					return new WP_Error( 'paypal_refund_error', $e->getMessage() );
 				}
 
 			}
@@ -427,7 +427,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 
 						return true;
 					} catch ( PayPal_API_Exception $e ) {
-						return $e->to_wp_error( 'paypal_refund_error' );
+						return new WP_Error( 'paypal_refund_error', $e->getMessage() );
 					}
 				}
 			}

--- a/includes/exceptions/class-wc-gateway-ppec-api-exception.php
+++ b/includes/exceptions/class-wc-gateway-ppec-api-exception.php
@@ -54,32 +54,20 @@ class PayPal_API_Exception extends Exception {
 			}
 		}
 
-		$error_objects = array();
-		foreach ( $errors as $value ) {
-			$error_objects[] = new PayPal_API_Error( $value['code'], $value['message'], $value['long'], $value['severity'] );
-		}
-
-		$this->errors = $error_objects;
-	}
-
-	/**
-	 * Returns the errors as WP_Error.
-	 *
-	 * @param string $code WP_Error code
-	 *
-	 * @return WP_Error Returns the errors as WP_Error
-	 */
-	public function to_wp_error( $code ) {
+		$this->errors   = array();
 		$error_messages = array();
-		foreach ( $this->errors as $error ) {
-			/* translators: error code and error message about refund from PayPal API. */
-			$error_messages[] = sprintf( __( 'Error: %1$s - %2$s.', 'woocommerce-gateway-paypal-express-checkout' ), $error->error_code, $error->long_message );
+		foreach ( $errors as $value ) {
+			$error = new PayPal_API_Error( $value['code'], $value['message'], $value['long'], $value['severity'] );
+			$this->errors[] = $error;
+
+			/* translators: placeholders are error code and message from PayPal */
+			$error_messages[] = sprintf( __( 'PayPal error (%1$s): %2$s', 'woocommerce-gateway-paypal-express-checkout' ), $error->error_code, $error->maptoBuyerFriendlyError() );
 		}
 
 		if ( empty( $error_messages ) ) {
 			$error_messages[] = __( 'An error occurred while calling the PayPal API.', 'woocommerce-gateway-paypal-express-checkout' );
 		}
 
-		return new WP_Error( $code, implode( PHP_EOL, $error_messages ) );
+		$this->message = implode( PHP_EOL, $error_messages );
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,7 +8,7 @@ function woo_pp_start_checkout() {
 		wp_safe_redirect( $redirect_url );
 		exit;
 	} catch( PayPal_API_Exception $e ) {
-		wc_gateway_ppec_format_paypal_api_exception( $e->errors );
+		wc_add_notice( $e->getMessage(), 'error' );
 
 		$redirect_url = WC()->cart->get_cart_url();
 		$settings     = wc_gateway_ppec()->settings;
@@ -37,12 +37,11 @@ function woo_pp_start_checkout() {
 	}
 }
 
+/**
+ * @deprecated
+ */
 function wc_gateway_ppec_format_paypal_api_exception( $errors ) {
-	$error_strings = array();
-	foreach ( $errors as $error ) {
-		$error_strings[] = $error->maptoBuyerFriendlyError();
-	}
-	wc_add_notice( __( 'Payment error:', 'woocommerce-gateway-paypal-express-checkout' ) . '<ul><li>' . implode( '</li><li>', $error_strings ) . '</li></ul>', 'error' );
+	_deprecated_function( 'wc_gateway_ppec_format_paypal_api_exception', '1.2.0', '' );
 }
 
 /**


### PR DESCRIPTION
This change also deprecates wc_gateway_ppec_format_paypal_api_exception,
as it's hard to read for new dev (what this func expects). Better just
to use wc_add_notice and pass the message from exception directly.

Fixes #218.