### PR TITLE
When cart is empty, don't show mini-cart buttons or attempt to render cart buttons

### DIFF
--- a/assets/css/wc-gateway-ppec-frontend-cart.css
+++ b/assets/css/wc-gateway-ppec-frontend-cart.css
@@ -34,3 +34,6 @@
 .site-header .widget_shopping_cart p.buttons.wcppec-cart-widget-spb {
     padding: 0 1em 1em;
 }
+.site-header .widget_shopping_cart .woocommerce-mini-cart__empty-message + p.buttons.wcppec-cart-widget-spb {
+	display: none;
+}

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -301,7 +301,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		wp_enqueue_style( 'wc-gateway-ppec-frontend-cart', wc_gateway_ppec()->plugin_url . 'assets/css/wc-gateway-ppec-frontend-cart.css' );
 
-		$is_cart     = is_cart() && 'yes' === $settings->cart_checkout_enabled;
+		$is_cart     = is_cart() && ! WC()->cart->is_empty() && 'yes' === $settings->cart_checkout_enabled;
 		$is_product  = is_product() && 'yes' === $settings->checkout_on_single_product_enabled;
 		$is_checkout = is_checkout() && 'yes' === $settings->mark_enabled && ! wc_gateway_ppec()->checkout->has_active_session();
 		$page        = $is_cart ? 'cart' : ( $is_product ? 'product' : ( $is_checkout ? 'checkout' : null ) );


### PR DESCRIPTION
Fixes buttons showing up in the mini-cart when the cart is empty:
<img width="273" alt="screen shot 2018-06-27 at 4 50 51 pm" src="https://user-images.githubusercontent.com/1867547/42276860-54e585dc-7f63-11e8-81e7-e933704e0cc3.png">

Also fixes a JS error any time an empty cart page is loaded.