### PR TITLE
Fix for issue #433

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.6.2 - 2018-xx-xx =
+* Fix - Tax not applied on the (Confirm your PayPal order) page at the checkout.
+
 = 1.6.1 - 2018-07-04 =
 * Fix - GDPR Fatal error exporting user data when they have PPEC subscriptions.
 * Fix - PayPal Credit still being disabled by default.


### PR DESCRIPTION
Addresses issues #433 

Sets current customer shipping and billing addresses from PayPal session as soon as the PayPal pop-up returns. This is necessary because the PPEC extension allows the customer to select an address in the PayPal pop-up, so the address must be retrieved from there:

<img width="572" alt="image" src="https://user-images.githubusercontent.com/6209518/42542689-df437e48-845c-11e8-8483-8ccc6ce56684.png">

Previously, even though the correct shipping address was displayed on the "Confirm your PayPal order" screen, it was not being used by WooCommerce to calculate the taxes. The correct taxes were only calculated at final checkout, so the final charged amount would not always match the confirmation screen.

Now the taxes are calculated from the same address that is displayed on the confirmation screen:
<img width="626" alt="image" src="https://user-images.githubusercontent.com/6209518/42542790-55d8336e-845d-11e8-8a8f-80d100c8d578.png">


