### PR TITLE
Default to signature method if certificate missing

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -119,12 +119,11 @@ class WC_Gateway_PPEC_Settings {
 	 * @return WC_Gateway_PPEC_Client_Credential_Signature|WC_Gateway_PPEC_Client_Credential_Certificate
 	 */
 	public function get_live_api_credentials() {
-		if ( $this->api_signature ) {
-			return new WC_Gateway_PPEC_Client_Credential_Signature( $this->api_username, $this->api_password, $this->api_signature, $this->api_subject );
+		if ( $this->api_certificate ) {
+			return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->api_username, $this->api_password, $this->api_certificate, $this->api_subject );
 		}
 
-		return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->api_username, $this->api_password, $this->api_certificate, $this->api_subject );
-
+		return new WC_Gateway_PPEC_Client_Credential_Signature( $this->api_username, $this->api_password, $this->api_signature, $this->api_subject );
 	}
 
 	/**
@@ -133,11 +132,11 @@ class WC_Gateway_PPEC_Settings {
 	 * @return WC_Gateway_PPEC_Client_Credential_Signature|WC_Gateway_PPEC_Client_Credential_Certificate
 	 */
 	public function get_sandbox_api_credentials() {
-		if ( $this->sandbox_api_signature ) {
-			return new WC_Gateway_PPEC_Client_Credential_Signature( $this->sandbox_api_username, $this->sandbox_api_password, $this->sandbox_api_signature, $this->sandbox_api_subject );
+		if ( $this->sandbox_api_certificate ) {
+			return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->sandbox_api_username, $this->sandbox_api_password, $this->sandbox_api_certificate, $this->sandbox_api_subject );
 		}
 
-		return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->sandbox_api_username, $this->sandbox_api_password, $this->sandbox_api_certificate, $this->sandbox_api_subject );
+		return new WC_Gateway_PPEC_Client_Credential_Signature( $this->sandbox_api_username, $this->sandbox_api_password, $this->sandbox_api_signature, $this->sandbox_api_subject );
 	}
 
 	/**


### PR DESCRIPTION
Swaps the signature method's being conditional on signature for the certificate method's being conditional on certificate.

In my case, since WooCommerce Services will be proxying the request if credentials are not available (https://github.com/Automattic/woocommerce-services/pull/1254), this change is so that cURL is not configured for a certificate if no credentials are available, which causes the request to an HTTPS server (i.e. https://api-staging.woocommerce.com) to fail.

If there is reason to keep this logic as it is, we can keep looking into other means of forcing the signature credentials or just disabling the cURL certificate.