### PR TITLE
Add a filter to paypal locale

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -306,7 +306,7 @@ class WC_Gateway_PPEC_Settings {
 		if ( ! in_array( $locale, $this->_supported_locales ) ) {
 			$locale = 'en_US';
 		}
-		return $locale;
+		return apply_filters( 'woocommerce_paypal_express_checkout_get_paypal_locale', $locale );
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -306,7 +306,7 @@ class WC_Gateway_PPEC_Settings {
 		if ( ! in_array( $locale, $this->_supported_locales ) ) {
 			$locale = 'en_US';
 		}
-		return apply_filters( 'woocommerce_paypal_express_checkout_get_paypal_locale', $locale );
+		return apply_filters( 'woocommerce_paypal_express_checkout_paypal_locale', $locale );
 	}
 
 	/**


### PR DESCRIPTION
Paypal locale can be different from the site locale, as for example with de_DE_formal where paypal would need de_DE. The filtering of get_locale() being pretty cumbersome because of tons of options, adding a filter seems to be the easiest way.