### PR TITLE
Fix discount sign change that was dropped in 1.2.0

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -440,6 +440,7 @@ class WC_Gateway_PPEC_Client {
 	 * This is the details when buyer is checking out from cart page.
 	 *
 	 * @since 1.2.0
+	 * @version 1.2.2
 	 *
 	 * @return array Order details
 	 */
@@ -494,7 +495,7 @@ class WC_Gateway_PPEC_Client {
 			$details['order_total']         -= $discounts;
 		} else {
 			if ( $discounts > 0 ) {
-				$details['items'][] = $this->_get_extra_offset_line_item( $discounts );
+				$details['items'][] = $this->_get_extra_offset_line_item( - abs( $discounts ) );
 			}
 
 			$details['ship_discount_amount'] = 0;

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -440,7 +440,7 @@ class WC_Gateway_PPEC_Client {
 	 * This is the details when buyer is checking out from cart page.
 	 *
 	 * @since 1.2.0
-	 * @version 1.2.2
+	 * @version 1.2.1
 	 *
 	 * @return array Order details
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,9 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 
 == Changelog ==
 
+= 1.2.2 =
+* Fix - Fix 10413 error that prevents checking out with a coupon
+
 = 1.2.1 =
 * Fix - Avoid plugin links notice when WooCommerce is not active - props rellect
 * Fix - Do not show this gateway when the cart amount is zero

--- a/readme.txt
+++ b/readme.txt
@@ -85,12 +85,10 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 
 == Changelog ==
 
-= 1.2.2 =
-* Fix - Fix 10413 error that prevents checking out with a coupon
-
 = 1.2.1 =
 * Fix - Avoid plugin links notice when WooCommerce is not active - props rellect
 * Fix - Do not show this gateway when the cart amount is zero
+* Fix - Fix 10413 error that prevents checking out with a coupon
 
 = 1.2.0 =
 * Fix - Prevent conflict with other gateways.

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Express Checkout Gateway
  * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: A payment gateway for PayPal Express Checkout (https://www.paypal.com/us/webapps/mpp/express-checkout).
- * Version: 1.2.2
+ * Version: 1.2.1
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Copyright: © 2017 WooCommerce / PayPal.
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'WC_GATEWAY_PPEC_VERSION', '1.2.2' );
+define( 'WC_GATEWAY_PPEC_VERSION', '1.2.1' );
 
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Express Checkout Gateway
  * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: A payment gateway for PayPal Express Checkout (https://www.paypal.com/us/webapps/mpp/express-checkout).
- * Version: 1.2.1
+ * Version: 1.2.2
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Copyright: © 2017 WooCommerce / PayPal.
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'WC_GATEWAY_PPEC_VERSION', '1.2.1' );
+define( 'WC_GATEWAY_PPEC_VERSION', '1.2.2' );
 
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.


### PR DESCRIPTION
Fixes #242 

To test:
- Add an item to the cart
- Add a coupon to the cart
- Verify you are able to complex checkout from the cart using Check Out with PayPal (i.e. that the 10413 does NOT happen)

cc @spraveenitpro @roykho @mattyza @dsmithweb 