### PR TITLE
Validate checkout form via AJAX upon opening payment flow

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -2,20 +2,26 @@
 ;( function ( $, window, document ) {
 	'use strict';
 
-	var showError = function( errorMessage ) {
+	// Show error notice at top of checkout form, or else within button container
+	var showError = function( errorMessage, selector ) {
 		var $checkout_form = $( 'form.checkout' );
+
+		if ( ! $checkout_form || ! $checkout_form.length ) {
+			$( selector ).prepend( errorMessage );
+			return;
+		}
 
 		// Adapted from https://github.com/woocommerce/woocommerce/blob/ea9aa8cd59c9fa735460abf0ebcb97fa18f80d03/assets/js/frontend/checkout.js#L514-L529
 		$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message' ).remove();
 		$checkout_form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + errorMessage + '</div>' );
 		$checkout_form.find( '.input-text, select, input:checkbox' ).trigger( 'validate' ).blur();
-		
+
 		var scrollElement = $( '.woocommerce-NoticeGroup-checkout' );
 		if ( ! scrollElement.length ) {
 			scrollElement = $checkout_form;
 		}
 		$.scroll_to_notices( scrollElement );
-		
+
 		$( document.body ).trigger( 'checkout_error' );
 	}
 
@@ -104,7 +110,7 @@
 								return '<li>' + message + '</li>';
 							} ).join( '' );
 
-							showError( '<ul class="woocommerce-error" role="alert">' + messageItems + '</ul>' );
+							showError( '<ul class="woocommerce-error" role="alert">' + messageItems + '</ul>', selector );
 							return null;
 						}
 						return response.data.token;

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -85,7 +85,7 @@
 						if ( ! response.success ) {
 							// Render error notice inside button container.
 							var $message = $( '<ul class="woocommerce-error" role="alert">' )
-								.append( $( '<li>' ).text( response.data.message ) );
+								.append( $( '<li>' ).html( response.data.message ) );
 							$( selector ).prepend( $message );
 							return null;
 						}

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -2,6 +2,23 @@
 ;( function ( $, window, document ) {
 	'use strict';
 
+	var showError = function( errorMessage ) {
+		var $checkout_form = $( 'form.checkout' );
+
+		// Adapted from https://github.com/woocommerce/woocommerce/blob/ea9aa8cd59c9fa735460abf0ebcb97fa18f80d03/assets/js/frontend/checkout.js#L514-L529
+		$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message' ).remove();
+		$checkout_form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + errorMessage + '</div>' );
+		$checkout_form.find( '.input-text, select, input:checkbox' ).trigger( 'validate' ).blur();
+		
+		var scrollElement = $( '.woocommerce-NoticeGroup-checkout' );
+		if ( ! scrollElement.length ) {
+			scrollElement = $checkout_form;
+		}
+		$.scroll_to_notices( scrollElement );
+		
+		$( document.body ).trigger( 'checkout_error' );
+	}
+
 	// Map funding method settings to enumerated options provided by PayPal.
 	var getFundingMethods = function( methods ) {
 		if ( ! methods ) {
@@ -83,10 +100,11 @@
 						body: data,
 					} ).then( function( response ) {
 						if ( ! response.success ) {
-							// Render error notice inside button container.
-							var $message = $( '<ul class="woocommerce-error" role="alert">' )
-								.append( $( '<li>' ).html( response.data.message ) );
-							$( selector ).prepend( $message );
+							var messageItems = response.data.messages.map( function( message ) {
+								return '<li>' + message + '</li>';
+							} ).join( '' );
+
+							showError( '<ul class="woocommerce-error" role="alert">' + messageItems + '</ul>' );
 							return null;
 						}
 						return response.data.token;

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -68,13 +68,19 @@
 					}
 				} ).then( function() {
 					// Make PayPal Checkout initialization request.
+					var data = $( selector ).closest( 'form' )
+						.add( $( '<input type="hidden" name="nonce" /> ' )
+							.attr( 'value', wc_ppec_context.start_checkout_nonce )
+						)
+						.add( $( '<input type="hidden" name="from_checkout" /> ' )
+							.attr( 'value', 'checkout' === wc_ppec_context.page && ! isMiniCart ? 'yes' : 'no' )
+						)
+						.serialize();
+
 					return paypal.request( {
 						method: 'post',
 						url: wc_ppec_context.start_checkout_url,
-						data: {
-							'nonce': wc_ppec_context.start_checkout_nonce,
-							'from_checkout': 'checkout' === wc_ppec_context.page && ! isMiniCart ? 'yes' : 'no',
-						},
+						body: data,
 					} ).then( function( response ) {
 						if ( ! response.success ) {
 							// Render error notice inside button container.

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -4,21 +4,23 @@
 
 	// Show error notice at top of checkout form, or else within button container
 	var showError = function( errorMessage, selector ) {
-		var $checkout_form = $( 'form.checkout' );
+		var $container = $( '.woocommerce-notices-wrapper, form.checkout' );
 
-		if ( ! $checkout_form || ! $checkout_form.length ) {
+		if ( ! $container || ! $container.length ) {
 			$( selector ).prepend( errorMessage );
 			return;
+		} else {
+			$container = $container.first();
 		}
 
 		// Adapted from https://github.com/woocommerce/woocommerce/blob/ea9aa8cd59c9fa735460abf0ebcb97fa18f80d03/assets/js/frontend/checkout.js#L514-L529
 		$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message' ).remove();
-		$checkout_form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + errorMessage + '</div>' );
-		$checkout_form.find( '.input-text, select, input:checkbox' ).trigger( 'validate' ).blur();
+		$container.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + errorMessage + '</div>' );
+		$container.find( '.input-text, select, input:checkbox' ).trigger( 'validate' ).blur();
 
 		var scrollElement = $( '.woocommerce-NoticeGroup-checkout' );
 		if ( ! scrollElement.length ) {
-			scrollElement = $checkout_form;
+			scrollElement = $container;
 		}
 		$.scroll_to_notices( scrollElement );
 

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -22,7 +22,15 @@
 		if ( ! scrollElement.length ) {
 			scrollElement = $container;
 		}
-		$.scroll_to_notices( scrollElement );
+
+		if ( $.scroll_to_notices ) {
+			$.scroll_to_notices( scrollElement );
+		} else {
+			// Compatibility with WC <3.3
+			$( 'html, body' ).animate( {
+				scrollTop: ( $container.offset().top - 100 )
+			}, 1000 );
+		}
 
 		$( document.body ).trigger( 'checkout_error' );
 	}

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.6.4 - 2018-xx-xx =
 * Fix - Billing address from Checkout form not being passed to PayPal via Smart Payment Button.
+* Fix - Checkout form not being validated until after Smart Payment Button payment flow.
 
 = 1.6.3 - 2018-08-15 =
 * Fix - Fatal error caused by a fix for Smart Payment Buttons.

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -151,8 +151,15 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 *
 	 * @since 1.6.4
 	 */
-	public function maybe_start_checkout( $data, $errors ) {
-		$error_messages = $errors->get_error_messages();
+	public function maybe_start_checkout( $data, $errors = null ) {
+		if ( is_null( $errors ) ) {
+			// Compatibility with WC <3.0
+			$error_messages = wc_get_notices( 'error' );
+			wc_clear_notices();
+		} else {
+			$error_messages = $errors->get_error_messages();
+		}
+
 		if ( empty( $error_messages ) ) {
 			$this->start_checkout();
 		} else {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -156,7 +156,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		if ( empty( $error_messages ) ) {
 			$this->start_checkout();
 		} else {
-			wp_send_json_error( array( 'message' => implode( '<br>', $error_messages ) ) );
+			wp_send_json_error( array( 'messages' => $error_messages ) );
 		}
 		exit;
 	}
@@ -171,7 +171,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 			wc_gateway_ppec()->checkout->start_checkout_from_cart();
 			wp_send_json_success( array( 'token' => WC()->session->paypal->token ) );
 		} catch( PayPal_API_Exception $e ) {
-			wp_send_json_error( array( 'message' => $e->getMessage() ) );
+			wp_send_json_error( array( 'messages' => array( $e->getMessage() ) ) );
 		}
 	}
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -153,7 +153,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 */
 	public function maybe_start_checkout( $data, $errors = null ) {
 		if ( is_null( $errors ) ) {
-			// Compatibility with WC <3.0
+			// Compatibility with WC <3.0: get notices and clear them so they don't re-appear.
 			$error_messages = wc_get_notices( 'error' );
 			wc_clear_notices();
 		} else {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -126,7 +126,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 	}
 
 	/**
-	 * Set Express Checkout and return token in response.
+	 * Handle AJAX request to start checkout flow, first triggering form validation if necessary.
 	 *
 	 * @since 1.6.0
 	 */
@@ -137,8 +137,36 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		if ( isset( $_POST['from_checkout'] ) && 'yes' === $_POST['from_checkout'] ) {
 			add_filter( 'woocommerce_cart_needs_shipping', '__return_false' );
-		}
 
+			// Intercept process_checkout call to exit after validation.
+			add_action( 'woocommerce_after_checkout_validation', array( $this, 'maybe_start_checkout' ), 10, 2 );
+			WC()->checkout->process_checkout();
+		} else {
+			$this->start_checkout();
+		}
+	}
+
+	/**
+	 * Report validation errors if any, or else proceed with checkout flow.
+	 *
+	 * @since 1.6.4
+	 */
+	public function maybe_start_checkout( $data, $errors ) {
+		$error_messages = $errors->get_error_messages();
+		if ( empty( $error_messages ) ) {
+			$this->start_checkout();
+		} else {
+			wp_send_json_error( array( 'message' => implode( '<br>', $error_messages ) ) );
+		}
+		exit;
+	}
+
+	/**
+	 * Set Express Checkout and return token in response.
+	 *
+	 * @since 1.6.4
+	 */
+	protected function start_checkout() {
 		try {
 			wc_gateway_ppec()->checkout->start_checkout_from_cart();
 			wp_send_json_success( array( 'token' => WC()->session->paypal->token ) );

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 = 1.6.4 - 2018-xx-xx =
 * Fix - Billing address from Checkout form not being passed to PayPal via Smart Payment Button.
+* Fix - Checkout form not being validated until after Smart Payment Button payment flow.
 
 = 1.6.3 - 2018-08-15 =
 * Fix - Fatal error caused by a fix for Smart Payment Buttons.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/451

Currently, the terms of service checkbox (and the rest of the checkout form's required fields) are validated only after the payment flow is complete, which causes an unnecessary loop in the flow and is too late. This change ensures that form data is sent along with the payment initialization call when a Smart Payment Button is clicked. On the Checkout screen, this triggers form validation on the server, and errors are reported.

Example with empty required fields:

<img width="200" alt="screen shot 2018-09-05 at 6 45 31 pm" src="https://user-images.githubusercontent.com/1867547/45125500-c1a88100-b13c-11e8-8564-d1732da10668.png">

Example with terms of service unchecked:

<img width="200" alt="screen shot 2018-09-05 at 6 45 49 pm" src="https://user-images.githubusercontent.com/1867547/45125504-c2d9ae00-b13c-11e8-970b-6ef6a918650a.png">

May be a step towards solving https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/467 (at least for the Smart Payment Buttons case).