### PR TITLE
Fix paying with PayPal on a variable product page

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -73,7 +73,7 @@
 			'nonce':       wc_ppec_generate_cart_context.generate_cart_nonce,
 			'qty':         $( '.quantity .qty' ).val(),
 			'attributes':  $( '.variations_form' ).length ? get_attributes().data : [],
-			'add-to-cart': $( '[name=add-to-cart]' ).val(),
+			'product_id': $( '[name=add-to-cart]' ).val(),
 		};
 
 		$.ajax( {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -70,8 +70,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 		WC()->shipping->reset_shipping();
 		$product = wc_get_product( $post->ID );
 
-		if ( ! empty( $_POST['add-to-cart'] ) ) {
-			$product = wc_get_product( absint( $_POST['add-to-cart'] ) );
+		if ( ! empty( $_POST['product_id'] ) ) {
+			$product = wc_get_product( absint( $_POST['product_id'] ) );
 		}
 
 		/**


### PR DESCRIPTION
Fixes #500

When making any kind of request to the server, WooCommerce runs this code: https://github.com/woocommerce/woocommerce/blob/897af8d20ef24e58164376ef65d980d2759f5956/includes/class-wc-form-handler.php#L706

If there's a GET/POST variable called `add-to-cart`, it will try to add that product to the cart. The request structure is different from what WC Core expects, so for variable products it won't find the required attributes and it will throw [an exception](https://github.com/woocommerce/woocommerce/blob/3.5.1/includes/class-wc-form-handler.php#L869).

For the most part it doesn't matter because the cart contents are cleaned up anyway before PayPal's `wc_ajax_generate_cart` will add the products to the cart correctly. But the exception thrown is persisted, so after coming back from a successful PayPal flow, [this logic](https://github.com/woocommerce/woocommerce/blob/ca08beaa42d396681cfa69c5222807702a77abf1/includes/shortcodes/class-wc-shortcode-checkout.php#L262) will kick in and display an error page.

To fix it, I simply renamed the `add-to-cart` POST parameter to `product_id` so it doesn't clash with that built-in WooCommerce functionality. Should help with performance a bit too.

To test:
* Enable SPB in product pages.
* Go to a variable product page.
* Pick a variation.
* Click the PayPal button.
* Go through the whole PayPal flow (you don't need to actually pay, so no need to use a sandbox account).
* When you're redirected back to the "Checkout - Order review" page, you shouldn't see any errors and you should see the button to confirm the order.