### PR TITLE
Fix missing Settings link on plugins page

### DIFF
--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -408,7 +408,7 @@ class WC_Gateway_PPEC_Plugin {
 	public function plugin_action_links( $links ) {
 		$plugin_links = array();
 
-		if ( $this->_bootstrapped ) {
+		if ( function_exists( 'WC' ) ) {
 			$setting_url = $this->get_admin_setting_link();
 			$plugin_links[] = '<a href="' . esc_url( $setting_url ) . '">' . esc_html__( 'Settings', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>';
 		}


### PR DESCRIPTION
The "Settings" link was conditionally removed in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/252 in order to fix an error when WooCommerce wasn't active (https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/251), but also applied to cases in which WooCommerce was active if PPEC was enabled but credentials hadn't been saved:

<img width="467" alt="screen shot 2018-01-23 at 9 00 10 am" src="https://user-images.githubusercontent.com/1867547/35279722-dc89d62c-001b-11e8-808f-d29d51d728b7.png">

This PR narrows the condition to the minimum necessary to fix https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/251.