### PR TITLE
Pre-fill contact information in PayPal Guest Checkout

### DIFF
--- a/includes/class-wc-gateway-ppec-address.php
+++ b/includes/class-wc-gateway-ppec-address.php
@@ -654,7 +654,8 @@ class PayPal_Address {
 			$prefix . 'CITY' => $this->_city,
 			$prefix . 'STATE' => $this->_state,
 			$prefix . 'ZIP' => $this->_zip,
-			$prefix . 'COUNTRYCODE' => $this->_country
+			$prefix . 'COUNTRYCODE' => $this->_country,
+			$prefix . 'PHONENUM' => $this->_phoneNumber,
 		);
 
 		return $params;

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -309,6 +309,10 @@ class WC_Gateway_PPEC_Client {
 			)
 		);
 
+		if ( ! empty( $details['email'] ) ) {
+			$params['EMAIL'] = $details['email'];
+		}
+
 		if ( $args['create_billing_agreement'] ) {
 			$params['L_BILLINGTYPE0']                 = 'MerchantInitiatedBillingSingleAgreement';
 			$params['L_BILLINGAGREEMENTDESCRIPTION0'] = $this->_get_billing_agreement_description();
@@ -698,6 +702,8 @@ class WC_Gateway_PPEC_Client {
 		}
 
 		$details['shipping_address'] = $shipping_address;
+
+		$details['email'] = $old_wc ? $order->billing_email : $order->get_billing_email();
 
 		return $details;
 	}

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -693,6 +693,10 @@ class WC_Gateway_PPEC_Client {
 		}
 		$shipping_address->setCountry( $shipping_country );
 
+		if ( ! $old_wc ) {
+			$shipping_address->setPhoneNumber( $old_wc ? '' : $order->get_billing_phone() );
+		}
+
 		$details['shipping_address'] = $shipping_address;
 
 		return $details;

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -458,6 +458,7 @@ class WC_Gateway_PPEC_Client {
 	 */
 	protected function _get_details_from_cart() {
 		$settings = wc_gateway_ppec()->settings;
+		$old_wc = version_compare( WC_VERSION, '3.0', '<' );
 
 		$decimals      = $settings->get_number_of_decimal_digits();
 		$rounded_total = $this->_get_rounded_total_in_cart();
@@ -468,6 +469,7 @@ class WC_Gateway_PPEC_Client {
 			'order_tax'         => round( WC()->cart->tax_total + WC()->cart->shipping_tax_total, $decimals ),
 			'shipping'          => round( WC()->cart->shipping_total, $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_cart(),
+			'email'             => $old_wc ? '' : WC()->customer->get_billing_email(),
 		);
 
 		return $this->get_details( $details, $discounts, $rounded_total, WC()->cart->total );


### PR DESCRIPTION
The "Contact Information" section of the PayPal checkout flow (when paying by credit card) requires both phone and email. These fields are currently not being pre-filled (with or without Smart Payment Buttons enabled), even though we ask this information on the Checkout screen:

Store | PayPal
-- | --
<img width="455" alt="screen shot 2018-09-05 at 10 35 07 pm" src="https://user-images.githubusercontent.com/1867547/45131959-2542a680-b15d-11e8-8e23-409b7a11b8dd.png"> | <img width="425" alt="screen shot 2018-09-05 at 10 28 24 pm" src="https://user-images.githubusercontent.com/1867547/45131523-499d8380-b15b-11e8-8bd8-5b3cbdcca1ab.png">

The changes so far will work only with Smart Payment Buttons disabled.

TODO once https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/476 is merged:
- [ ] make email pre-filling work with Smart Payment Buttons
- [ ] pass phone number to pre-fill, with Smart Payment Buttons