### PR TITLE
Verify terms acceptance before initializing payment

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -74,6 +74,8 @@
 						data: {
 							'nonce': wc_ppec_context.start_checkout_nonce,
 							'from_checkout': 'checkout' === wc_ppec_context.page && ! isMiniCart ? 'yes' : 'no',
+							'terms-field': $( 'form.checkout [name="terms-field"]' ).val() || 0,
+							'terms': $( 'form.checkout [name="terms"]' ).is( ':checked' ) || 0,
 						},
 					} ).then( function( response ) {
 						if ( ! response.success ) {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -134,6 +134,12 @@ class WC_Gateway_PPEC_Cart_Handler {
 			wp_die( __( 'Cheatin&#8217; huh?', 'woocommerce-gateway-paypal-express-checkout' ) );
 		}
 
+		if ( ! empty( $_POST['terms-field'] ) && empty( $_POST['terms'] ) ) {
+			$message = __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce-gateway-paypal-express-checkout' );
+			wp_send_json_error( array( 'message' => $message ) );
+			return;
+		}
+
 		if ( isset( $_POST['from_checkout'] ) && 'yes' === $_POST['from_checkout'] ) {
 			add_filter( 'woocommerce_cart_needs_shipping', '__return_false' );
 		}


### PR DESCRIPTION
Fixes #451

This now shows up when using Smart Payment Buttons on the regular checkout page, when attempting to start payment with a terms and conditions field present and unchecked:

<img width="352" alt="screen shot 2018-07-12 at 1 35 24 pm" src="https://user-images.githubusercontent.com/1867547/42650297-091dfd0a-85da-11e8-81dc-1943df065524.png">

Previously, this verification would happen only after the payment is authorized on the PayPal side.

Duplicates (unfortunately) logic and string from WooCommerce core in these places: [#](https://github.com/woocommerce/woocommerce/blob/3fa3830b6ceeaafda7eab8f5fa3534026913bd71/includes/class-wc-form-handler.php#L375-L376), [#](https://github.com/woocommerce/woocommerce/blob/3fa3830b6ceeaafda7eab8f5fa3534026913bd71/includes/class-wc-checkout.php#L748-L749).