### PR TITLE
Fix enabled/disabled toggle's javascript

### DIFF
--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -77,7 +77,7 @@ wc_enqueue_js( "
 			}
 		}).change();
 
-		$( '#woocommerce_ppec_paypal_mark_enabled' ).change(function(){
+		$( '#woocommerce_ppec_paypal_enabled' ).change(function(){
 			if ( $( this ).is( ':checked' ) ) {
 				$( ppec_mark_fields ).closest( 'tr' ).show();
 			} else {


### PR DESCRIPTION
The `ID` used in the js for the _Enabled/Disabled_ toggle was incorrect. I presume from a _recent_ change, but not had time to look through the plugins history.

Please get this fix merged and deployed to the WP plugin-market asap 😬  🙏 

Closes #325