### PR TITLE
Fix paypal error 10413

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -480,7 +480,7 @@ class WC_Gateway_PPEC_Client {
 
 		$items = array();
 		foreach ( WC()->cart->cart_contents as $cart_item_key => $values ) {
-			$amount = round( $values['line_subtotal'] / $values['quantity'] , $decimals );
+			$amount = round( $values['line_total'] / $values['quantity'] , $decimals );
 
 			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 				$name = $values['data']->post->post_title;


### PR DESCRIPTION
This fixes Issue #340. Code changed from **line_subtotal** to **line_total**, because line_total accounts for the amount changes (such as coupon discounts), whereas **line_subtotal** doesn't.