### PR TITLE
Truncate product descriptions to conform to 127-character paypal limit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.6.4 - 2018-xx-xx =
 * Fix - Billing address from Checkout form not being passed to PayPal via Smart Payment Button.
+* Fix - Truncate the line item descriptions to avoid exceeding PayPal character limits.
 
 = 1.6.3 - 2018-08-15 =
 * Fix - Fatal error caused by a fix for Smart Payment Buttons.

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -327,7 +327,7 @@ class WC_Gateway_PPEC_Client {
 			foreach ( $details['items'] as $line_item_key => $values ) {
 				$line_item_params = array(
 					'L_PAYMENTREQUEST_0_NAME' . $count => $values['name'],
-					'L_PAYMENTREQUEST_0_DESC' . $count => ! empty( $values['description'] ) ? strip_tags( $values['description'] ) : '',
+					'L_PAYMENTREQUEST_0_DESC' . $count => ! empty( $values['description'] ) ? substr( strip_tags( $values['description'] ), 0, 127 ) : '',
 					'L_PAYMENTREQUEST_0_QTY' . $count  => $values['quantity'],
 					'L_PAYMENTREQUEST_0_AMT' . $count  => $values['amount'],
 				);

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 = 1.6.4 - 2018-xx-xx =
 * Fix - Billing address from Checkout form not being passed to PayPal via Smart Payment Button.
+* Fix - Truncate the line item descriptions to avoid exceeding PayPal character limits.
 
 = 1.6.3 - 2018-08-15 =
 * Fix - Fatal error caused by a fix for Smart Payment Buttons.


### PR DESCRIPTION
Solves #171 

To test:

1) Create/Edit a product such that it has a description longer than 127 characters. Checkout with PayPal and review logs for a warning message from PayPal:

[L_ERRORCODE0] => 11812
[L_SHORTMESSAGE0] => Invalid Data
[L_LONGMESSAGE0] => The value of Description parameter has been truncated.
[L_SEVERITYCODE0] => Warning

2) Switch to this branch and repeat the test. Your descriptions should be truncated automatically and that warning message should disappear.