### PR TITLE
Display PayPal fees under the totals on the order admin page

### DIFF
--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -311,9 +311,8 @@ class WC_Gateway_PPEC_Admin_Handler {
 		$order = wc_get_order( $order_id );
 
 		$old_wc         = version_compare( WC_VERSION, '3.0', '<' );
-		$order_id       = $old_wc ? $order->id : $order->get_id();
 		$payment_method = $old_wc ? $order->payment_method : $order->get_payment_method();
-		$paypal_fee     = $old_wc ? get_post_meta( $order_id, 'PayPal Transaction Fee', true ) : $order->get_meta( 'PayPal Transaction Fee', true );
+		$paypal_fee     = wc_gateway_ppec_get_transaction_fee( $order );
 		$order_currency = $old_wc ? $order->order_currency : $order->get_currency();
 		$order_total    = $old_wc ? $order->order_total : $order->get_total();
 

--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -313,7 +313,7 @@ class WC_Gateway_PPEC_Admin_Handler {
 		$old_wc         = version_compare( WC_VERSION, '3.0', '<' );
 		$order_id       = $old_wc ? $order->id : $order->get_id();
 		$payment_method = $old_wc ? $order->payment_method : $order->get_payment_method();
-		$paypal_fee     = get_post_meta( $order_id, 'PayPal Transaction Fee', true );
+		$paypal_fee     = $old_wc ? get_post_meta( $order_id, 'PayPal Transaction Fee', true ) : $order->get_meta( 'PayPal Transaction Fee', true );
 		$order_currency = $old_wc ? $order->order_currency : $order->get_currency();
 		$order_total    = $old_wc ? $order->order_total : $order->get_total();
 

--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -336,7 +336,7 @@ class WC_Gateway_PPEC_Admin_Handler {
 		</tr>
 		<tr>
 			<td class="label ppec-payout">
-				<?php echo wc_help_tip( __( 'This represents the net total that will be credited to your PayPal account. This may be in the currency that is set in your PayPal account.', 'woocommerce-gateway-paypal-express-checkout' ) ); ?>
+				<?php echo wc_help_tip( __( 'This represents the net total that will be credited to your PayPal account. This may be in a different currency than is set in your PayPal account.', 'woocommerce-gateway-paypal-express-checkout' ) ); ?>
 				<?php esc_html_e( 'PayPal Payout:', 'woocommerce-gateway-paypal-express-checkout' ); ?>
 			</td>
 			<td width="1%"></td>

--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -29,6 +29,8 @@ class WC_Gateway_PPEC_Admin_Handler {
 
 		add_action( 'load-woocommerce_page_wc-settings', array( $this, 'maybe_redirect_to_ppec_settings' ) );
 		add_action( 'load-woocommerce_page_wc-settings', array( $this, 'maybe_reset_api_credentials' ) );
+
+		add_action( 'woocommerce_admin_order_totals_after_total', array( $this, 'display_order_fee_and_payout' ) );
 	}
 
 	public function add_capture_charge_order_action( $actions ) {
@@ -296,5 +298,54 @@ class WC_Gateway_PPEC_Admin_Handler {
 		$settings->save();
 
 		wp_safe_redirect( wc_gateway_ppec()->get_admin_setting_link() );
+	}
+
+	/**
+	 * Displays the PayPal fee and the net total of the transaction without the PayPal charges
+	 *
+	 * @since 1.6.6
+	 *
+	 * @param int $order_id
+	 */
+	public function display_order_fee_and_payout( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		$old_wc         = version_compare( WC_VERSION, '3.0', '<' );
+		$order_id       = $old_wc ? $order->id : $order->get_id();
+		$payment_method = $old_wc ? $order->payment_method : $order->get_payment_method();
+		$paypal_fee     = get_post_meta( $order_id, 'PayPal Transaction Fee', true );
+		$order_currency = $old_wc ? $order->order_currency : $order->get_currency();
+		$order_total    = $old_wc ? $order->order_total : $order->get_total();
+
+		if ( 'ppec_paypal' !== $payment_method || ! is_numeric( $paypal_fee ) ) {
+			return;
+		}
+
+		$net = $order_total - $paypal_fee;
+
+		?>
+
+		<tr>
+			<td class="label ppec-fee">
+				<?php echo wc_help_tip( __( 'This represents the fee PayPal collects for the transaction.', 'woocommerce-gateway-paypal-express-checkout' ) ); ?>
+				<?php esc_html_e( 'PayPal Fee:', 'woocommerce-gateway-paypal-express-checkout' ); ?>
+			</td>
+			<td width="1%"></td>
+			<td class="total">
+				-&nbsp;<?php echo wc_price( $paypal_fee, array( 'currency' => $order_currency ) ); ?>
+			</td>
+		</tr>
+		<tr>
+			<td class="label ppec-payout">
+				<?php echo wc_help_tip( __( 'This represents the net total that will be credited to your PayPal account. This may be in the currency that is set in your PayPal account.', 'woocommerce-gateway-paypal-express-checkout' ) ); ?>
+				<?php esc_html_e( 'PayPal Payout:', 'woocommerce-gateway-paypal-express-checkout' ); ?>
+			</td>
+			<td width="1%"></td>
+			<td class="total">
+				<?php echo wc_price( $net, array( 'currency' => $order_currency ) ); ?>
+			</td>
+		</tr>
+
+		<?php
 	}
 }

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -939,6 +939,9 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		// Handle $payment response
 		if ( 'completed' === strtolower( $payment->payment_status ) ) {
 			$order->payment_complete( $payment->transaction_id );
+			if ( isset( $payment->fee_amount ) ){
+				wc_gateway_ppec_set_transaction_fee( $order, $payment->fee_amount );
+			}
 		} else {
 			if ( 'authorization' === $payment->pending_reason ) {
 				$order->update_status( 'on-hold', __( 'Payment authorized. Change payment status to processing or complete to capture funds.', 'woocommerce-gateway-paypal-express-checkout' ) );

--- a/includes/class-wc-gateway-ppec-ipn-handler.php
+++ b/includes/class-wc-gateway-ppec-ipn-handler.php
@@ -166,9 +166,10 @@ class WC_Gateway_PPEC_IPN_Handler extends WC_Gateway_PPEC_PayPal_Request_Handler
 	 * @param array $posted_data Posted data
 	 */
 	protected function payment_status_completed( $order, $posted_data ) {
-		$order_id = version_compare( WC_VERSION, '3.0', '<' ) ? $order->id : $order->get_id();
+		$old_wc   = version_compare( WC_VERSION, '3.0', '<' );
+		$order_id = $old_wc ? $order->id : $order->get_id();
 
-		if ( $order->has_status( array( 'processing', 'completed' ) ) ) {
+		if ( $order->has_status( array( 'completed' ) ) ) {
 			wc_gateway_ppec_log( 'Aborting, Order #' . $order_id . ' is already complete.' );
 			exit;
 		}
@@ -183,7 +184,12 @@ class WC_Gateway_PPEC_IPN_Handler extends WC_Gateway_PPEC_PayPal_Request_Handler
 			if ( ! empty( $posted_data['mc_fee'] ) ) {
 				// Log paypal transaction fee.
 				$transaction_fee = wc_clean( $posted_data['mc_fee'] );
-				update_post_meta( $order_id, 'PayPal Transaction Fee', $transaction_fee );
+				if ( $old_wc ) {
+					update_post_meta( $order_id, 'PayPal Transaction Fee', $transaction_fee );
+				} else {
+					$order->update_meta_data( 'PayPal Transaction Fee', $transaction_fee );
+					$order->save_meta_data();
+				}
 			}
 		} else {
 			if ( 'authorization' === $posted_data['pending_reason'] ) {
@@ -319,6 +325,10 @@ class WC_Gateway_PPEC_IPN_Handler extends WC_Gateway_PPEC_PayPal_Request_Handler
 					$order->update_meta_data( $meta_key, $value );
 				}
 			}
+		}
+
+		if ( ! $old_wc ) {
+			$order->save_meta_data();
 		}
 
 		if ( ! empty( $posted_data['txn_id'] ) ) {

--- a/includes/class-wc-gateway-ppec-ipn-handler.php
+++ b/includes/class-wc-gateway-ppec-ipn-handler.php
@@ -183,13 +183,7 @@ class WC_Gateway_PPEC_IPN_Handler extends WC_Gateway_PPEC_PayPal_Request_Handler
 			$this->payment_complete( $order, ( ! empty( $posted_data['txn_id'] ) ? wc_clean( $posted_data['txn_id'] ) : '' ), __( 'IPN payment completed', 'woocommerce-gateway-paypal-express-checkout' ) );
 			if ( ! empty( $posted_data['mc_fee'] ) ) {
 				// Log paypal transaction fee.
-				$transaction_fee = wc_clean( $posted_data['mc_fee'] );
-				if ( $old_wc ) {
-					update_post_meta( $order_id, 'PayPal Transaction Fee', $transaction_fee );
-				} else {
-					$order->update_meta_data( 'PayPal Transaction Fee', $transaction_fee );
-					$order->save_meta_data();
-				}
+				wc_gateway_ppec_set_transaction_fee( $order, $posted_data['mc_fee'] );
 			}
 		} else {
 			if ( 'authorization' === $posted_data['pending_reason'] ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -90,3 +90,26 @@ function wc_gateway_ppec_is_credit_supported() {
 function wc_gateway_ppec_is_using_credit() {
 	return ! empty( $_GET['use-ppc'] ) && 'true' === $_GET['use-ppc'];
 }
+
+const PPEC_FEE_META_NAME  = 'PayPal Transaction Fee';
+
+function wc_gateway_ppec_set_transaction_fee( $order, $fee ) {
+	if ( empty( $fee ) ) {
+		return;
+	}
+	$fee = wc_clean( $fee );
+	if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		update_post_meta( $order->id, PPEC_FEE_META_NAME, $fee );
+	} else {
+		$order->update_meta_data( PPEC_FEE_META_NAME, $fee );
+		$order->save_meta_data();
+	}
+}
+
+function wc_gateway_ppec_get_transaction_fee( $order ) {
+	if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		return get_post_meta( $order->id, PPEC_FEE_META_NAME, true );
+	} else {
+		return $order->get_meta( PPEC_FEE_META_NAME, true );
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -91,25 +91,66 @@ function wc_gateway_ppec_is_using_credit() {
 	return ! empty( $_GET['use-ppc'] ) && 'true' === $_GET['use-ppc'];
 }
 
-const PPEC_FEE_META_NAME  = 'PayPal Transaction Fee';
+const PPEC_FEE_META_NAME_OLD = 'PayPal Transaction Fee';
+const PPEC_FEE_META_NAME_NEW = '_paypal_transaction_fee';
 
+/**
+ * Sets the PayPal Fee in the order metadata
+ *
+ * @since 1.6.6
+ *
+ * @param object $order Order to modify
+ * @param string $fee Fee to save
+ */
 function wc_gateway_ppec_set_transaction_fee( $order, $fee ) {
 	if ( empty( $fee ) ) {
 		return;
 	}
 	$fee = wc_clean( $fee );
 	if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-		update_post_meta( $order->id, PPEC_FEE_META_NAME, $fee );
+		update_post_meta( $order->id, PPEC_FEE_META_NAME_NEW, $fee );
 	} else {
-		$order->update_meta_data( PPEC_FEE_META_NAME, $fee );
+		$order->update_meta_data( PPEC_FEE_META_NAME_NEW, $fee );
 		$order->save_meta_data();
 	}
 }
 
+/**
+ * Gets the PayPal Fee from the order metadata, migrates if the fee was saved under a legacy key
+ *
+ * @since 1.6.6
+ *
+ * @param object $order Order to read
+ * @return string Returns the fee or an empty string if the fee has not been set on the order
+ */
 function wc_gateway_ppec_get_transaction_fee( $order ) {
-	if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-		return get_post_meta( $order->id, PPEC_FEE_META_NAME, true );
+	$old_wc = version_compare( WC_VERSION, '3.0', '<' );
+
+	//retrieve the fee using the new key
+	if ( $old_wc ) {
+		$fee = get_post_meta( $order->id, PPEC_FEE_META_NAME_NEW, true );
 	} else {
-		return $order->get_meta( PPEC_FEE_META_NAME, true );
+		$fee = $order->get_meta( PPEC_FEE_META_NAME_NEW, true );
 	}
+
+	//if the fee was found, return
+	if ( is_numeric( $fee ) ) {
+		return $fee;
+	}
+
+	//attempt to retrieve the old meta, delete its old key, and migrate it to the new one
+	if ( $old_wc ) {
+		$fee = get_post_meta( $order->id, PPEC_FEE_META_NAME_OLD, true );
+		delete_post_meta( $order->id, PPEC_FEE_META_NAME_OLD );
+	} else {
+		$fee = $order->get_meta( PPEC_FEE_META_NAME_OLD, true );
+		$order->delete_meta_data( PPEC_FEE_META_NAME_OLD );
+		$order->save_meta_data();
+	}
+
+	if ( is_numeric( $fee ) ) {
+		wc_gateway_ppec_set_transaction_fee( $order, $fee );
+	}
+
+	return $fee;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 == Changelog ==
 
+= 1.6.6 - 201x-xx-xx =
+* Add - display PayPal fees under the totals on the order admin page
+
 = 1.6.5 - 2018-10-31 =
 * Fix - Truncate the line item descriptions to avoid exceeding PayPal character limits.
 * Update - WC 3.5 compatibility.


### PR DESCRIPTION
Fixes #504 

<img width="302" alt="screen shot 2018-12-06 at 14 17 03" src="https://user-images.githubusercontent.com/800604/49589666-de359e80-f961-11e8-84a3-0da0757bfc12.png">

Test steps:
* if you're using a local site, make sure you're running ngrok
* purchase an item and pay using the PPEC
* log into the merchant dashboard on PayPal and accept the payment - paypal should sand an update to your site containing the fees
* open the order in wp-admin and verify that the fees appear