### PR TITLE
Enable PPEC by default on product and checkout pages

### DIFF
--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -279,7 +279,7 @@ return apply_filters( 'woocommerce_paypal_express_checkout_settings', array(
 		'label'       => __( 'Enable the PayPal Mark on regular checkout', 'woocommerce-gateway-paypal-express-checkout' ),
 		'description' => __( 'This enables the PayPal mark, which can be shown on regular WooCommerce checkout to use PayPal Express Checkout like a regular WooCommerce gateway.', 'woocommerce-gateway-paypal-express-checkout' ),
 		'desc_tip'    => true,
-		'default'     => 'no',
+		'default'     => 'yes',
 	),
 	'logo_image_url' => array(
 		'title'       => __( 'Logo Image (190×60)', 'woocommerce-gateway-paypal-express-checkout' ),

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -330,7 +330,7 @@ return apply_filters( 'woocommerce_paypal_express_checkout_settings', array(
 		'title'       => __( 'Checkout on Single Product', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Checkout on Single Product', 'woocommerce-gateway-paypal-express-checkout' ),
-		'default'     => 'no',
+		'default'     => 'yes',
 		'description' => __( 'Enable Express checkout on Single Product view.', 'woocommerce-gateway-paypal-express-checkout' ),
 	),
 


### PR DESCRIPTION
PayPal have requested that we have the buttons appear on the Single Product and Regular Checkout pages by default.

Please share if there are specific considerations around why they currently default to disabled.