### PR TITLE
Add hooks for request endpoint and settings

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -96,11 +96,12 @@ class WC_Gateway_PPEC_Client {
 	 * @return string
 	 */
 	public function get_endpoint() {
-		return sprintf(
+		$endpoint = sprintf(
 			'https://%s%s.paypal.com/nvp',
 			$this->_credential->get_endpoint_subdomain(),
 			'sandbox' === $this->_environment ? '.sandbox' : ''
 		);
+		return apply_filters( 'woocommerce_paypal_express_checkout_request_endpoint', $endpoint, $this->_credential->get_username() );
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -100,7 +100,7 @@ class WC_Gateway_PPEC_Client {
 			'https://%s%s.paypal.com/nvp',
 			$this->_credential->get_endpoint_subdomain(),
 			'sandbox' === $this->_environment ? '.sandbox' : ''
-		) );
+		), $this->_environment );
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -96,12 +96,11 @@ class WC_Gateway_PPEC_Client {
 	 * @return string
 	 */
 	public function get_endpoint() {
-		$endpoint = sprintf(
+		return apply_filters( 'woocommerce_paypal_express_checkout_request_endpoint', sprintf(
 			'https://%s%s.paypal.com/nvp',
 			$this->_credential->get_endpoint_subdomain(),
 			'sandbox' === $this->_environment ? '.sandbox' : ''
-		);
-		return apply_filters( 'woocommerce_paypal_express_checkout_request_endpoint', $endpoint, $this->_credential->get_username() );
+		) );
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -68,7 +68,7 @@ class WC_Gateway_PPEC_Settings {
 		return null;
 	}
 
-	public function __isset( $name ) {
+	public function __isset( $key ) {
 		return array_key_exists( $key, $this->_settings );
 	}
 

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -111,7 +111,7 @@ wc_enqueue_js( "
 /**
  * Settings for PayPal Gateway.
  */
-return array(
+return apply_filters( 'wc_ppec_settings', array(
 	'enabled' => array(
 		'title'   => __( 'Enable/Disable', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'    => 'checkbox',
@@ -398,4 +398,4 @@ return array(
 			'drop' => __( 'Do not send line items to PayPal', 'woocommerce-gateway-paypal-express-checkout' ),
 		),
 	),
-);
+) );

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -111,7 +111,7 @@ wc_enqueue_js( "
 /**
  * Settings for PayPal Gateway.
  */
-return apply_filters( 'wc_ppec_settings', array(
+return apply_filters( 'woocommerce_paypal_express_checkout_settings', array(
 	'enabled' => array(
 		'title'   => __( 'Enable/Disable', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'    => 'checkbox',


### PR DESCRIPTION
Adds filter `woocommerce_paypal_express_checkout_request_endpoint` (alongside the existing `woocommerce_paypal_express_checkout_request_body`) to be able to relay API requests via another server. This will be used for authenticating API requests on the WCS server. (Context in p7bbVw-2kH-p2.)

Also adds a settings filter — see [precedent in Stripe plugin](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/6d8164689007384cd7178d2d65bdec3a1c2094bb/includes/settings-stripe.php#L6) — in order to be able to disable settings we know won't work with an API Subject lacking non-default permissions.

Let me know if MITM or other security concerns come to mind, though I don't believe this would make anything possible that isn't already.

<s>Marking "in progress" until https://github.com/Automattic/woocommerce-services/pull/1254 is approved without further changes to this plugin necessary.</s>