### PR TITLE
Fix WooCommerce 2.7 compatibility, address pass back

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec-paypal-request-handler.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec-paypal-request-handler.php
@@ -50,7 +50,14 @@ abstract class WC_Gateway_PPEC_PayPal_Request_Handler {
 			$order_id = wc_get_order_id_by_order_key( $order_key );
 			$order    = wc_get_order( $order_id );
 		}
-		if ( ! $order || $order->order_key !== $order_key ) {
+
+		if ( $order ) {
+			$order_key_from_order = version_compare( WC_VERSION, '2.7', '<' ) ? $order->order_key : $order->get_order_key();
+		} else {
+			$order_key_from_order = '';
+		}
+
+		if ( ! $order || $order_key_from_order !== $order_key ) {
 			wc_gateway_ppec_log( sprintf( '%s: %s', __FUNCTION__, 'Error: Order Keys do not match.' ) );
 			return false;
 		}

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -114,6 +114,9 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 				// Store addresses given by PayPal
 				$order->set_address( $checkout->get_mapped_billing_address( $checkout_details ), 'billing' );
 				$order->set_address( $checkout->get_mapped_shipping_address( $checkout_details ), 'shipping' );
+				if ( version_compare( WC_VERSION, '2.7', '>=' ) ) {
+					$order->save(); // required to avoid other wc_get_order calls in this same http context returning stale orders
+				}
 
 				// Complete the payment now.
 				$checkout->do_payment( $order, $session->token, $session->payer_id );

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -346,7 +346,9 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		// loop through each transaction to compile list of txns that are able to be refunded
 		// process refunds against each txn in the list until full amount of refund is reached
 		// first loop through, try to find a transaction that equals the refund amount being requested
-		$txn_data = get_post_meta( $order_id, '_woo_pp_txnData', true );
+		$old_wc = version_compare( WC_VERSION, '2.7', '<' );
+		$txn_data = $old_wc ? get_post_meta( $order_id, '_woo_pp_txnData', true ) : $order->get_meta( '_woo_pp_txnData', true );
+		$order_currency = $old_wc ? $order->order_currency : $order->get_currency();
 
 		foreach ( $txn_data['refundable_txns'] as $key => $value ) {
 			$refundable_amount = $value['amount'] - $value['refunded_amount'];
@@ -355,10 +357,14 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 				$refund_type = ( 0 == $value['refunded_amount'] ) ? 'Full' : 'Partial';
 
 				try {
-					$refund_txn_id = WC_Gateway_PPEC_Refund::refund_order( $order, $amount, $refund_type, $reason, $order->get_order_currency() );
+					$refund_txn_id = WC_Gateway_PPEC_Refund::refund_order( $order, $amount, $refund_type, $reason, $order_currency );
 					$txn_data['refundable_txns'][ $key ]['refunded_amount'] += $amount;
 					$order->add_order_note( sprintf( __( 'PayPal refund completed; transaction ID = %s', 'woocommerce-gateway-paypal-express-checkout' ), $refund_txn_id ) );
-					update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
+					if ( $old_wc ) {
+						update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
+					} else {
+						$order->update_meta_data( '_woo_pp_txnData', $txn_data );
+					}
 
 					return true;
 
@@ -374,10 +380,14 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 			if ( $amount < $refundable_amount ) {
 
 				try {
-					$refund_txn_id = WC_Gateway_PPEC_Refund::refund_order( $order, $amount, 'Partial', $reason, $order->get_order_currency() );
+					$refund_txn_id = WC_Gateway_PPEC_Refund::refund_order( $order, $amount, 'Partial', $reason, $order_currency );
 					$txn_data['refundable_txns'][ $key ]['refunded_amount'] += $amount;
 					$order->add_order_note( sprintf( __( 'PayPal refund completed; transaction ID = %s', 'woocommerce-gateway-paypal-express-checkout' ), $refund_txn_id ) );
-					update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
+					if ( $old_wc ) {
+						update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
+					} else {
+						$order->update_meta_data( '_woo_pp_txnData', $txn_data );
+					}
 
 					return true;
 
@@ -419,11 +429,15 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 					}
 
 					try {
-						$refund_txn_id = WC_Gateway_PPEC_Refund::refund_order( $order, $amount_to_refund, $refund_type, $reason, $order->get_order_currency() );
+						$refund_txn_id = WC_Gateway_PPEC_Refund::refund_order( $order, $amount_to_refund, $refund_type, $reason, $order_currency );
 						$total_to_refund -= $amount_to_refund;
 						$txn_data['refundable_txns'][ $key ]['refunded_amount'] += $amount_to_refund;
 						$order->add_order_note( sprintf( __( 'PayPal refund completed; transaction ID = %s', 'woocommerce-gateway-paypal-express-checkout' ), $refund_txn_id ) );
-						update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
+						if ( $old_wc ) {
+							update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
+						} else {
+							$order->update_meta_data( '_woo_pp_txnData', $txn_data );
+						}
 
 						return true;
 					} catch ( PayPal_API_Exception $e ) {

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -251,14 +251,6 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			return;
 		}
 
-		// TODO: When https://github.com/woocommerce/woocommerce/issues/13269 is fixed
-		// we don't need to do this anymore to avoid "undefined index" notices for
-		// billing_first_name and billing_last_name
-		if ( version_compare( WC_VERSION, '2.7', '>=' ) ) {
-			$checkout->posted['billing_first_name'] = $payer_info['billing_first_name'];
-			$checkout->posted['billing_last_name'] = $payer_info['billing_last_name'];
-		}
-
 		if ( $checkout->must_create_account || ! empty( $checkout->posted['createaccount'] ) ) {
 			foreach ( $payer_info as $k => $v ) {
 				$checkout->posted[ $k ] = $v;
@@ -784,8 +776,8 @@ class WC_Gateway_PPEC_Checkout_Handler {
 
 		$old_wc = version_compare( WC_VERSION, '2.7', '<' );
 		if ( $old_wc ) {
-			update_post_meta( $order_id, '_paypal_status', strtolower( $payment->payment_status ) );
-			update_post_meta( $order_id, '_transaction_id', $payment->transaction_id );
+			update_post_meta( $order->id, '_paypal_status', strtolower( $payment->payment_status ) );
+			update_post_meta( $order->id, '_transaction_id', $payment->transaction_id );
 		} else {
 			$order->update_meta_data( '_paypal_status', strtolower( $payment->payment_status ) );
 			$order->update_meta_data( '_transaction_id', $payment->transaction_id );

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -251,6 +251,14 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			return;
 		}
 
+		// TODO: When https://github.com/woocommerce/woocommerce/issues/13269 is fixed
+		// we don't need to do this anymore to avoid "undefined index" notices for
+		// billing_first_name and billing_last_name
+		if ( version_compare( WC_VERSION, '2.7', '>=' ) ) {
+			$checkout->posted['billing_first_name'] = $payer_info['billing_first_name'];
+			$checkout->posted['billing_last_name'] = $payer_info['billing_last_name'];
+		}
+
 		if ( $checkout->must_create_account || ! empty( $checkout->posted['createaccount'] ) ) {
 			foreach ( $payer_info as $k => $v ) {
 				$checkout->posted[ $k ] = $v;

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -112,7 +112,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		} else {
 			$checkout_fields = $checkout->get_checkout_fields();
 			$checkout_fields['billing'] = array();
-			$checkout_fields['billing'] = array();
+			$checkout_fields['shipping'] = array();
 			$checkout->checkout_fields = $checkout_fields;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 
 = 1.2.0 =
 * Fix - Prevent conflict with other gateways.
-* Fix - Compatibility with WooCommerce 2.7
+* Fix - Compatibility with WooCommerce 2.7, including ensuring the customer address is saved correctly.
 
 = 1.1.3 =
 * Fix   - Guest users can checkout without giving shipping information when required.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes, akeda, dwainm, royho, allendav, slash1andy,
 Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, store, sales, sell, shop, shopping, cart, checkout, configurable, paypal
 Requires at least: 4.4
 Tested up to: 4.4
-Stable tag: 1.1.2
+Stable tag: 1.2.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -87,6 +87,7 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 
 = 1.2.0 =
 * Fix - Prevent conflict with other gateways.
+* Fix - Compatibility with WooCommerce 2.7
 
 = 1.1.3 =
 * Fix   - Guest users can checkout without giving shipping information when required.

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,17 +3,17 @@
  * Plugin Name: WooCommerce PayPal Express Checkout Gateway
  * Plugin URI: https://www.woothemes.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: A payment gateway for PayPal Express Checkout (https://www.paypal.com/us/webapps/mpp/express-checkout).
- * Version: 1.1.3
+ * Version: 1.2.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
- * Copyright: © 2016 WooCommerce / PayPal.
+ * Copyright: © 2017 WooCommerce / PayPal.
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: woocommerce-gateway-paypal-express-checkout
  * Domain Path: /languages
  */
 /**
- * Copyright (c) 2015 PayPal, Inc.
+ * Copyright (c) 2017 PayPal, Inc.
  *
  * The name of the PayPal may not be used to endorse or promote products derived from this
  * software without specific prior written permission. THIS SOFTWARE IS PROVIDED ``AS IS'' AND
@@ -36,7 +36,7 @@ function wc_gateway_ppec() {
 	if ( ! isset( $plugin ) ) {
 		require_once( 'includes/class-wc-gateway-ppec-plugin.php' );
 
-		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.1.3' );
+		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.2.0' );
 	}
 
 	return $plugin;


### PR DESCRIPTION
Fixes #233 

#### To Test

```
SETUP

- IMPORTANT: You must use a host accessible from the Internet (i.e. not localhost) in order for PayPal chatback/IPN to work
- WP_DEBUG true
- Install and activate the latest WooCommerce 2.7 beta
- Install and activate the Subscriptions extension
- Under wp-admin > WooCommerce > Settings
    - Base location: United States (US) - Washington
    - Currency: United States Dollar ($)
- Under wp-admin > WooCommerce > Settings > Checkout
    - Enable guest checkout: checked
- Under wp-admin > WooCommerce > Settings > Tax > Tax Options
    - Prices entered with tax: No, I will enter prices exclusive of tax
    - Calculate tax based on: Customer shipping address
    - Shipping tax class: Shipping tax class based on cart items
    - Rounding: unchecked
    - Additional tax classes: Reduced rate (first line), Zero rate (second line)
    - Display prices in the shop: Excluding tax
    - Display prices during cart and checkout: Excluding tax
    - Price display suffix: empty (N/A)
    - Display tax totals: Itemized
- Under wp-admin > WooCommerce > Settings > Tax > Standard Rates
    - US, WA, *, *, 7.5000, State Tax, 1, unchecked, checked
- Install and activate the PPEC extension
- Under wp-admin > WooCommerce > Settings > Checkout > PayPal Express Checkout
    - Enable PayPal Express Checkout: checked
    - Environment: Sandbox
    - Save changes (important)
    - Connect to Sandbox using a test account
        - Hint: Create test buyer and test seller accounts at https://developer.paypal.com
        - You have to use a real PayPal account to sign in to developer.paypal.com  - but after you do that you can create all the test buyer and test seller accounts you want - and don’t worry, you won’t be charged real money with the test accounts
        - You can manage test accounts at https://developer.paypal.com/developer/accounts/
        - For example, I created a BUSINESS account  test-seller-us@allendav.com
        - and a PERSONAL account test-buyer-us@allendav.com 
    - Save Changes after connecting (not sure if this is needed or not)
    - Button Size: Large
    - PayPal Mark: unchecked
    - Logo image: empty
    - Header image: empty
    - Page style: empty
    - Landing page: Login (PayPal account login)
    - Enable PayPal credit: unchecked
    - Debug Log: checked
    - Invoice prefix: “WC-“
    - Billing Address: unchecked
    - Payment action: Sale
    - Instant Payments: unchecked
    - Subtotal mismatch behavior: Add another line item
    - Save Changes again
- wp-admin > Products > A Simple Shippable Tax-Free Product
    - Regular Price: 100
    - Tax status: None
    - Tax class: Standard
    - Shipping Weight: 1
    - Shipping Dimensions: 4, 4, 4
- wp-admin > Products > A Simple Shippable Taxable Product
    - Regular Price: 100
    - Tax status: None
    - Tax class: Standard
    - Shipping Weight: 1
    - Shipping Dimensions: 4, 4, 4
- wp-admin > WooCommerce > Settings > Shipping > Rest of the World
    - Flat Rate
        - Tax Status: Taxable
        - 10

ORDER 1
- While logged in, add the item to your cart
- While on the cart view, click on the Check Out with PayPal at the bottom of the cart page
- Verify no PHP notices/errors are logged in PHP error logs (on wpsandbox.me sandboxes, check both public_html/error_log and public_html/wp-admin/error_log
    - Note that a WC_Gateway_PPEC_Client::_request: remote request debug log message may be logged - this is normal
    - Note that a WC_Gateway_PPEC_Client::_process_response: acknowleged response body debug log message may be logged - this is normal
- In the modal that appears, click on Log In to PayPal
- Provide a username and password for a sandbox test buyer account
- Click on Continue
- Verify you are shown the Confirm your PayPal order page
- Click on Place Order
- Verify the order completes successfully and that a complete shipping address is present in the order
- Verify the only things in the logs are success messages (including WC_Gateway_PPEC_Client::_process_response and WC_Gateway_PPEC_Client::_request log messages). Especially make sure there are no PHP notices or WooCommerce deprecation notices.

ORDER 2
- Repeat order 1 but in an incognito window (i.e. not logged into the site)

ORDER 3
- In wp-admin > WooCommerce > Settings > Checkout > PayPal Express Checkout change auth+capture to just auth
- Repeat order 2
- In wp-admin > WooCommerce > Orders, verify you can capture that order successfully

ORDER 4
- In wp-admin > WooCommerce > Settings > Disable guest checkout
- Repeat order 2

REFUND
- Verify you can refund order 2

Repeat all the above with 2.6.x
```