### PR TITLE
Omit 'Express Checkout' portion of default payment method title

### DIFF
--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -127,7 +127,7 @@ return apply_filters( 'woocommerce_paypal_express_checkout_settings', array(
 		'title'       => __( 'Title', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'        => 'text',
 		'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-gateway-paypal-express-checkout' ),
-		'default'     => __( 'PayPal Express Checkout', 'woocommerce-gateway-paypal-express-checkout' ),
+		'default'     => __( 'PayPal', 'woocommerce-gateway-paypal-express-checkout' ),
 		'desc_tip'    => true,
 	),
 	'description' => array(


### PR DESCRIPTION
From the customer's (rather than merchant's) perspective, "Express Checkout" is arguably an implementation detail that they shouldn't need to worry about. This change affects the default user-facing payment method title, simplifying it to "PayPal", in response to this mockup from PayPal:

<img width="315" alt="screen shot 2018-06-20 at 12 16 22 pm" src="https://user-images.githubusercontent.com/1867547/41671059-03bf27d8-7484-11e8-82c5-e1d24c7e968b.png">

...and also in light of this code with disables PPEC on regular checkout if the standard "PayPal" gateway is enabled: https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/ca9939ee8b5aa42a741ab5f60c795ba916c68567/includes/class-wc-gateway-ppec-checkout-handler.php#L498-L501