### PR TITLE
Fix missing PayPal branding in 'Buy Now' button

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -44,6 +44,7 @@
 				layout: button_layout,
 				size: button_size,
 				label: button_label,
+				branding: true,
 				tagline: false,
 			},
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.6.1 - 2018-xx-xx =
 * Fix - GDPR Fatal error exporting user data when they have PPEC subscriptions.
 * Fix - PayPal Credit still being disabled by default.
+* Fix - Missing PayPal branding in "Buy Now" Smart Payment Button.
 
 = 1.6.0 - 2018-06-27 =
 * Add - Smart Payment Buttons mode as alternative to directly embedded image links for all instances of PayPal button.

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 = 1.6.1 - 2018-xx-xx =
 * Fix - GDPR Fatal error exporting user data when they have PPEC subscriptions.
 * Fix - PayPal Credit still being disabled by default.
+* Fix - Missing PayPal branding in "Buy Now" Smart Payment Button.
 
 = 1.6.0 - 2018-06-27 =
 * Add - Smart Payment Buttons mode as alternative to directly embedded image links for all instances of PayPal button.


### PR DESCRIPTION
When the primary 'PayPal Checkout' button – in Smart Payment Buttons mode – is the only one that appears in horizontal layout (default for single product page), the `label: buynow` value we are passing causes the PayPal branding to disappear, unless `branding: true` is also passed. This PR makes sure the latter is passed in every case – it makes no difference in cases when the `label` doesn't appear.

Before | After
-- | --
<img width="458" alt="screen shot 2018-07-04 at 3 54 15 am" src="https://user-images.githubusercontent.com/1867547/42264207-fc75b78e-7f3d-11e8-9156-fab17b2d0dd2.png"> | <img width="448" alt="screen shot 2018-07-04 at 3 54 31 am" src="https://user-images.githubusercontent.com/1867547/42264208-fdc4c7ce-7f3d-11e8-8f32-9426a8635933.png">

Addresses feedback in https://wordpress.org/support/topic/paypal-logo-on-new-smart-button/