### PR TITLE
Use the woocommerce_default_address_fields instead to ensure not-required fields stay not-required

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -114,7 +114,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 	 * @return array
 	 */
 	public function filter_default_address_fields( $fields ) {
-		if ( ! WC()->cart->needs_shipping() ) {
+		if ( method_exists( WC()->cart, 'needs_shipping' ) && ! WC()->cart->needs_shipping() ) {
 			$not_required_fields = array( 'address_1', 'city', 'state', 'postcode', 'country' );
 			foreach ( $not_required_fields as $not_required_field ) {
 				if ( array_key_exists( $not_required_field, $fields ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,7 @@ https://gist.github.com/mikejolley/ad2ecc286c9ad6cefbb7065ba6dfef48
 * Fix - Avoid plugin links notice when WooCommerce is not active - props rellect
 * Fix - Do not show this gateway when the cart amount is zero
 * Fix - Fix 10413 error that prevents checking out with a coupon
+* Fix - Filter default address fields to ensure they are not required
 
 = 1.2.0 =
 * Fix - Prevent conflict with other gateways.


### PR DESCRIPTION
Concerns #256 

Still having trouble reproducing #256 but this fix does address a way we were #doingitwrong when it comes to un-requiring fields.  See https://github.com/woocommerce/woocommerce/blob/25747f8fc70278014eadfcc59468081465ac2404/includes/class-wc-countries.php#L1134

To test:

```
- wp-admin > WooCommerce > Settings > Checkout > PayPal Express Checkout
    - Enable PayPal Express Checkout
    - Environment: Sandbox
    - Enable the PayPal Mark on Regular Checkout
- wp-admin > WooCommerce > Settings > Checkout
    - Enable guest checkout
- Open an incognito window, add a virtual item to the cart and then initiate checkout with PayPal from the cart using a test buyer in the same country as the store's base location. Verify you can complete checkout successfully.  Verify that buyer address information input boxes are NOT displayed on the WooCommerce checkout form nor is the buyer's address stored in the order in Edit Order.
- Repeat with a new incognito session with a shippable item. Verify you can complete checkout successfully. Verify that buyer address information input boxes are NOT displayed on the WooCommerce checkout form but is received from PayPal, displayed during checkout and ultimately stored in the order in Edit Order.  Ensure the address displayed in Edit Order is the one provided by PayPal for the buyer.
- Repeat with a shippable item with a test buyer in a different country than the store.
- Repeat but proceed to checkout, fill in the buyer's address on the WooCommerce checkout form, and then select PayPal as the payment gateway. Verify you can complete checkout successfully. Ensure the address entered on the WooCommerce checkout form is the address displayed in Edit Order.
```