### PR TITLE
Fix single product Smart Payment Button failing without existing session

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -331,7 +331,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				'page'                 => $page,
 				'button_color'         => $settings->button_color,
 				'button_shape'         => $settings->button_shape,
-				'start_checkout_nonce' => wp_create_nonce( '_wc_ppec_start_checkout_nonce' ),
+				'start_checkout_nonce' => $this->create_nonce( '_wc_ppec_start_checkout_nonce' ),
 				'start_checkout_url'   => WC_AJAX::get_endpoint( 'wc_ppec_start_checkout' ),
 			);
 
@@ -362,11 +362,22 @@ class WC_Gateway_PPEC_Cart_Handler {
 			wp_enqueue_script( 'wc-gateway-ppec-generate-cart', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-generate-cart.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
 			wp_localize_script( 'wc-gateway-ppec-generate-cart', 'wc_ppec_generate_cart_context',
 				array(
-					'generate_cart_nonce' => wp_create_nonce( '_wc_ppec_generate_cart_nonce' ),
+					'generate_cart_nonce' => $this->create_nonce( '_wc_ppec_generate_cart_nonce' ),
 					'ajaxurl'             => WC_AJAX::get_endpoint( 'wc_ppec_generate_cart' ),
 				)
 			);
 		}
+	}
+
+	/**
+	 * Ensures a session is active, so that nonce is not invalidated by new session created on AJAX POST request.
+	 */
+	protected function create_nonce( $action ) {
+		if ( ! WC()->session->has_session() ) {
+			WC()->session->set_customer_session_cookie( true );
+		}
+
+		return wp_create_nonce( $action );
 	}
 
 	/**


### PR DESCRIPTION
The nonce created with no session will not match the nonce verified when a session is created on AJAX POST. This causes AJAX requests to fail, breaking cart generation and SPB payment from single product pages.

This PR makes sure a session is there by the time the nonce is created. Should address reports of PayPal window closing immediately (https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/438, [forum thread](https://wordpress.org/support/topic/many-bugs-in-1-6-0-version/)).

To reproduce broken payments with Smart Payment Buttons enabled, open single product page in a new session (e.g. Firefox Private Browsing), click the PayPal Checkout button, and see the PayPal window open and immediately close.

To reproduce failed cart generation (with or without Smart Payment Buttons), open single product page in a new session, enter a quantity greater than 1, click the PayPal Checkout button, and observe only 1 item being listed.