### PR TITLE
Store checkout form data in customer session, for pre-filling PayPal form

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -161,6 +161,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		}
 
 		if ( empty( $error_messages ) ) {
+			$this->set_customer_data( $_POST );
 			$this->start_checkout();
 		} else {
 			wp_send_json_error( array( 'messages' => $error_messages ) );
@@ -179,6 +180,45 @@ class WC_Gateway_PPEC_Cart_Handler {
 			wp_send_json_success( array( 'token' => WC()->session->paypal->token ) );
 		} catch( PayPal_API_Exception $e ) {
 			wp_send_json_error( array( 'messages' => array( $e->getMessage() ) ) );
+		}
+	}
+
+	/**
+	 * Store checkout form data in customer session.
+	 *
+	 * @since 1.6.4
+	 */
+	protected function set_customer_data( $data ) {
+		$customer = WC()->customer;
+
+		$shipping_prefix = isset( $data['ship_to_different_address'] ) ? 'shipping' : 'billing';
+
+		$customer->set_shipping_address( $data[ $shipping_prefix . '_address_1' ] );
+		$customer->set_shipping_address_2( $data[ $shipping_prefix . '_address_2' ] );
+		$customer->set_shipping_city( $data[ $shipping_prefix . '_city' ] );
+		$customer->set_shipping_state( $data[ $shipping_prefix . '_state' ] );
+		$customer->set_shipping_postcode( $data[ $shipping_prefix . '_postcode' ] );
+		$customer->set_shipping_country( $data[ $shipping_prefix . '_country' ] );
+
+		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+			$customer->set_address( $data['billing_address_1'] );
+			$customer->set_address_2( $data['billing_address_2'] );
+			$customer->set_city( $data['billing_city'] );
+			$customer->set_state( $data['billing_state'] );
+			$customer->set_postcode( $data['billing_postcode'] );
+			$customer->set_country( $data['billing_country'] );
+		} else {
+			$customer->set_shipping_first_name( $data[ $shipping_prefix . '_first_name' ] );
+			$customer->set_shipping_last_name( $data[ $shipping_prefix . '_last_name' ] );
+			$customer->set_billing_first_name( $data['billing_first_name'] );
+			$customer->set_billing_last_name( $data['billing_last_name'] );
+
+			$customer->set_billing_address_1( $data['billing_address_1'] );
+			$customer->set_billing_address_2( $data['billing_address_2'] );
+			$customer->set_billing_city( $data['billing_city'] );
+			$customer->set_billing_state( $data['billing_state'] );
+			$customer->set_billing_postcode( $data['billing_postcode'] );
+			$customer->set_billing_country( $data['billing_country'] );
 		}
 	}
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -191,34 +191,61 @@ class WC_Gateway_PPEC_Cart_Handler {
 	protected function set_customer_data( $data ) {
 		$customer = WC()->customer;
 
-		$shipping_prefix = isset( $data['ship_to_different_address'] ) ? 'shipping' : 'billing';
+		$billing_first_name = empty( $data[ 'billing_first_name' ] ) ? '' : wc_clean( $data[ 'billing_first_name' ] );
+		$billing_last_name  = empty( $data[ 'billing_last_name' ] )  ? '' : wc_clean( $data[ 'billing_last_name' ] );
+		$billing_address_1  = empty( $data[ 'billing_address_1' ] )  ? '' : wc_clean( $data[ 'billing_address_1' ] );
+		$billing_address_2  = empty( $data[ 'billing_address_2' ] )  ? '' : wc_clean( $data[ 'billing_address_2' ] );
+		$billing_city       = empty( $data[ 'billing_city' ] )       ? '' : wc_clean( $data[ 'billing_city' ] );
+		$billing_state      = empty( $data[ 'billing_state' ] )      ? '' : wc_clean( $data[ 'billing_state' ] );
+		$billing_postcode   = empty( $data[ 'billing_postcode' ] )   ? '' : wc_clean( $data[ 'billing_postcode' ] );
+		$billing_country    = empty( $data[ 'billing_country' ] )    ? '' : wc_clean( $data[ 'billing_country' ] );
 
-		$customer->set_shipping_address( $data[ $shipping_prefix . '_address_1' ] );
-		$customer->set_shipping_address_2( $data[ $shipping_prefix . '_address_2' ] );
-		$customer->set_shipping_city( $data[ $shipping_prefix . '_city' ] );
-		$customer->set_shipping_state( $data[ $shipping_prefix . '_state' ] );
-		$customer->set_shipping_postcode( $data[ $shipping_prefix . '_postcode' ] );
-		$customer->set_shipping_country( $data[ $shipping_prefix . '_country' ] );
+		if ( isset( $data['ship_to_different_address'] ) ) {
+			$shipping_first_name = empty( $data[ 'shipping_first_name' ] ) ? '' : wc_clean( $data[ 'shipping_first_name' ] );
+			$shipping_last_name  = empty( $data[ 'shipping_last_name' ] )  ? '' : wc_clean( $data[ 'shipping_last_name' ] );
+			$shipping_address_1  = empty( $data[ 'shipping_address_1' ] )  ? '' : wc_clean( $data[ 'shipping_address_1' ] );
+			$shipping_address_2  = empty( $data[ 'shipping_address_2' ] )  ? '' : wc_clean( $data[ 'shipping_address_2' ] );
+			$shipping_city       = empty( $data[ 'shipping_city' ] )       ? '' : wc_clean( $data[ 'shipping_city' ] );
+			$shipping_state      = empty( $data[ 'shipping_state' ] )      ? '' : wc_clean( $data[ 'shipping_state' ] );
+			$shipping_postcode   = empty( $data[ 'shipping_postcode' ] )   ? '' : wc_clean( $data[ 'shipping_postcode' ] );
+			$shipping_country    = empty( $data[ 'shipping_country' ] )    ? '' : wc_clean( $data[ 'shipping_country' ] );
+		} else {
+			$shipping_first_name = $billing_first_name;
+			$shipping_last_name  = $billing_last_name;
+			$shipping_address_1  = $billing_address_1;
+			$shipping_address_2  = $billing_address_2;
+			$shipping_city       = $billing_city;
+			$shipping_state      = $billing_state;
+			$shipping_postcode   = $billing_postcode;
+			$shipping_country    = $billing_country;
+		}
+
+		$customer->set_shipping_address( $shipping_address_1 );
+		$customer->set_shipping_address_2( $shipping_address_2 );
+		$customer->set_shipping_city( $shipping_city );
+		$customer->set_shipping_state( $shipping_state );
+		$customer->set_shipping_postcode( $shipping_postcode );
+		$customer->set_shipping_country( $shipping_country );
 
 		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			$customer->set_address( $data['billing_address_1'] );
-			$customer->set_address_2( $data['billing_address_2'] );
-			$customer->set_city( $data['billing_city'] );
-			$customer->set_state( $data['billing_state'] );
-			$customer->set_postcode( $data['billing_postcode'] );
-			$customer->set_country( $data['billing_country'] );
+			$customer->set_address( $billing_address_1 );
+			$customer->set_address_2( $billing_address_2 );
+			$customer->set_city( $billing_city );
+			$customer->set_state( $billing_state );
+			$customer->set_postcode( $billing_postcode );
+			$customer->set_country( $billing_country );
 		} else {
-			$customer->set_shipping_first_name( $data[ $shipping_prefix . '_first_name' ] );
-			$customer->set_shipping_last_name( $data[ $shipping_prefix . '_last_name' ] );
-			$customer->set_billing_first_name( $data['billing_first_name'] );
-			$customer->set_billing_last_name( $data['billing_last_name'] );
+			$customer->set_shipping_first_name( $shipping_first_name );
+			$customer->set_shipping_last_name( $shipping_last_name );
+			$customer->set_billing_first_name( $billing_first_name );
+			$customer->set_billing_last_name( $billing_last_name );
 
-			$customer->set_billing_address_1( $data['billing_address_1'] );
-			$customer->set_billing_address_2( $data['billing_address_2'] );
-			$customer->set_billing_city( $data['billing_city'] );
-			$customer->set_billing_state( $data['billing_state'] );
-			$customer->set_billing_postcode( $data['billing_postcode'] );
-			$customer->set_billing_country( $data['billing_country'] );
+			$customer->set_billing_address_1( $billing_address_1 );
+			$customer->set_billing_address_2( $billing_address_2 );
+			$customer->set_billing_city( $billing_city );
+			$customer->set_billing_state( $billing_state );
+			$customer->set_billing_postcode( $billing_postcode );
+			$customer->set_billing_country( $billing_country );
 		}
 	}
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -147,7 +147,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 	}
 
 	/**
-	 * Report validation errors if any, or else proceed with checkout flow.
+	 * Report validation errors if any, or else save form data in session and proceed with checkout flow.
 	 *
 	 * @since 1.6.4
 	 */


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/474 – the "name" part, which was not fixed by https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/476 because the customer name is not updated in the session when the address changes.

This PR shares a commit (https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/482/commits/b82d9c95e9ff9c9c98a3a0c6180fe38a7a486503) with https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/475, which passes checkout form data in the AJAX request. Here, it is used to store the complete customer data in the session.

(Also a prerequisite for https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/477.)

To test:
- With "Credit Card" not a hidden funding method in the settings
- And with the cart not empty
- Enter values into the billing address fields on the Checkout screen
- Click a credit card button: <img width="200" alt="screen shot 2018-09-05 at 6 04 11 pm" src="https://user-images.githubusercontent.com/1867547/45128562-acd3e980-b14c-11e8-8049-c0c6c7655013.png">
- Verify that first and last name fields are pre-filled on the PayPal side as entered on the store

A little more context on how the form is pre-filled: if available, it is actually the shipping address which is used to pre-fill the form, rather than the billing address, because only one address can be sent to PayPal, and it is as "SHIPTO" fields. It is actually used to pre-fill the shipping address (when starting on screens other than Checkout), and pre-filling the billing address seems to be a secondary consequence.