### PR TITLE
Fix PHP warning due to incorrect assumption of setting value type

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.6.1 - 2018-xx-xx =
 * Fix - GDPR Fatal error exporting user data when they have PPEC subscriptions.
 * Fix - PayPal Credit still being disabled by default.
+* Fix - PHP warning when PayPal Credit not supported and no funding methods hidden.
 
 = 1.6.0 - 2018-06-27 =
 * Add - Smart Payment Buttons mode as alternative to directly embedded image links for all instances of PayPal button.

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -277,7 +277,9 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		if ( ! wc_gateway_ppec_is_credit_supported() ) {
 			$data['credit_enabled'] = 'no';
-			if ( ! in_array( 'CREDIT', $data['hide_funding_methods'] ) ) {
+			if ( ! $data['hide_funding_methods'] ) {
+				$data['hide_funding_methods'] = array( 'CREDIT' );
+			} elseif ( ! in_array( 'CREDIT', $data['hide_funding_methods'] ) ) {
 				$data['hide_funding_methods'][] = 'CREDIT';
 			}
 		}

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -277,7 +277,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		if ( ! wc_gateway_ppec_is_credit_supported() ) {
 			$data['credit_enabled'] = 'no';
-			if ( ! $data['hide_funding_methods'] ) {
+			if ( ! is_array( $data['hide_funding_methods'] ) ) {
 				$data['hide_funding_methods'] = array( 'CREDIT' );
 			} elseif ( ! in_array( 'CREDIT', $data['hide_funding_methods'] ) ) {
 				$data['hide_funding_methods'][] = 'CREDIT';

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 = 1.6.1 - 2018-xx-xx =
 * Fix - GDPR Fatal error exporting user data when they have PPEC subscriptions.
 * Fix - PayPal Credit still being disabled by default.
+* Fix - PHP warning when PayPal Credit not supported and no funding methods hidden.
 
 = 1.6.0 - 2018-06-27 =
 * Add - Smart Payment Buttons mode as alternative to directly embedded image links for all instances of PayPal button.


### PR DESCRIPTION
Appears when PayPal Credit is not supported and Hide Funding Method(s) multiselect setting is empty, the value for which is encoded as `''` rather than `array()`.

To reproduce issue, select country other than US or currency other than USD so that PayPal Credit is not supported. Save empty selection for "Hide Funding Method(s)" with vertical layout, and observe PHP warning when rendering button on the front-end.

Reported in https://wordpress.org/support/topic/get-warning-when-enable-credit-card-in-express-smart-button/