### PR TITLE
Filter for details sent to PayPal to fix decimal quantities error 10413

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -619,7 +619,7 @@ class WC_Gateway_PPEC_Client {
 			$details['items'][] = $this->_get_extra_offset_line_item( $details['total_item_amount'] - $lisum );
 		}
 
-		return $details;
+		return apply_filters( 'woocommerce_paypal_express_checkout_get_details', $details );
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -619,6 +619,17 @@ class WC_Gateway_PPEC_Client {
 			$details['items'][] = $this->_get_extra_offset_line_item( $details['total_item_amount'] - $lisum );
 		}
 
+		/**
+		 * Filter PayPal order details.
+		 * 
+		 * Provide opportunity for developers to modify details passed to PayPal.
+		 * This was originally introduced to add a mechanism to allow for
+		 * decimal product quantity support.
+		 * 
+		 * @since 1.6.6
+		 * 
+		 * @param array $details Current PayPal order details
+		 */
 		return apply_filters( 'woocommerce_paypal_express_checkout_get_details', $details );
 	}
 


### PR DESCRIPTION
This filter is useful to let developers modify details passed to PayPal.
Specially to unset $details['items'] for letting PayPal accept decimal quantities of products (issue #430)