### PR TITLE
Implement PayPal credit on checkout

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -466,17 +466,4 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 	public function is_available() {
 		return 'yes' === $this->enabled;
 	}
-
-	/**
-	 * Whether PayPal credit is supported.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @return bool Returns true if PayPal credit is supported
-	 */
-	public function is_credit_supported() {
-		$base = wc_get_base_location();
-
-		return 'US' === $base['country'];
-	}
 }

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -14,7 +14,6 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 	 */
 	public function __construct() {
 		$this->has_fields         = false;
-		$this->icon               = 'https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png';
 		$this->supports[]         = 'refunds';
 		$this->method_title       = __( 'PayPal Express Checkout', 'woocommerce-gateway-paypal-express-checkout' );
 		$this->method_description = __( 'Allow customers to conveniently checkout directly with PayPal.', 'woocommerce-gateway-paypal-express-checkout' );

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -55,6 +55,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$this->paymentaction              = $this->get_option( 'paymentaction', 'sale' );
 		$this->logo_image_url             = $this->get_option( 'logo_image_url' );
 		$this->subtotal_mismatch_behavior = $this->get_option( 'subtotal_mismatch_behavior', 'add' );
+		$this->use_ppc                    = false;
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 
@@ -92,7 +93,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 			try {
 				return array(
 					'result'   => 'success',
-					'redirect' => $checkout->start_checkout_from_checkout( $order_id ),
+					'redirect' => $checkout->start_checkout_from_checkout( $order_id, $this->use_ppc ),
 				);
 			} catch ( PayPal_API_Exception $e ) {
 				wc_add_notice( $e->getMessage(), 'error' );

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -649,11 +649,12 @@ class WC_Gateway_PPEC_Checkout_Handler {
 	/**
 	 * Handler when buyer is checking out from checkout page.
 	 *
-	 * @param int $order_id Order ID
+	 * @param int  $order_id Order ID.
+	 * @param bool $use_ppc  Whether to use PayPal credit.
 	 *
 	 * @return string Redirect URL.
 	 */
-	public function start_checkout_from_checkout( $order_id ) {
+	public function start_checkout_from_checkout( $order_id, $use_ppc ) {
 		$settings     = wc_gateway_ppec()->settings;
 
 		$context_args = array(
@@ -665,6 +666,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			'source'            => 'order',
 			'order_id'          => $order_id,
 			'expires_in'        => $settings->get_token_session_length(),
+			'use_paypal_credit' => $use_ppc,
 		);
 
 		return $this->start_checkout( $context_args, $session_data_args );

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -619,7 +619,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 
 			WC()->session->paypal = new WC_Gateway_PPEC_Session_Data( $session_data_args );
 
-			return $settings->get_paypal_redirect_url( $response['TOKEN'], false );
+			return $settings->get_paypal_redirect_url( $response['TOKEN'], false, $session_data_args['use_paypal_credit'] );
 		} else {
 			throw new PayPal_API_Exception( $response );
 		}

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -598,32 +598,26 @@ class WC_Gateway_PPEC_Checkout_Handler {
 	}
 
 	/**
-	 * Handler when buyer is checking out from cart page.
+	 * Generic checkout handler.
 	 *
-	 * @todo This methods looks similar to start_checkout_from_checkout. Please
-	 *       refactor by merging them.
+	 * @param array $context_args Context parameters for checkout.
+	 * @param array $session_data_args Session parameters (token pre-populated).
 	 *
 	 * @throws PayPal_API_Exception
+	 * @return string Redirect URL.
 	 */
-	public function start_checkout_from_cart() {
+	protected function start_checkout( $context_args, $session_data_args ) {
 		$settings     = wc_gateway_ppec()->settings;
 		$client       = wc_gateway_ppec()->client;
-		$context_args = array(
-			'start_from' => 'cart',
-		);
 		$context_args['create_billing_agreement'] = $this->needs_billing_agreement_creation( $context_args );
 
 		$params   = $client->get_set_express_checkout_params( $context_args );
 		$response = $client->set_express_checkout( $params );
+
 		if ( $client->response_has_success_status( $response ) ) {
-			WC()->session->paypal = new WC_Gateway_PPEC_Session_Data(
-				array(
-					'token'             => $response['TOKEN'],
-					'source'            => 'cart',
-					'expires_in'        => $settings->get_token_session_length(),
-					'use_paypal_credit' => wc_gateway_ppec_is_using_credit(),
-				)
-			);
+			$session_data_args['token'] = $response['TOKEN'];
+
+			WC()->session->paypal = new WC_Gateway_PPEC_Session_Data( $session_data_args );
 
 			return $settings->get_paypal_redirect_url( $response['TOKEN'], false );
 		} else {
@@ -632,40 +626,48 @@ class WC_Gateway_PPEC_Checkout_Handler {
 	}
 
 	/**
+	 * Handler when buyer is checking out from cart page.
+	 *
+	 * @return string Redirect URL.
+	 */
+	public function start_checkout_from_cart() {
+		$settings     = wc_gateway_ppec()->settings;
+
+		$context_args = array(
+			'start_from' => 'cart',
+		);
+
+		$session_data_args = array(
+			'source'            => 'cart',
+			'expires_in'        => $settings->get_token_session_length(),
+			'use_paypal_credit' => wc_gateway_ppec_is_using_credit(),
+		);
+
+		return $this->start_checkout( $context_args, $session_data_args );
+	}
+
+	/**
 	 * Handler when buyer is checking out from checkout page.
 	 *
-	 * @todo This methods looks similar to start_checkout_from_cart. Please
-	 *       refactor by merging them.
-	 *
-	 * @throws PayPal_API_Exception
-	 *
 	 * @param int $order_id Order ID
+	 *
+	 * @return string Redirect URL.
 	 */
 	public function start_checkout_from_checkout( $order_id ) {
 		$settings     = wc_gateway_ppec()->settings;
-		$client       = wc_gateway_ppec()->client;
+
 		$context_args = array(
 			'start_from' => 'checkout',
 			'order_id'   => $order_id,
 		);
-		$context_args['create_billing_agreement'] = $this->needs_billing_agreement_creation( $context_args );
 
-		$params   = $client->get_set_express_checkout_params( $context_args );
-		$response = $client->set_express_checkout( $params );
-		if ( $client->response_has_success_status( $response ) ) {
-			WC()->session->paypal = new WC_Gateway_PPEC_Session_Data(
-				array(
-					'token'      => $response['TOKEN'],
-					'source'     => 'order',
-					'order_id'   => $order_id,
-					'expires_in' => $settings->get_token_session_length()
-				)
-			);
+		$session_data_args = array(
+			'source'            => 'order',
+			'order_id'          => $order_id,
+			'expires_in'        => $settings->get_token_session_length(),
+		);
 
-			return $settings->get_paypal_redirect_url( $response['TOKEN'], true );
-		} else {
-			throw new PayPal_API_Exception( $response );
-		}
+		return $this->start_checkout( $context_args, $session_data_args );
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-gateway-loader.php
+++ b/includes/class-wc-gateway-ppec-gateway-loader.php
@@ -19,6 +19,7 @@ class WC_Gateway_PPEC_Gateway_Loader {
 		require_once( $includes_path . 'abstracts/abstract-wc-gateway-ppec.php' );
 
 		require_once( $includes_path . 'class-wc-gateway-ppec-with-paypal.php' );
+		require_once( $includes_path . 'class-wc-gateway-ppec-with-paypal-credit.php' );
 		require_once( $includes_path . 'class-wc-gateway-ppec-with-paypal-addons.php' );
 
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'payment_gateways' ) );
@@ -32,10 +33,17 @@ class WC_Gateway_PPEC_Gateway_Loader {
 	 * @return array Payment methods
 	 */
 	public function payment_gateways( $methods ) {
+		$settings = wc_gateway_ppec()->settings;
+
 		if ( $this->can_use_addons() ) {
 			$methods[] = 'WC_Gateway_PPEC_With_PayPal_Addons';
 		} else {
 			$methods[] = 'WC_Gateway_PPEC_With_PayPal';
+		}
+
+		$base = wc_get_base_location();
+		if ( 'yes' === $settings->credit_enabled && 'US' === $base['country'] ) {
+			$methods[] = 'WC_Gateway_PPEC_With_PayPal_Credit';
 		}
 
 		return $methods;

--- a/includes/class-wc-gateway-ppec-gateway-loader.php
+++ b/includes/class-wc-gateway-ppec-gateway-loader.php
@@ -41,8 +41,7 @@ class WC_Gateway_PPEC_Gateway_Loader {
 			$methods[] = 'WC_Gateway_PPEC_With_PayPal';
 		}
 
-		$base = wc_get_base_location();
-		if ( 'yes' === $settings->credit_enabled && 'US' === $base['country'] ) {
+		if ( $settings->is_credit_enabled() ) {
 			$methods[] = 'WC_Gateway_PPEC_With_PayPal_Credit';
 		}
 

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -157,10 +157,11 @@ class WC_Gateway_PPEC_Settings {
 	 *                       to 'commit' which makes PayPal sets the button text
 	 *                       to **Pay Now** ont the PayPal _Review your information_
 	 *                       page.
+	 * @param bool   $ppc    Whether to use PayPal credit.
 	 *
 	 * @return string PayPal redirect URL
 	 */
-	public function get_paypal_redirect_url( $token, $commit = false ) {
+	public function get_paypal_redirect_url( $token, $commit = false, $ppc = false ) {
 		$url = 'https://www.';
 
 		if ( 'live' !== $this->environment ) {
@@ -171,6 +172,10 @@ class WC_Gateway_PPEC_Settings {
 
 		if ( $commit ) {
 			$url .= '&useraction=commit';
+		}
+
+		if ( $ppc ) {
+			$url .= '#/checkout/chooseCreditOffer';
 		}
 
 		return $url;

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -345,12 +345,7 @@ class WC_Gateway_PPEC_Settings {
 	 * @return bool Returns true if PayPal Credit is enabled and supported
 	 */
 	public function is_credit_enabled() {
-		$gateways = WC()->payment_gateways->get_available_payment_gateways();
-		if ( ! isset( $gateways['ppec_paypal'] ) ) {
-			return false;
-		}
-
-		return 'yes' === $this->credit_enabled && $gateways['ppec_paypal']->is_credit_supported();
+		return 'yes' === $this->credit_enabled && wc_gateway_ppec_is_credit_supported();
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-with-paypal-credit.php
+++ b/includes/class-wc-gateway-ppec-with-paypal-credit.php
@@ -20,5 +20,7 @@ class WC_Gateway_PPEC_With_PayPal_Credit extends WC_Gateway_PPEC {
 			$ipn_handler = new WC_Gateway_PPEC_IPN_Handler( $this );
 			$ipn_handler->handle();
 		}
+
+		$this->use_ppc = true;
 	}
 }

--- a/includes/class-wc-gateway-ppec-with-paypal-credit.php
+++ b/includes/class-wc-gateway-ppec-with-paypal-credit.php
@@ -1,0 +1,24 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_Gateway_PPEC_With_PayPal_Credit extends WC_Gateway_PPEC {
+	public function __construct() {
+		$this->icon    = 'https://www.paypalobjects.com/webstatic/en_US/i/buttons/ppc-acceptance-small.png';
+
+		parent::__construct();
+
+		if ( ! is_admin() ) {
+			if ( wc_gateway_ppec()->checkout->is_started_from_checkout_page() ) {
+				$this->title = __( 'PayPal Credit', 'woocommerce-gateway-paypal-express-checkout' );;
+			}
+		}
+
+		if ( $this->is_available() ) {
+			$ipn_handler = new WC_Gateway_PPEC_IPN_Handler( $this );
+			$ipn_handler->handle();
+		}
+	}
+}

--- a/includes/class-wc-gateway-ppec-with-paypal.php
+++ b/includes/class-wc-gateway-ppec-with-paypal.php
@@ -6,7 +6,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Gateway_PPEC_With_PayPal extends WC_Gateway_PPEC {
 	public function __construct() {
-		$this->id = 'ppec_paypal';
+		$this->id   = 'ppec_paypal';
+		$this->icon = 'https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png';
 
 		parent::__construct();
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -69,6 +69,19 @@ function wc_gateway_ppec_log( $message ) {
 }
 
 /**
+ * Whether PayPal credit is supported.
+ *
+ * @since 1.5.0
+ *
+ * @return bool Returns true if PayPal credit is supported
+ */
+function wc_gateway_ppec_is_credit_supported() {
+	$base = wc_get_base_location();
+
+	return 'US' === $base['country'];
+}
+
+/**
  * Checks whether buyer is checking out with PayPal Credit.
  *
  * @since 1.2.0

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -44,7 +44,7 @@ if ( $enable_ips && $needs_sandbox_creds ) {
 }
 
 $credit_enabled_label = __( 'Enable PayPal Credit', 'woocommerce-gateway-paypal-express-checkout' );
-if ( ! $this->is_credit_supported() ) {
+if ( ! wc_gateway_ppec_is_credit_supported() ) {
 	$credit_enabled_label .= '<p><em>' . __( 'This option is disabled. Currently PayPal Credit only available for U.S. merchants.', 'woocommerce-gateway-paypal-express-checkout' ) . '</em></p>';
 }
 
@@ -319,7 +319,7 @@ return array(
 		'title'       => __( 'Enable PayPal Credit', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'        => 'checkbox',
 		'label'       => $credit_enabled_label,
-		'disabled'    => ! $this->is_credit_supported(),
+		'disabled'    => ! wc_gateway_ppec_is_credit_supported(),
 		'default'     => 'no',
 		'desc_tip'    => true,
 		'description' => __( 'This enables PayPal Credit, which displays a PayPal Credit button next to the Express Checkout button. PayPal Express Checkout lets you give customers access to financing through PayPal Credit® - at no additional cost to you. You get paid up front, even though customers have more time to pay. A pre-integrated payment button shows up next to the PayPal Button, and lets customers pay quickly with PayPal Credit®.', 'woocommerce-gateway-paypal-express-checkout' ),


### PR DESCRIPTION
Fixes #292.

- Refactor checkout methods (code duplication)
- Implement a separate gateway class for PayPal credit (with a separate logo, title)
- Refactor some methods so that they can be used in the context of woocommerce filter