### PR TITLE
Fix Error 10413 when using coupons

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.6.7 - 2019-XX-XX =
+* Fix - Error 10413 when using coupons
+
 = 1.6.6 - 2019-01-09 =
 * Fix - Discount items were not being included
 * Add - Filter for order details to accept decimal quantities of products

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -577,7 +577,7 @@ class WC_Gateway_PPEC_Client {
 		if ( $details['total_item_amount'] == $discounts ) {
 			// Omit line items altogether.
 			unset( $details['items'] );
-		} else if ( $discounts > 0 && $discounts < $details['total_item_amount'] ) {
+		} else if ( $discounts > 0 && $discounts < $details['total_item_amount'] && ! empty( $details['items'] ) ) {
 			// Else if there is discount, add them to the line-items
 			$details['items'][] = $this->_get_extra_discount_line_item($discounts);
 		}
@@ -626,13 +626,13 @@ class WC_Gateway_PPEC_Client {
 
 		/**
 		 * Filter PayPal order details.
-		 * 
+		 *
 		 * Provide opportunity for developers to modify details passed to PayPal.
 		 * This was originally introduced to add a mechanism to allow for
 		 * decimal product quantity support.
-		 * 
+		 *
 		 * @since 1.6.6
-		 * 
+		 *
 		 * @param array $details Current PayPal order details
 		 */
 		return apply_filters( 'woocommerce_paypal_express_checkout_get_details', $details );

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 == Changelog ==
 
+= 1.6.7 - 2019-xx-xx =
+* Fix - Error 10413 when using coupons
+
 = 1.6.6 - 2019-01-09 =
 * Fix - Discount items were not being included
 * Add - Filter for order details to accept decimal quantities of products


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/517
This bug was fixed in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/341, but it re-appeared in `1.6.6`. This PR fixes the `Error 10413` bug and also keeps the separate "Discount" lines in the PayPal flow.

I'm not sure how to test this since I haven't managed to reproduce it locally. It seems to be related with differences in precision when handling lots of numbers with decimals in the same order (shipping price, taxes, discount coupon, item price...). At the end, somehow the sum of all the parts is different than the total so PayPal fails.

@zanza321 @beehavendesignz I would prefer to be able to reproduce this error at least once before releasing the fix. I'm confident this won't break things more but we shouldn't just update the plugin without being sure that it works as intended. If you could tell us this information for the orders that failed, it would be extremely helpful:
- What option do you have in the `Subtotal Mismatch Behavior` setting of PayPal Checkout?
- Currency
- Product price
- Coupon price (or %). What kind of discount is it? Per-product, or per-cart?
- Shipping price for that order
- Tax amount for that order