### PR TITLE
Remove OpenSSL warning when using LibreSSL

### DIFF
--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -223,7 +223,7 @@ class WC_Gateway_PPEC_Plugin {
 			throw new Exception( $openssl_warning, self::DEPENDENCIES_UNSATISFIED );
 		}
 
-		preg_match( '/^OpenSSL ([\d.]+)/', OPENSSL_VERSION_TEXT, $matches );
+		preg_match( '/^(?:Libre|Open)SSL ([\d.]+)/', OPENSSL_VERSION_TEXT, $matches );
 		if ( empty( $matches[1] ) ) {
 			throw new Exception( $openssl_warning, self::DEPENDENCIES_UNSATISFIED );
 		}


### PR DESCRIPTION
LibreSSL forked from OpenSSL 1.0.1g and is therefore > OpenSSL 1.0.1 so
the warning is redundant.

Add check for LibreSSL in OPENSSL_VERSION_TEXT and make non-caputuring
to avoid breaking the version number check