### PR TITLE
Disable gateway when the cart total is zero

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -402,9 +402,11 @@ class WC_Gateway_PPEC_Checkout_Handler {
 	}
 
 	/**
-	 * Maybe disable other gateways.
+	 * Maybe disable this or other gateways.
 	 *
 	 * @since 1.0.0
+	 * @version 1.2.1
+	 *
 	 * @param array $gateways Available gateways
 	 *
 	 * @return array Available gateways
@@ -421,6 +423,13 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		// If using PayPal standard (this is admin choice) we don't need to also show PayPal EC on checkout.
 		} elseif ( is_checkout() && ( isset( $gateways['paypal'] ) || 'no' === wc_gateway_ppec()->settings->mark_enabled ) ) {
 			unset( $gateways['ppec_paypal'] );
+		}
+
+		// If the cart total is zero (e.g. because of a coupon), don't allow this gateway
+		if ( is_cart() || is_checkout() ) {
+			if ( isset( $gateways['ppec_paypal'] ) && ( 0 >= WC()->cart->total ) ) {
+				unset( $gateways['ppec_paypal'] );
+			}
 		}
 
 		return $gateways;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes, akeda, dwainm, royho, allendav, slash1andy,
 Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, store, sales, sell, shop, shopping, cart, checkout, configurable, paypal
 Requires at least: 4.4
 Tested up to: 4.4
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -84,6 +84,10 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 3. Checkout with PayPal directly from the Cart.
 
 == Changelog ==
+
+= 1.2.1 =
+* Fix - Avoid plugin links notice when WooCommerce is not active - props rellect
+* Fix - Do not show this gateway when the cart amount is zero
 
 = 1.2.0 =
 * Fix - Prevent conflict with other gateways.

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -25,6 +25,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+if ( ! defined( 'WC_GATEWAY_PPEC_VERSION' ) ) {
+	define( 'WC_GATEWAY_PPEC_VERSION', '1.2.1' );
+}
+
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.
  *
@@ -36,7 +40,7 @@ function wc_gateway_ppec() {
 	if ( ! isset( $plugin ) ) {
 		require_once( 'includes/class-wc-gateway-ppec-plugin.php' );
 
-		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.2.1' );
+		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, WC_GATEWAY_PPEC_VERSION );
 	}
 
 	return $plugin;

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Express Checkout Gateway
  * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: A payment gateway for PayPal Express Checkout (https://www.paypal.com/us/webapps/mpp/express-checkout).
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Copyright: © 2017 WooCommerce / PayPal.
@@ -36,7 +36,7 @@ function wc_gateway_ppec() {
 	if ( ! isset( $plugin ) ) {
 		require_once( 'includes/class-wc-gateway-ppec-plugin.php' );
 
-		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.2.0' );
+		$plugin = new WC_Gateway_PPEC_Plugin( __FILE__, '1.2.1' );
 	}
 
 	return $plugin;

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -25,9 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! defined( 'WC_GATEWAY_PPEC_VERSION' ) ) {
-	define( 'WC_GATEWAY_PPEC_VERSION', '1.2.1' );
-}
+define( 'WC_GATEWAY_PPEC_VERSION', '1.2.1' );
 
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.


### PR DESCRIPTION
Fixes #250 

To Test:
* Enable and set up the gateway, including enabling it on checkout
* Add an item to the cart
* Ensure the gateway presents on both the cart and checkout pages
* Add a coupon to the cart that zeros out the cart
* Ensure the gateway is NOT presented on the cart nor checkout pages