### PR TITLE
Provide customer address to PayPal flow even when no order is created

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.6.4 - 2018-xx-xx =
+* Fix - Billing address from Checkout form not being passed to PayPal via Smart Payment Button.
+
 = 1.6.3 - 2018-08-15 =
 * Fix - Fatal error caused by a fix for Smart Payment Buttons.
 

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -464,6 +464,7 @@ class WC_Gateway_PPEC_Client {
 			'order_tax'         => round( WC()->cart->tax_total + WC()->cart->shipping_tax_total, $decimals ),
 			'shipping'          => round( WC()->cart->shipping_total, $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_cart(),
+			'shipping_address'  => $this->_get_address_from_customer(),
 		);
 
 		return $this->get_details( $details, $discounts, $rounded_total, WC()->cart->total );
@@ -696,6 +697,59 @@ class WC_Gateway_PPEC_Client {
 		$details['shipping_address'] = $shipping_address;
 
 		return $details;
+	}
+
+	/**
+	 * Get PayPal shipping address from customer.
+	 *
+	 * @return array Address
+	 */
+	protected function _get_address_from_customer() {
+		$customer = WC()->customer;
+
+		$shipping_address = new PayPal_Address;
+
+		$old_wc = version_compare( WC_VERSION, '3.0', '<' );
+
+		if ( $customer->get_shipping_address() || $customer->get_shipping_address_2() ) {
+			$shipping_first_name = $old_wc ? '' : $customer->get_shipping_first_name();
+			$shipping_last_name  = $old_wc ? '' : $customer->get_shipping_last_name();
+			$shipping_address_1  = $customer->get_shipping_address();
+			$shipping_address_2  = $customer->get_shipping_address_2();
+			$shipping_city       = $customer->get_shipping_city();
+			$shipping_state      = $customer->get_shipping_state();
+			$shipping_postcode   = $customer->get_shipping_postcode();
+			$shipping_country    = $customer->get_shipping_country();
+		} else {
+			// Fallback to billing in case no shipping methods are set. The address returned from PayPal
+			// will be stored in the order as billing.
+			$shipping_first_name = $old_wc ? ''                         : $customer->get_billing_first_name();
+			$shipping_last_name  = $old_wc ? ''                         : $customer->get_billing_last_name();
+			$shipping_address_1  = $old_wc ? $customer->get_address()   : $customer->get_billing_address_1();
+			$shipping_address_2  = $old_wc ? $customer->get_address_2() : $customer->get_billing_address_2();
+			$shipping_city       = $old_wc ? $customer->get_city()      : $customer->get_billing_city();
+			$shipping_state      = $old_wc ? $customer->get_state()     : $customer->get_billing_state();
+			$shipping_postcode   = $old_wc ? $customer->get_postcode()  : $customer->get_billing_postcode();
+			$shipping_country    = $old_wc ? $customer->get_country()   : $customer->get_billing_country();
+		}
+
+		$shipping_address->setName( $shipping_first_name . ' ' . $shipping_last_name );
+		$shipping_address->setStreet1( $shipping_address_1 );
+		$shipping_address->setStreet2( $shipping_address_2 );
+		$shipping_address->setCity( $shipping_city );
+		$shipping_address->setState( $shipping_state );
+		$shipping_address->setZip( $shipping_postcode );
+
+		// In case merchant only expects domestic shipping and hides shipping
+		// country, fallback to base country.
+		//
+		// @see https://github.com/woothemes/woocommerce-gateway-paypal-express-checkout/issues/139
+		if ( empty( $shipping_country ) ) {
+			$shipping_country = WC()->countries->get_base_country();
+		}
+		$shipping_address->setCountry( $shipping_country );
+
+		return $shipping_address;
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -739,14 +739,6 @@ class WC_Gateway_PPEC_Client {
 		$shipping_address->setCity( $shipping_city );
 		$shipping_address->setState( $shipping_state );
 		$shipping_address->setZip( $shipping_postcode );
-
-		// In case merchant only expects domestic shipping and hides shipping
-		// country, fallback to base country.
-		//
-		// @see https://github.com/woothemes/woocommerce-gateway-paypal-express-checkout/issues/139
-		if ( empty( $shipping_country ) ) {
-			$shipping_country = WC()->countries->get_base_country();
-		}
 		$shipping_address->setCountry( $shipping_country );
 
 		return $shipping_address;

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 == Changelog ==
 
+= 1.6.4 - 2018-xx-xx =
+* Fix - Billing address from Checkout form not being passed to PayPal via Smart Payment Button.
+
 = 1.6.3 - 2018-08-15 =
 * Fix - Fatal error caused by a fix for Smart Payment Buttons.
 


### PR DESCRIPTION
Partially addresses https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/474
Should address https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/448 as well

If the customer has entered address data, this will be passed to the checkout form on the PayPal side to prefill the billing address fields (e.g. for the guest checkout flow when a credit card button is clicked).

In particular, this corrects the broken experience on the Checkout screen in which the (required) billing address is requested as part of the PayPal flow, without autofilled values – even after having been entered on the store's Checkout screen.

(Open to refactoring away code duplication, in particular [L681-L695](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/17f48123522c5a703ed0e2accd9c41f7103f9a5c/includes/class-wc-gateway-ppec-client.php#L681-L695) and [L736-L750](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/17f48123522c5a703ed0e2accd9c41f7103f9a5c/includes/class-wc-gateway-ppec-client.php#L736-L750).)

To test:
- With "Credit Card" not a hidden funding method in the settings
- And with the cart not empty
- Enter values into the billing address fields on the Checkout screen
- Click a credit card button: <img width="200" alt="screen shot 2018-09-05 at 6 04 11 pm" src="https://user-images.githubusercontent.com/1867547/45128562-acd3e980-b14c-11e8-8049-c0c6c7655013.png">
- Verify that <s>name and</s> address fields are prefilled as previously entered