### PR TITLE
Duplicate checkout setting when PP Credit is enabled closes #369

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.5.4 - 2018-xx-xx =
 * Fix - When returning from PayPal, place order buttons says "proceed to payment".
 * Fix - Impossible to open API credentials after saving Settings.
+* Fix - Duplicate checkout settings when PP Credit option is enabled.
 
 = 1.5.3 - 2018-03-28 =
 * Fix - wp_enqueue_media was not correctly loaded causing weird behavior with other parts of system wanting to use it.

--- a/includes/class-wc-gateway-ppec-with-paypal-credit.php
+++ b/includes/class-wc-gateway-ppec-with-paypal-credit.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-class WC_Gateway_PPEC_With_PayPal_Credit extends WC_Gateway_PPEC {
+class WC_Gateway_PPEC_With_PayPal_Credit extends WC_Gateway_PPEC_With_PayPal {
 	public function __construct() {
 		$this->icon    = 'https://www.paypalobjects.com/webstatic/en_US/i/buttons/ppc-acceptance-small.png';
 


### PR DESCRIPTION
* Fix - Duplicate checkout settings when PP Credit option is enabled.