### PR TITLE
use shipping discount instead of tax when adjustment negative

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -507,10 +507,16 @@ class WC_Gateway_PPEC_Client {
 		// probably a tax mismatch).
 		$wc_order_total = round( WC()->cart->total, $decimals );
 		if ( $wc_order_total != $details['order_total'] ) {
-			$details['order_tax']  += $wc_order_total - $details['order_total'];
+			if ( $details['order_total'] < $wc_order_total ) { // tax cannot be negative
+				$details['order_tax']  += $wc_order_total - $details['order_total'];
+				$details['order_tax'] = round( $details['order_tax'], $decimals );
+			}
+			else {
+				$details['ship_discount_amount'] += $wc_order_total - $details['order_total'];
+				$details['ship_discount_amount'] = round( $details['ship_discount_amount'], $decimals );
+			}
 			$details['order_total'] = $wc_order_total;
 		}
-		$details['order_tax'] = round( $details['order_tax'], $decimals );
 
 		if ( ! is_numeric( $details['shipping'] ) ) {
 			$details['shipping'] = 0;
@@ -645,10 +651,16 @@ class WC_Gateway_PPEC_Client {
 		// probably a tax mismatch).
 		$wc_order_total = round( $order->get_total(), $decimals );
 		if ( $wc_order_total != $details['order_total'] ) {
-			$details['order_tax']  += $wc_order_total - $details['order_total'];
+			if ( $details['order_total'] < $wc_order_total ) { // tax cannot be negative
+				$details['order_tax']  += $wc_order_total - $details['order_total'];
+				$details['order_tax'] = round( $details['order_tax'], $decimals );
+			}
+			else {
+				$details['ship_discount_amount'] += $wc_order_total - $details['order_total'];
+				$details['ship_discount_amount'] = round( $details['ship_discount_amount'], $decimals );
+			}
 			$details['order_total'] = $wc_order_total;
 		}
-		$details['order_tax'] = round( $details['order_tax'], $decimals );
 
 		if ( ! is_numeric( $details['shipping'] ) ) {
 			$details['shipping'] = 0;


### PR DESCRIPTION
The tax amount cannot be negative, use shipping discount in this case for total mismatch workarounds.