### PR TITLE
Fixes #288 - Shipping Address being required on Virtual products

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -53,6 +53,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$this->invoice_prefix             = $this->get_option( 'invoice_prefix', 'WC-' );
 		$this->instant_payments           = 'yes' === $this->get_option( 'instant_payments', 'no' );
 		$this->require_billing            = 'yes' === $this->get_option( 'require_billing', 'no' );
+		$this->always_send_shipping       = 'yes' === $this->get_option( 'always_send_shipping', 'no' );		
 		$this->paymentaction              = $this->get_option( 'paymentaction', 'sale' );
 		$this->logo_image_url             = $this->get_option( 'logo_image_url' );
 		$this->subtotal_mismatch_behavior = $this->get_option( 'subtotal_mismatch_behavior', 'add' );

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -382,8 +382,9 @@ class WC_Gateway_PPEC_Plugin {
 	 * @return bool
 	 */
 	public static function needs_shipping() {
-		// In case there are no shipping methods defined, we still return true (see #249)
-		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) ) {
+		// In case there are no shipping methods defined, we check for setting 'always send shipping' (see #249 and #288)
+		$settings_array = (array) get_option( 'woocommerce_ppec_paypal_settings', array() );
+		if ( 'yes' === $settings_array['always_send_shipping'] ) {
 			return true;
 		}
 

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -359,6 +359,13 @@ return array(
 		'default'     => 'no',
 		'description' => sprintf( __( 'PayPal only returns a shipping address back to the website. To make sure billing address is returned as well, please enable this functionality on your PayPal account by calling %1$sPayPal Technical Support%2$s.', 'woocommerce-gateway-paypal-express-checkout' ), '<a href="https://www.paypal.com/us/selfhelp/contact/call">', '</a>' ),
 	),
+	'always_send_shipping' => array(
+		'title'       => __( 'Send Shipping Addresses', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Always send Shipping Address', 'woocommerce-gateway-paypal-express-checkout' ),
+		'default'     => 'no',
+		'description' => __( 'Send shipping address to PayPal even if shipping method is not setup in WooCommerce.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),	
 	'require_phone_number' => array(
 		'title'       => __( 'Require Phone Number', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'        => 'checkbox',


### PR DESCRIPTION
Fixes #288 "Shipping Address being required on Virtual products" by tweaking the fix to #249. I've added an option in the settings to allow users to always send the shipping address to Paypal if they don't want to configure a shipping option. This will be disabled by default, so that virtual orders will not attempt to send shipping address.