### PR TITLE
Fix fatal error when session object does not yet exists before using …

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -701,6 +701,10 @@ class WC_Gateway_PPEC_Checkout_Handler {
 	 * @return bool Returns true if buyer checkout from checkout page
 	 */
 	public function is_started_from_checkout_page() {
+		if ( ! is_object( WC()->session ) ) {
+			return false;
+		}
+
 		$session = WC()->session->get( 'paypal' );
 
 		return (

--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 == Changelog ==
 
+= 1.5.3 =
+* Fix - Make sure session object exists before use to prevent fatal error.
+
 = 1.5.2 =
 * Tweak - Express checkout shouldn't display "Review your order before the payment".
 * Fix   - Compatibility with Subscriptions and Checkout from Single Product page.


### PR DESCRIPTION
…closes #378

* Fix - Make sure session object exists before use to prevent fatal error.

I was not able to replicate this error with the noted comments in the issue but I have put in a check to make sure we're seeing a session object before use.