### PR TITLE
Fix using the PayPal smart button on a variable product page, or a product with Addons

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -86,10 +86,8 @@
 			data[ field_pairs[ i ].name ] = field_pairs[ i ].value;
 		}
 
-		if ( ! data[ 'ppec-add-to-cart' ] ) {
-			// If this is a simple product, the "Submit" button has the product ID as "value", we need to include it explicitly
-			data[ 'ppec-add-to-cart' ] = $( '[name=add-to-cart]' ).val();
-		}
+		// If this is a simple product, the "Submit" button has the product ID as "value", we need to include it explicitly
+		data[ 'ppec-add-to-cart' ] = $( '[name=add-to-cart]' ).val();
 
 		$.ajax( {
 			type:    'POST',

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -30,20 +30,34 @@
 			$( '#woo_pp_ec_button_product > *' ).css( 'pointer-events', 'none' );
 		} );
 
+    var variation_valid = true;
+    var fields_valid = true;
+    var update_button = function() {
+        $( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );
+	};
+
+    var validate_form = function() {
+        silent_validation = true;
+        fields_valid = true;
+        form.find( 'select:enabled, input:enabled, textarea:enabled' ).each( function() {
+            fields_valid = fields_valid && this.checkValidity();
+        } );
+        silent_validation = false;
+        update_button();
+    };
+
 	// It's a variations form, button availability should depend on its events
-	var variation_valid = true;
 	if ( $( '.variations_form' ).length ) {
-		$( '#woo_pp_ec_button_product' ).trigger( 'disable' );
 		variation_valid = false;
 
 		$( '.variations_form' )
 		.on( 'show_variation', function( event, form, purchasable ) {
-			$( '#woo_pp_ec_button_product' ).trigger( purchasable ? 'enable' : 'disable' );
 			variation_valid = purchasable;
+            update_button();
 		} )
 		.on( 'hide_variation', function() {
-			$( '#woo_pp_ec_button_product' ).trigger( 'disable' );
 			variation_valid = false;
+            update_button();
 		} );
 	}
 
@@ -55,18 +69,8 @@
 			e.preventDefault();
 		}
 	}, true );
-	form.on( 'change', 'select, input, textarea', function() {
-		if ( ! variation_valid ) {
-			return;
-		}
-		silent_validation = true;
-		var valid = true;
-		form.find( 'select:enabled, input:enabled, textarea:enabled' ).each( function() {
-			valid = valid && this.checkValidity();
-		} );
-		$( '#woo_pp_ec_button_product' ).trigger( valid ? 'enable' : 'disable' );
-		silent_validation = false;
-	} );
+	form.on( 'change', 'select, input, textarea', validate_form );
+	validate_form();
 
 	var get_attributes = function() {
 		var select = $( '.variations_form' ).find( '.variations select' ),

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -38,10 +38,7 @@
 
 	var validate_form = function() {
 		silent_validation = true;
-		fields_valid = true;
-		form.find( 'select:enabled, input:enabled, textarea:enabled' ).each( function() {
-			fields_valid = fields_valid && this.checkValidity();
-		} );
+		fields_valid = form.get( 0 ).checkValidity();
 		silent_validation = false;
 		update_button();
 	};

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -30,21 +30,21 @@
 			$( '#woo_pp_ec_button_product > *' ).css( 'pointer-events', 'none' );
 		} );
 
-    var variation_valid = true;
-    var fields_valid = true;
-    var update_button = function() {
-        $( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );
+	var variation_valid = true;
+	var fields_valid = true;
+	var update_button = function() {
+		$( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );
 	};
 
-    var validate_form = function() {
-        silent_validation = true;
-        fields_valid = true;
-        form.find( 'select:enabled, input:enabled, textarea:enabled' ).each( function() {
-            fields_valid = fields_valid && this.checkValidity();
-        } );
-        silent_validation = false;
-        update_button();
-    };
+	var validate_form = function() {
+		silent_validation = true;
+		fields_valid = true;
+		form.find( 'select:enabled, input:enabled, textarea:enabled' ).each( function() {
+			fields_valid = fields_valid && this.checkValidity();
+		} );
+		silent_validation = false;
+		update_button();
+	};
 
 	// It's a variations form, button availability should depend on its events
 	if ( $( '.variations_form' ).length ) {
@@ -53,11 +53,11 @@
 		$( '.variations_form' )
 		.on( 'show_variation', function( event, form, purchasable ) {
 			variation_valid = purchasable;
-            update_button();
+			update_button();
 		} )
 		.on( 'hide_variation', function() {
 			variation_valid = false;
-            update_button();
+			update_button();
 		} );
 	}
 
@@ -77,14 +77,14 @@
 			'nonce': wc_ppec_generate_cart_context.generate_cart_nonce,
 		};
 
-        var field_pairs = form.serializeArray();
-        for ( var i = 0; i < field_pairs.length; i++ ) {
-        	// Prevent the default WooCommerce PHP form handler from recognizing this as an "add to cart" call
-            if ( 'add-to-cart' === field_pairs[ i ].name ) {
-                field_pairs[ i ].name = 'ppec-add-to-cart';
+		var field_pairs = form.serializeArray();
+		for ( var i = 0; i < field_pairs.length; i++ ) {
+			// Prevent the default WooCommerce PHP form handler from recognizing this as an "add to cart" call
+			if ( 'add-to-cart' === field_pairs[ i ].name ) {
+				field_pairs[ i ].name = 'ppec-add-to-cart';
 			}
 			data[ field_pairs[ i ].name ] = field_pairs[ i ].value;
-        }
+		}
 
 		$.ajax( {
 			type:    'POST',

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -33,8 +33,10 @@
 	// True if the product is simple or the user selected a valid variation. False on variable product without a valid variation selected
 	var variation_valid = true;
 
-	// True if all the fields of the product form are valid. False otherwise
+	// True if all the fields of the product form are valid (such as required fields configured by Product Add-Ons). False otherwise
 	var fields_valid = true;
+
+	var form = $( 'form.cart' );
 
 	var update_button = function() {
 		$( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );
@@ -61,7 +63,6 @@
 	}
 
 	// Disable the button if there are invalid fields in the product page (like required fields from Product Addons)
-	var form = $( 'form.cart' );
 	form.on( 'change', 'select, input, textarea', function() {
 		// Hack: IE11 uses the previous field value for the checkValidity() check if it's called in the onChange handler
 		setTimeout( validate_form, 0 );

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -77,9 +77,9 @@
 			'nonce': wc_ppec_generate_cart_context.generate_cart_nonce,
 		};
 
-        var field_pairs = $( form ).serializeArray();
+        var field_pairs = form.serializeArray();
         for ( var i = 0; i < field_pairs.length; i++ ) {
-        	// Prevent the default WooCommerce PHP form handler to recognize this as an "add to cart" call
+        	// Prevent the default WooCommerce PHP form handler from recognizing this as an "add to cart" call
             if ( 'add-to-cart' === field_pairs[ i ].name ) {
                 field_pairs[ i ].name = 'ppec-add-to-cart';
 			}

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -31,17 +31,42 @@
 		} );
 
 	// It's a variations form, button availability should depend on its events
+	var variation_valid = true;
 	if ( $( '.variations_form' ).length ) {
 		$( '#woo_pp_ec_button_product' ).trigger( 'disable' );
+		variation_valid = false;
 
 		$( '.variations_form' )
 		.on( 'show_variation', function( event, form, purchasable ) {
 			$( '#woo_pp_ec_button_product' ).trigger( purchasable ? 'enable' : 'disable' );
+			variation_valid = purchasable;
 		} )
 		.on( 'hide_variation', function() {
 			$( '#woo_pp_ec_button_product' ).trigger( 'disable' );
+			variation_valid = false;
 		} );
 	}
+
+	// Disable the button if there are invalid fields in the product page (like required fields from Product Addons)
+	var silent_validation;
+	var form = $( 'form.cart' );
+	form.get( 0 ).addEventListener( 'invalid', function( e ) {
+		if ( silent_validation ) {
+			e.preventDefault();
+		}
+	}, true );
+	form.on( 'change', 'select, input, textarea', function() {
+		if ( ! variation_valid ) {
+			return;
+		}
+		silent_validation = true;
+		var valid = true;
+		form.find( 'select:enabled, input:enabled, textarea:enabled' ).each( function() {
+			valid = valid && this.checkValidity();
+		} );
+		$( '#woo_pp_ec_button_product' ).trigger( valid ? 'enable' : 'disable' );
+		silent_validation = false;
+	} );
 
 	var get_attributes = function() {
 		var select = $( '.variations_form' ).find( '.variations select' ),

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -30,8 +30,15 @@
 			$( '#woo_pp_ec_button_product > *' ).css( 'pointer-events', 'none' );
 		} );
 
+	// True if the product is simple or the user selected a valid variation. False on variable product without a valid variation selected
 	var variation_valid = true;
+
+	// True if all the fields of the product form are valid. False otherwise
 	var fields_valid = true;
+
+	// True if there's an automatic form validation being performed (not user-initiated), so the user must not be alerted. False otherwise
+	var silent_validation = false;
+
 	var update_button = function() {
 		$( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );
 	};
@@ -59,7 +66,6 @@
 	}
 
 	// Disable the button if there are invalid fields in the product page (like required fields from Product Addons)
-	var silent_validation;
 	var form = $( 'form.cart' );
 	form.get( 0 ).addEventListener( 'invalid', function( e ) {
 		if ( silent_validation ) {

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -67,11 +67,6 @@
 
 	// Disable the button if there are invalid fields in the product page (like required fields from Product Addons)
 	var form = $( 'form.cart' );
-	form.get( 0 ).addEventListener( 'invalid', function( e ) {
-		if ( silent_validation ) {
-			e.preventDefault();
-		}
-	}, true );
 	form.on( 'change', 'select, input, textarea', function() {
 		// Hack: IE11 uses the previous field value for the checkValidity() check if it's called in the onChange handler
 		setTimeout( validate_form, 0 );

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -45,34 +45,21 @@
 
 	var get_attributes = function() {
 		var select = $( '.variations_form' ).find( '.variations select' ),
-			data   = {},
-			count  = 0,
-			chosen = 0;
+			data   = {};
 
 		select.each( function() {
 			var attribute_name = $( this ).data( 'attribute_name' ) || $( this ).attr( 'name' );
-			var value	  = $( this ).val() || '';
-
-			if ( value.length > 0 ) {
-				chosen++;
-			}
-
-			count++;
-			data[ attribute_name ] = value;
+            data[ attribute_name ] = $( this ).val() || '';
 		} );
 
-		return {
-			'count'      : count,
-			'chosenCount': chosen,
-			'data'       : data
-		};
+		return data;
 	};
 
 	var generate_cart = function( callback ) {
 		var data = {
 			'nonce':       wc_ppec_generate_cart_context.generate_cart_nonce,
 			'qty':         $( '.quantity .qty' ).val(),
-			'attributes':  $( '.variations_form' ).length ? get_attributes().data : [],
+			'attributes':  $( '.variations_form' ).length ? get_attributes() : [],
 			'add-to-cart': $( '[name=add-to-cart]' ).val(),
 		};
 

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -88,6 +88,11 @@
 			'add-to-cart': $( '[name=add-to-cart]' ).val(),
 		};
 
+		// Integrate with Product Addons
+		$( form ).find( '[name^=addon-]:enabled' ).each( function () {
+			data[ $( this ).attr( 'name' ) ] = $( this ).val();
+		} );
+
 		$.ajax( {
 			type:    'POST',
 			data:    data,

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -66,7 +66,10 @@
 			e.preventDefault();
 		}
 	}, true );
-	form.on( 'change', 'select, input, textarea', validate_form );
+	form.on( 'change', 'select, input, textarea', function() {
+		// Hack: IE11 uses the previous field value for the checkValidity() check if it's called in the onChange handler
+		setTimeout( validate_form, 0 );
+	} );
 	validate_form();
 
 	var generate_cart = function( callback ) {

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -87,6 +87,7 @@
 		}
 
 		if ( ! data[ 'ppec-add-to-cart' ] ) {
+			// If this is a simple product, the "Submit" button has the product ID as "value", we need to include it explicitly
 			data[ 'ppec-add-to-cart' ] = $( '[name=add-to-cart]' ).val();
 		}
 

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -72,30 +72,19 @@
 	form.on( 'change', 'select, input, textarea', validate_form );
 	validate_form();
 
-	var get_attributes = function() {
-		var select = $( '.variations_form' ).find( '.variations select' ),
-			data   = {};
-
-		select.each( function() {
-			var attribute_name = $( this ).data( 'attribute_name' ) || $( this ).attr( 'name' );
-            data[ attribute_name ] = $( this ).val() || '';
-		} );
-
-		return data;
-	};
-
 	var generate_cart = function( callback ) {
 		var data = {
-			'nonce':       wc_ppec_generate_cart_context.generate_cart_nonce,
-			'qty':         $( '.quantity .qty' ).val(),
-			'attributes':  $( '.variations_form' ).length ? get_attributes() : [],
-			'add-to-cart': $( '[name=add-to-cart]' ).val(),
+			'nonce': wc_ppec_generate_cart_context.generate_cart_nonce,
 		};
 
-		// Integrate with Product Addons
-		$( form ).find( '[name^=addon-]:enabled' ).each( function () {
-			data[ $( this ).attr( 'name' ) ] = $( this ).val();
-		} );
+        var field_pairs = $( form ).serializeArray();
+        for ( var i = 0; i < field_pairs.length; i++ ) {
+        	// Prevent the default WooCommerce PHP form handler to recognize this as an "add to cart" call
+            if ( 'add-to-cart' === field_pairs[ i ].name ) {
+                field_pairs[ i ].name = 'ppec-add-to-cart';
+			}
+			data[ field_pairs[ i ].name ] = field_pairs[ i ].value;
+        }
 
 		$.ajax( {
 			type:    'POST',

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -36,17 +36,12 @@
 	// True if all the fields of the product form are valid. False otherwise
 	var fields_valid = true;
 
-	// True if there's an automatic form validation being performed (not user-initiated), so the user must not be alerted. False otherwise
-	var silent_validation = false;
-
 	var update_button = function() {
 		$( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );
 	};
 
 	var validate_form = function() {
-		silent_validation = true;
 		fields_valid = form.get( 0 ).checkValidity();
-		silent_validation = false;
 		update_button();
 	};
 

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -86,6 +86,10 @@
 			data[ field_pairs[ i ].name ] = field_pairs[ i ].value;
 		}
 
+		if ( ! data[ 'ppec-add-to-cart' ] ) {
+			data[ 'ppec-add-to-cart' ] = $( '[name=add-to-cart]' ).val();
+		}
+
 		$.ajax( {
 			type:    'POST',
 			data:    data,

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -53,6 +53,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 	/**
 	 * Generates the cart for PayPal Checkout on a product level.
+	 * TODO: Why not let the default "add-to-cart" PHP form handler insert the product into the cart? Investigate.
 	 *
 	 * @since 1.4.0
 	 */
@@ -70,8 +71,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 		WC()->shipping->reset_shipping();
 		$product = wc_get_product( $post->ID );
 
-		if ( ! empty( $_POST['add-to-cart'] ) ) {
-			$product = wc_get_product( absint( $_POST['add-to-cart'] ) );
+		if ( ! empty( $_POST['ppec-add-to-cart'] ) ) {
+			$product = wc_get_product( absint( $_POST['ppec-add-to-cart'] ) );
 		}
 
 		/**
@@ -80,11 +81,11 @@ class WC_Gateway_PPEC_Cart_Handler {
 		 * simple or variable product.
 		 */
 		if ( $product ) {
-			$qty     = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
+			$qty     = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
 			wc_empty_cart();
 
 			if ( $product->is_type( 'variable' ) ) {
-				$attributes = array_map( 'wc_clean', $_POST['attributes'] );
+				$attributes = array_map( 'wc_clean', $_POST );
 
 				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 					$variation_id = $product->get_matching_variation( $attributes );
@@ -93,7 +94,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 					$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 				}
 
-				WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
+				WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id );
 			} else {
 				WC()->cart->add_to_cart( $product->get_id(), $qty );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,10 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 == Changelog ==
 
+= 1.6.6 - 201x-xx-xx =
+* Fix - unable to buy variation from product page
+* Fix - can use PayPal from product page without inputting required fields
+
 = 1.6.5 - 2018-10-31 =
 * Fix - Truncate the line item descriptions to avoid exceeding PayPal character limits.
 * Update - WC 3.5 compatibility.


### PR DESCRIPTION
Fixes #500 
Fixes #467

I've merged both fixes into the same PR because they are very related and the amount of code is still small enough for a single PR.

### Fix for #500 (Unable to buy variation from product page)

This PR includes a more complete version of the fix on https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/506.

When making any kind of request to the server, WooCommerce runs this code: https://github.com/woocommerce/woocommerce/blob/897af8d20ef24e58164376ef65d980d2759f5956/includes/class-wc-form-handler.php#L706

If there's a GET/POST variable called `add-to-cart`, it will try to add that product to the cart. The request structure is different from what WC Core expects, so for variable products it won't find the required attributes and it will throw [an exception](https://github.com/woocommerce/woocommerce/blob/3.5.1/includes/class-wc-form-handler.php#L869).

For the most part it doesn't matter because the cart contents are cleaned up anyway before PayPal's `wc_ajax_generate_cart` will add the products to the cart correctly. But the exception thrown is persisted, so after coming back from a successful PayPal flow, [this logic](https://github.com/woocommerce/woocommerce/blob/ca08beaa42d396681cfa69c5222807702a77abf1/includes/shortcodes/class-wc-shortcode-checkout.php#L262) will kick in and display an error page.

To fix it, I simply renamed the `add-to-cart` POST parameter to `ppec-add-to-cart` so it doesn't clash with that built-in WooCommerce functionality. Should help with performance a bit too.

#### To test:
* Enable SPB in product pages.
* Go to a variable product page.
* Pick a variation.
* Click the PayPal button.
* Go through the whole PayPal flow (you don't need to actually pay, so no need to use a sandbox account).
* When you're redirected back to the "Checkout - Order review" page, you shouldn't see any errors and you should see the button to confirm the order.### Fix for #500 (Unable to buy variation from product page)

### Fix for #467 (can use PayPal from product page without inputting required fields)

Product Addons adds plain HTML5 form fields to the product page. Those fields can have a `required` flag or even more complex validation. The `Add to cart` is a plain `<input type=submit>` button, so in modern browsers ([anything newer than IE10](https://caniuse.com/#feat=constraint-validation)), that validation is run automatically before attempting to submit the form. I've added equivalent logic on JS, checking the validity of every field on the form and disabling the PayPal button if there's any invalid one.

This PR also includes better integration (i.e. not broken) with Product Addons. Product Addons adds some merchant-configurable fields to the product page, and those fields are sent to the server when the item is added to the cart.

The solution here is to preserve the same logic while sending the "generate cart" AJAX request that happens when clicking the PayPal smart button.

#### To test:
* Enable SPB in product pages.
* Install Product Addons, add some optional and/or requried fields to the product you're testing this with.
* Go to the product page.
* Check that, unless you fill all the required fields, the PayPal button will be disabled and unresponsive.
* Go through the whole PayPal flow (you don't need to actually pay, so no need to use a sandbox account).
* When you're redirected back to the "Checkout - Order review" page, you shouldn't see any errors, you should see the button to confirm the order, and you should see on the order summary all the values for the fields you entered.

This solution is not 100% ideal because the behaviour of the PayPal button is not 100% consistent with the `Add to cart` button (the `Add to Cart` button stays enabled but the form will display errors if you click it). But for now I think it's a net improvement.