### PR TITLE
Update gateway settings for Canadian english locale

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -25,6 +25,7 @@ class WC_Gateway_PPEC_Settings {
 		'da_DK',
 		'de_DE',
 		'en_AU',
+		'en_CA',
 		'en_GB',
 		'en_US',
 		'es_ES',


### PR DESCRIPTION
Added en_CA locale in order to get the paypal express checkout to use Canada as the default checkout country when wordpress locale is set to en_CA for Canada