### PR TITLE
Modify Simple Payment Button gateway to inherit from existing gateway classes

### DIFF
--- a/includes/class-wc-gateway-ppec-gateway-loader.php
+++ b/includes/class-wc-gateway-ppec-gateway-loader.php
@@ -22,6 +22,7 @@ class WC_Gateway_PPEC_Gateway_Loader {
 		require_once( $includes_path . 'class-wc-gateway-ppec-with-paypal-credit.php' );
 		require_once( $includes_path . 'class-wc-gateway-ppec-with-paypal-addons.php' );
 		require_once( $includes_path . 'class-wc-gateway-ppec-with-spb.php' );
+		require_once( $includes_path . 'class-wc-gateway-ppec-with-spb-addons.php' );
 
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'payment_gateways' ) );
 	}
@@ -37,7 +38,11 @@ class WC_Gateway_PPEC_Gateway_Loader {
 		$settings = wc_gateway_ppec()->settings;
 
 		if ( 'yes' === $settings->use_spb ) {
-			$methods[] = 'WC_Gateway_PPEC_With_SPB';
+			if ( $this->can_use_addons() ) {
+				$methods[] = 'WC_Gateway_PPEC_With_SPB_Addons';
+			} else {
+				$methods[] = 'WC_Gateway_PPEC_With_SPB';
+			}
 			return $methods;
 		}
 

--- a/includes/class-wc-gateway-ppec-with-spb-addons.php
+++ b/includes/class-wc-gateway-ppec-with-spb-addons.php
@@ -5,9 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Implementation is duplicated in WC_Gateway_PPEC_With_SPB.
+ * Duplicate of implementation in WC_Gateway_PPEC_With_SPB.
  */
-class WC_Gateway_PPEC_With_SPB extends WC_Gateway_PPEC_With_PayPal {
+class WC_Gateway_PPEC_With_SPB_Addons extends WC_Gateway_PPEC_With_PayPal_Addons {
 	public function __construct() {
 		parent::__construct();
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/439 (and subscriptions not working in SPB in general).

Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/444

Instead of extending the base abstract class, SPB gateway now extends `WC_Gateway_PPEC_With_PayPal`. **Duplicates** `WC_Gateway_PPEC_With_SPB` code into a separate `WC_Gateway_PPEC_With_SPB_Addons` class (avoiding use of traits to support PHP <5.4), which will no longer be necessary after https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/436.