### PR TITLE
Fix incorrect order's stock reducer.

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec-paypal-request-handler.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec-paypal-request-handler.php
@@ -77,7 +77,7 @@ abstract class WC_Gateway_PPEC_PayPal_Request_Handler {
 	 */
 	protected function payment_on_hold( $order, $reason = '' ) {
 		$order->update_status( 'on-hold', $reason );
-		wc_reduce_stock_levels( $order_id );
+		$order->reduce_order_stock();
 		WC()->cart->empty_cart();
 	}
 }


### PR DESCRIPTION
It should use `$order->reduce_order_stock()` instead of
`wc_reduce_stock_levels()`. The latter is added in 2.7 or `master` branch.

Fixes #228.