### PR TITLE
Enable PayPal Credit by default, and restrict its support by currency

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -76,10 +76,8 @@ function wc_gateway_ppec_log( $message ) {
  * @return bool Returns true if PayPal credit is supported
  */
 function wc_gateway_ppec_is_credit_supported() {
-	$base     = wc_get_base_location();
-	$currency = get_option( 'woocommerce_currency', 'GBP' );
-
-	return 'US' === $base['country'] && 'USD' === $currency;
+	$base = wc_get_base_location();
+	return 'US' === $base['country'] && 'USD' === get_woocommerce_currency();
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -76,9 +76,10 @@ function wc_gateway_ppec_log( $message ) {
  * @return bool Returns true if PayPal credit is supported
  */
 function wc_gateway_ppec_is_credit_supported() {
-	$base = wc_get_base_location();
+	$base     = wc_get_base_location();
+	$currency = get_option( 'woocommerce_currency', 'GBP' );
 
-	return 'US' === $base['country'];
+	return 'US' === $base['country'] && 'USD' === $currency;
 }
 
 /**

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -48,6 +48,9 @@ if ( ! wc_gateway_ppec_is_credit_supported() ) {
 	$credit_enabled_label .= '<p><em>' . __( 'This option is disabled. Currently PayPal Credit only available for U.S. merchants using USD currency.', 'woocommerce-gateway-paypal-express-checkout' ) . '</em></p>';
 }
 
+$credit_enabled_description  = __( 'This enables PayPal Credit, which displays a PayPal Credit button next to the Express Checkout button. PayPal Express Checkout lets you give customers access to financing through PayPal Credit® - at no additional cost to you. You get paid up front, even though customers have more time to pay. A pre-integrated payment button shows up next to the PayPal Button, and lets customers pay quickly with PayPal Credit®.', 'woocommerce-gateway-paypal-express-checkout' );
+$credit_enabled_description .= __( ' (Should be unchecked for stores involved in Real Money Gaming.)', 'woocommerce-gateway-paypal-express-checkout' );
+
 wc_enqueue_js( "
 	jQuery( function( $ ) {
 		var ppec_mark_fields      = '#woocommerce_ppec_paypal_title, #woocommerce_ppec_paypal_description';
@@ -324,7 +327,7 @@ return apply_filters( 'woocommerce_paypal_express_checkout_settings', array(
 		'disabled'    => ! wc_gateway_ppec_is_credit_supported(),
 		'default'     => 'yes',
 		'desc_tip'    => true,
-		'description' => __( 'This enables PayPal Credit, which displays a PayPal Credit button next to the Express Checkout button. PayPal Express Checkout lets you give customers access to financing through PayPal Credit® - at no additional cost to you. You get paid up front, even though customers have more time to pay. A pre-integrated payment button shows up next to the PayPal Button, and lets customers pay quickly with PayPal Credit®.', 'woocommerce-gateway-paypal-express-checkout' ),
+		'description' => $credit_enabled_description,
 	),
 	'checkout_on_single_product_enabled' => array(
 		'title'       => __( 'Checkout on Single Product', 'woocommerce-gateway-paypal-express-checkout' ),

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -48,8 +48,7 @@ if ( ! wc_gateway_ppec_is_credit_supported() ) {
 	$credit_enabled_label .= '<p><em>' . __( 'This option is disabled. Currently PayPal Credit only available for U.S. merchants using USD currency.', 'woocommerce-gateway-paypal-express-checkout' ) . '</em></p>';
 }
 
-$credit_enabled_description  = __( 'This enables PayPal Credit, which displays a PayPal Credit button next to the Express Checkout button. PayPal Express Checkout lets you give customers access to financing through PayPal Credit® - at no additional cost to you. You get paid up front, even though customers have more time to pay. A pre-integrated payment button shows up next to the PayPal Button, and lets customers pay quickly with PayPal Credit®.', 'woocommerce-gateway-paypal-express-checkout' );
-$credit_enabled_description .= __( ' (Should be unchecked for stores involved in Real Money Gaming.)', 'woocommerce-gateway-paypal-express-checkout' );
+$credit_enabled_description  = __( 'This enables PayPal Credit, which displays a PayPal Credit button next to the Express Checkout button. PayPal Express Checkout lets you give customers access to financing through PayPal Credit® - at no additional cost to you. You get paid up front, even though customers have more time to pay. A pre-integrated payment button shows up next to the PayPal Button, and lets customers pay quickly with PayPal Credit®. (Should be unchecked for stores involved in Real Money Gaming.)', 'woocommerce-gateway-paypal-express-checkout' );
 
 wc_enqueue_js( "
 	jQuery( function( $ ) {

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -45,7 +45,7 @@ if ( $enable_ips && $needs_sandbox_creds ) {
 
 $credit_enabled_label = __( 'Enable PayPal Credit', 'woocommerce-gateway-paypal-express-checkout' );
 if ( ! wc_gateway_ppec_is_credit_supported() ) {
-	$credit_enabled_label .= '<p><em>' . __( 'This option is disabled. Currently PayPal Credit only available for U.S. merchants.', 'woocommerce-gateway-paypal-express-checkout' ) . '</em></p>';
+	$credit_enabled_label .= '<p><em>' . __( 'This option is disabled. Currently PayPal Credit only available for U.S. merchants using USD currency.', 'woocommerce-gateway-paypal-express-checkout' ) . '</em></p>';
 }
 
 wc_enqueue_js( "

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -322,7 +322,7 @@ return apply_filters( 'woocommerce_paypal_express_checkout_settings', array(
 		'type'        => 'checkbox',
 		'label'       => $credit_enabled_label,
 		'disabled'    => ! wc_gateway_ppec_is_credit_supported(),
-		'default'     => 'no',
+		'default'     => 'yes',
 		'desc_tip'    => true,
 		'description' => __( 'This enables PayPal Credit, which displays a PayPal Credit button next to the Express Checkout button. PayPal Express Checkout lets you give customers access to financing through PayPal Credit® - at no additional cost to you. You get paid up front, even though customers have more time to pay. A pre-integrated payment button shows up next to the PayPal Button, and lets customers pay quickly with PayPal Credit®.', 'woocommerce-gateway-paypal-express-checkout' ),
 	),


### PR DESCRIPTION
Based on the guidelines in [this doc](https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/customize-button/#funding-methods):
1. Adds a USD currency check to the function testing for PayPal Credit support
2. Enables the PayPal Credit option by default
3. Mentions the "Real Money Gaming" restriction in the description