### PR TITLE
Revert adding request endpoint filter

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -96,11 +96,11 @@ class WC_Gateway_PPEC_Client {
 	 * @return string
 	 */
 	public function get_endpoint() {
-		return apply_filters( 'woocommerce_paypal_express_checkout_request_endpoint', sprintf(
+		return sprintf(
 			'https://%s%s.paypal.com/nvp',
 			$this->_credential->get_endpoint_subdomain(),
 			'sandbox' === $this->_environment ? '.sandbox' : ''
-		), $this->_environment );
+		);
 	}
 
 	/**


### PR DESCRIPTION
Reverts the change in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/347 that added an API endpoint URL filter, which didn't end up being used for the purposes that it was intended for.