### PR TITLE
Adjust markup to fix help tip alignment for image settings

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -532,8 +532,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		?>
 		<tr valign="top">
 			<th scope="row" class="titledesc">
-				<?php echo $this->get_tooltip_html( $data ); ?>
-				<label for="<?php echo esc_attr( $field_key ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
+				<label for="<?php echo esc_attr( $field_key ); ?>"><?php echo wp_kses_post( $data['title'] ); ?> <?php echo $this->get_tooltip_html( $data ); ?></label>
 			</th>
 
 			<td class="image-component-wrapper">


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/418

Moves tooltip into `<label>` to catch up with change in WC core help tip styling: https://github.com/woocommerce/woocommerce/commit/d8814f93819a41a64f9f6571542488de8db65dab

Before | After
-- | --
<img width="658" alt="screen shot 2018-06-14 at 2 25 42 pm" src="https://user-images.githubusercontent.com/1867547/41430751-e99b3a6c-6fde-11e8-8762-3342a6abd054.png"> | <img width="660" alt="screen shot 2018-06-14 at 2 26 07 pm" src="https://user-images.githubusercontent.com/1867547/41430754-eb135514-6fde-11e8-929b-a91fb888aa63.png">