### PR TITLE
Only enqueue the checkout and payment buttons scripts when needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ deploy-to-wp-org.sh
 node_modules
 Gruntfile.js
 package.json
+.idea
+*.iml

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -267,7 +267,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		?>
 		<div class="wcppec-checkout-buttons woo_pp_cart_buttons_div">
-			<?php if ( 'yes' === $settings->use_spb ) : ?>
+			<?php if ( 'yes' === $settings->use_spb ) :
+				wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' ); ?>
 			<div id="woo_pp_ec_button_product"></div>
 			<?php else : ?>
 
@@ -303,7 +304,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 				</div>
 			<?php endif; ?>
 
-			<?php if ( 'yes' === $settings->use_spb ) : ?>
+			<?php if ( 'yes' === $settings->use_spb ) :
+				wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' ); ?>
 			<div id="woo_pp_ec_button_cart"></div>
 			<?php else : ?>
 
@@ -336,7 +338,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 		}
 		?>
 
-		<?php if ( 'yes' === $settings->use_spb ) : ?>
+		<?php if ( 'yes' === $settings->use_spb ) :
+			wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' ); ?>
 		<p class="woocommerce-mini-cart__buttons buttons wcppec-cart-widget-spb">
 			<span id="woo_pp_ec_button_mini_cart"></span>
 		</p>
@@ -427,8 +430,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 			);
 
 		} elseif ( 'yes' === $settings->use_spb ) {
-			wp_enqueue_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
-			wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', array( 'jquery', 'paypal-checkout-js' ), wc_gateway_ppec()->version, true );
+			wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
+			wp_register_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', array( 'jquery', 'paypal-checkout-js' ), wc_gateway_ppec()->version, true );
 
 			$data = array(
 				'environment'          => 'sandbox' === $settings->get_environment() ? 'sandbox' : 'production',

--- a/includes/class-wc-gateway-ppec-with-spb-addons.php
+++ b/includes/class-wc-gateway-ppec-with-spb-addons.php
@@ -19,6 +19,7 @@ class WC_Gateway_PPEC_With_SPB_Addons extends WC_Gateway_PPEC_With_PayPal_Addons
 	 * Display PayPal button on the checkout page order review.
 	 */
 	public function display_paypal_button() {
+		wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
 		?>
 		<div id="woo_pp_ec_button_checkout"></div>
 		<?php

--- a/includes/class-wc-gateway-ppec-with-spb.php
+++ b/includes/class-wc-gateway-ppec-with-spb.php
@@ -19,6 +19,7 @@ class WC_Gateway_PPEC_With_SPB extends WC_Gateway_PPEC_With_PayPal {
 	 * Display PayPal button on the checkout page order review.
 	 */
 	public function display_paypal_button() {
+		wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
 		?>
 		<div id="woo_pp_ec_button_checkout"></div>
 		<?php


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/462

I've changed some `wp_enqueue_script()` to `wp_register_script()`, and moved the actual enqueueing of the scripts to the moment the Smart Paypal Button containers are rendered. The result is that the Smart PayPal Buttons will keep working normally, and no extra JS will be included if the buttons aren't rendered.

@dechov I've tried using Storefront, the buttons load correctly in the product page, cart, and checkout. Is there anything that could go wrong? What kind of caching issues did you encounter?