### PR TITLE
Fix 3.0 compatibility, including registration handling

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -111,13 +111,6 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 					$checkout->create_billing_agreement( $order, $checkout_details );
 				}
 
-				// Store addresses given by PayPal
-				$order->set_address( $checkout->get_mapped_billing_address( $checkout_details ), 'billing' );
-				$order->set_address( $checkout->get_mapped_shipping_address( $checkout_details ), 'shipping' );
-				if ( version_compare( WC_VERSION, '3.0', '>=' ) ) {
-					$order->save(); // required to avoid other wc_get_order calls in this same http context returning stale orders
-				}
-
 				// Complete the payment now.
 				$checkout->do_payment( $order, $session->token, $session->payer_id );
 

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -104,7 +104,8 @@ class WC_Gateway_PPEC_Checkout_Handler {
 
 	/**
 	 * Since PayPal doesn't always give us the phone number for the buyer, we need to make
-	 * that field is not required
+	 * that field not required. And if the cart doesn't need shipping at all, don't require
+	 * the address fields either (this is unique to PPEC)
 	 *
 	 * @since 1.2.0
 	 * @param $billing_fields array
@@ -115,6 +116,16 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		if ( array_key_exists( 'billing_phone', $billing_fields ) ) {
 			$billing_fields['billing_phone']['required'] = false;
 		};
+
+		if ( ! WC()->cart->needs_shipping() ) {
+			$not_required_fields = array( 'billing_address_1', 'billing_city', 'billing_state', 'billing_postcode' );
+			foreach ( $not_required_fields as $not_required_field ) {
+				if ( array_key_exists( $not_required_field, $billing_fields ) ) {
+					$billing_fields[ $not_required_field ]['required'] = false;
+				}
+			}
+		}
+
 		return $billing_fields;
 	}
 
@@ -156,7 +167,9 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		if ( empty( $billing_details['address_1'] ) ) {
 			$copyable_keys = array( 'address_1', 'address_2', 'city', 'state', 'postcode', 'country' );
 			foreach ( $copyable_keys as $copyable_key ) {
-				$billing_details[ $copyable_key ] = $shipping_details[ $copyable_key ];
+				if ( array_key_exists( $copyable_key, $shipping_details ) ) {
+					$billing_details[ $copyable_key ] = $shipping_details[ $copyable_key ];
+				}
 			}
 		}
 		foreach( $billing_details as $key => $value ) {

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -811,9 +811,10 @@ class WC_Gateway_PPEC_Client {
 				'order_id'  => $order_id,
 				'order_key' => $order_key,
 			) ),
+			'NOSHIPPING'                     => WC()->cart->needs_shipping() ? 0 : 1,
 		);
 
-		if ( ! empty( $details['shipping_address'] ) ) {
+		if ( WC()->cart->needs_shipping() && ! empty( $details['shipping_address'] ) ) {
 			$params = array_merge(
 				$params,
 				$details['shipping_address']->getAddressParams( 'PAYMENTREQUEST_0_SHIPTO' )


### PR DESCRIPTION
Fixes #234 

#### Changes:
- 3.0 compatibility fixes concerning POSTed data
- Carts that don't require shipping won't fail to check out when postcode is not provided
- Registration presents and works correctly on final order screen

#### To Test:

```
- With 2.6 and 3.0
- With WP_DEBUG true

Note Concerning API Credentials
- Log in to your Sandbox and go to the Test Accounts list at https://developer.paypal.com/developer/accounts/
- You will want to use a BUSINESS or BUSINESS Pro from this list, or make a new one
- Click on the arrow to the left of it to expand options below it and then click on Profile
- On the Account Details modal that appears, click on the API Credentials tab

Test Case 1 Setup
- wp-admin > Settings > Accounts
    - Check “Enable customer registration on the Checkout page”
    - Uncheck “Automatically generate username from customer email”
    - Uncheck “Automatically generate customer password”
    - Save changes
- wp-admin > Settings > Checkout > Checkout options
    - Check (enable) “Enable guest checkout”
    - Save changes
- wp-admin > Settings > Checkout > PayPal Express Checkout
    - Enabled
    - Sandbox
    - API Username, Password and Signature filled in from developer.paypal.com
    - Enable PayPal Mark on regular checkout
    - Leave PayPal Credit disabled for now
    - Leave Require Billing Address disabled
    - Payment Action: Sale
    - Save changes

Test Case 1A, Checkout from Cart with a Tax-Free Virtual Item and No Account Creation Required
- Incognito
- Add a virtual item to your cart
- From the cart page, click on Check out with PayPal. The PayPal “modal” should appear and prompt you to log in.
- Sign into PayPal using a test PERSONAL account from developer.paypal.com 
- Click on Continue to close the PayPal modal and return to checkout
- Verify your billing details match the PayPal PERSONAL account details
- Leave Create an account unchecked
- Click on “Place Order” and verify it completes successfully
- In Edit Order, review the order and make sure the buyer details match the PayPal PERSONAL account details - note since this is a virtual item there will be no address information
- Verify no errors or notices are logged (PayPal _request and _process_response messages are normal)

Test Case 1B, Checkout from Cart with a Shippable Item and No Account Creation Required
- Same as 1B but choose a shippable item instead
- Note: Since this is a shippable item, make sure the buyer details include shipping address information

Test Case 1C, Checkout from Checkout with a Shippable Item and No Account Creation Required
- Same as 1B but instead of using the PayPal button on the cart page
    - Go to the checkout page
    - Fill in your billing details
    - Select “PayPal Express Checkout” as your payment method
    - Click on the “Continue to Payment” button
- Note: Since checkout from checkout prompts the user for their billing address, THAT is the address that should be displayed, not their PayPal address

Test Case 2 Setup
- Same as Test Case 1 Setup, but in wp-admin > Settings > Checkout > Checkout options
    - Uncheck (disable) “Enable guest checkout”

Test Case 2A, Checkout from Cart with a Tax-Free Virtual Item and Account Creation Required
- Same as 1A but make sure you are required to fill in a username and password before you can finish placing your order
- Delete the user before proceeding to the next test (to avoid being prompted to login)

Test Case 2B, Checkout from Cart with a Shippable Item and Account Creation Required
- Same as 1B but make sure you are required to fill in a username and password before you can finish placing your order
- Delete the user before proceeding to the next test (to avoid being prompted to login)

Test Case 2C, Checkout from Checkout with a Shippable Item and Account Creation Required
- Same as 1C but make sure you are required to fill in a username and password before you can finish placing your order
- Note: Since checkout from checkout prompts the user for their billing address, THAT is the address that should be displayed, not their PayPal address

```