### PR TITLE
Global attributes stripped before sent to PayPal if unicode characters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.6.19 - 2020-xx-xx =
 * Fix - Check if order exists before adding order actions
+* Fix - Global attributes stripped before sent to PayPal if unicode characters
 
 = 1.6.18 - 2019-12-05 =
 * Fix - Send fees to PayPal as line items

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -86,7 +86,29 @@ class WC_Gateway_PPEC_Cart_Handler {
 			wc_empty_cart();
 
 			if ( $product->is_type( 'variable' ) ) {
-				$attributes = array_map( 'wc_clean', $_POST['attributes'] );
+				$attributes = array();
+				$slugs      = array();
+
+				/**
+				 * We need to make sure we're not passing bad data to a query later on, 
+				 * so we get the attributes for the product. 
+				 */
+				foreach ( $product->get_attributes() as $attribute ) {
+					foreach ( $attribute->get_terms() as $term ) {
+						$slugs[] = $term->slug;
+					}
+				}
+
+				/**
+				 * And then we clean anything that doesn't match a slug for the product. 
+				 */
+				foreach ( $_POST['attributes'] as $attribute => $term ) {
+					if ( in_array( $term, $slugs ) ) {
+						$attributes[ $attribute ] = $term;
+					} else {
+						$attributes[ $attribute ] = wc_clean( $term );
+					}
+				}
 
 
 				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -87,29 +87,25 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 			if ( $product->is_type( 'variable' ) ) {
 				$attributes = array();
-				$slugs      = array();
 
-				/**
-				 * We need to make sure we're not passing bad data to a query later on, 
-				 * so we get the attributes for the product. 
-				 */
 				foreach ( $product->get_attributes() as $attribute ) {
-					foreach ( $attribute->get_terms() as $term ) {
-						$slugs[] = $term->slug;
+					if ( ! $attribute['is_variation'] ) {
+						continue;
+					}
+
+					$attribute_key = 'attribute_' . sanitize_title( $attribute['name'] );
+
+					if ( isset( $_POST['attributes'][ $attribute_key ] ) ) {
+						if ( $attribute['is_taxonomy'] ) {
+							// Don't use wc_clean as it destroys sanitized characters.
+							$value = sanitize_title( wp_unslash( $_POST['attributes'][ $attribute_key ] ) );
+						} else {
+							$value = html_entity_decode( wc_clean( wp_unslash( $_POST['attributes'][ $attribute_key ] ) ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+						}
+
+						$attributes[ $attribute_key ] = $value;
 					}
 				}
-
-				/**
-				 * And then we clean anything that doesn't match a slug for the product. 
-				 */
-				foreach ( $_POST['attributes'] as $attribute => $term ) {
-					if ( in_array( $term, $slugs ) ) {
-						$attributes[ $attribute ] = $term;
-					} else {
-						$attributes[ $attribute ] = wc_clean( $term );
-					}
-				}
-
 
 				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 					$variation_id = $product->get_matching_variation( $attributes );


### PR DESCRIPTION
Fixes #469 

Rather than cleaning everything that is passed, this does a check to see if what was passed matches an existing attribute term slug. `wc_clean` will remove all encoded items, so it isn't the best way to handle this, which is mentioned [here](https://github.com/woocommerce/woocommerce/blob/3.4.4/includes/data-stores/class-wc-product-data-store-cpt.php#L1059).

@woocommerce/extendables for review assignment
