### PR TITLE
Improve cart checkout button appearance in no-linked-account case

### DIFF
--- a/assets/css/wc-gateway-ppec-frontend-cart.css
+++ b/assets/css/wc-gateway-ppec-frontend-cart.css
@@ -9,7 +9,7 @@
 	margin: 0 0 1em;
 }
 .wcppec-checkout-buttons__button {
-	display: block;
+	display: inline-block;
 	text-decoration: none !important;
 	border: 0 !important;
 	padding-top: 1em;

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -202,10 +202,6 @@ class WC_Gateway_PPEC_Cart_Handler {
 		$settings = wc_gateway_ppec()->settings;
 		$client   = wc_gateway_ppec()->client;
 
-		if ( ! $client->get_payer_id() ) {
-			return;
-		}
-
 		wp_enqueue_style( 'wc-gateway-ppec-frontend-cart', wc_gateway_ppec()->plugin_url . 'assets/css/wc-gateway-ppec-frontend-cart.css' );
 
 		if ( is_cart() ) {


### PR DESCRIPTION
If the "Check out with PayPal" [button is shown](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/848031d587a4fe19c85546ee095d59af8daf3d8b/includes/class-wc-gateway-ppec-cart-handler.php#L24) — and it is, if the PPEC gateway [is enabled](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/848031d587a4fe19c85546ee095d59af8daf3d8b/includes/class-wc-gateway-ppec-cart-handler.php#L18) — then we should also enqueue its styles and scripts with no [further condition](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/848031d587a4fe19c85546ee095d59af8daf3d8b/includes/class-wc-gateway-ppec-cart-handler.php#L205).

This change is to remove the latter condition so that the button appears and works normally in the case where a PayPal account is not linked (specifically, https://github.com/Automattic/woocommerce-services/pull/1254/). There is also a tweak to the CSS so as to fix the button's appearance in the Twenty Seventeen theme.

... | Storefront | Twenty Seventeen
-- | -- | --
PPEC disabled | <img width="423" alt="screen shot 2018-01-10 at 9 56 46 pm" src="https://user-images.githubusercontent.com/1867547/34806474-2c346e50-f651-11e7-8d14-a989d1effba9.png"> | <img width="381" alt="screen shot 2018-01-10 at 5 46 04 pm" src="https://user-images.githubusercontent.com/1867547/34806477-3498f3d6-f651-11e7-9fa4-23184589a49f.png">
PPEC enabled, `master` | <img width="427" alt="screen shot 2018-01-10 at 9 27 55 pm" src="https://user-images.githubusercontent.com/1867547/34806499-55e3bb0c-f651-11e7-80f7-21aed6a85049.png"> | <img width="363" alt="screen shot 2018-01-10 at 5 46 33 pm" src="https://user-images.githubusercontent.com/1867547/34806505-60ac937e-f651-11e7-8ef6-011b2b6a6f57.png"> (text cut off)
https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/commit/5f64e034c1082947cbbbc39318088e1f1622c41b | <img width="420" alt="3" src="https://user-images.githubusercontent.com/1867547/34806540-8c20b9a4-f651-11e7-8da9-41d6ba658bc1.png"> | <img width="366" alt="screen shot 2018-01-10 at 5 46 52 pm" src="https://user-images.githubusercontent.com/1867547/34806544-9284ebee-f651-11e7-91bc-2e2839ddc9d3.png"> (full-width underline)
https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/commit/9e45c4f0b27757d6afa30e4340c2bb383f459d57 | <img width="421" alt="4" src="https://user-images.githubusercontent.com/1867547/34806563-a6921d6e-f651-11e7-84af-273994a3dcb4.png"> | <img width="364" alt="screen shot 2018-01-10 at 5 48 00 pm" src="https://user-images.githubusercontent.com/1867547/34806554-9f2ac792-f651-11e7-8d98-1826d014b402.png">




