### PR TITLE
Always load the spb JS file, but only load the huge checkout.js file when needed

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -144,19 +144,16 @@
 		}, selector );
 	};
 
-	var already_loading_script = false;
-	var renderWithLazyLoad = function( isMiniCart ) {
-		var onSuccess = render.bind( null, isMiniCart );
-		if ( already_loading_script ) {
-			onSuccess();
+	var load_script_task = null;
+	var renderWithLazyLoad = function ( isMiniCart ) {
+		if ( ! load_script_task ) {
+			load_script_task = $.ajax( {
+				url: 'https://www.paypalobjects.com/api/checkout.js',
+				dataType: 'script',
+				cache: true,
+			} );
 		}
-		already_loading_script = true;
-		$.ajax( {
-			url: 'https://www.paypalobjects.com/api/checkout.js',
-			dataType: 'script',
-			cache: true,
-			success: onSuccess,
-		} );
+		load_script_task.done( render.bind( null, isMiniCart ) );
 	};
 
 	// Render cart, single product, or checkout buttons.

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -144,10 +144,25 @@
 		}, selector );
 	};
 
+	var already_loading_script = false;
+	var renderWithLazyLoad = function( isMiniCart ) {
+		var onSuccess = render.bind( null, isMiniCart );
+		if ( already_loading_script ) {
+			onSuccess();
+		}
+		already_loading_script = true;
+		$.ajax( {
+			url: 'https://www.paypalobjects.com/api/checkout.js',
+			dataType: 'script',
+			cache: true,
+			success: onSuccess,
+		} );
+	};
+
 	// Render cart, single product, or checkout buttons.
 	if ( wc_ppec_context.page ) {
-		render();
-		$( document.body ).on( 'updated_cart_totals updated_checkout', render.bind( this, false ) );
+		renderWithLazyLoad();
+		$( document.body ).on( 'updated_cart_totals updated_checkout', renderWithLazyLoad.bind( this, false ) );
 	}
 
 	// Render buttons in mini-cart if present.
@@ -156,7 +171,7 @@
 		if ( $button.length ) {
 			// Clear any existing button in container, and render.
 			$button.empty();
-			render( true );
+			renderWithLazyLoad( true );
 		}
 	} );
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -279,8 +279,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		?>
 		<div class="wcppec-checkout-buttons woo_pp_cart_buttons_div">
-			<?php if ( 'yes' === $settings->use_spb ) :
-				wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' ); ?>
+			<?php if ( 'yes' === $settings->use_spb ) : ?>
 			<div id="woo_pp_ec_button_product"></div>
 			<?php else : ?>
 
@@ -316,8 +315,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				</div>
 			<?php endif; ?>
 
-			<?php if ( 'yes' === $settings->use_spb ) :
-				wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' ); ?>
+			<?php if ( 'yes' === $settings->use_spb ) : ?>
 			<div id="woo_pp_ec_button_cart"></div>
 			<?php else : ?>
 
@@ -350,8 +348,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		}
 		?>
 
-		<?php if ( 'yes' === $settings->use_spb ) :
-			wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' ); ?>
+		<?php if ( 'yes' === $settings->use_spb ) : ?>
 		<p class="woocommerce-mini-cart__buttons buttons wcppec-cart-widget-spb">
 			<span id="woo_pp_ec_button_mini_cart"></span>
 		</p>
@@ -427,8 +424,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		$page        = $is_cart ? 'cart' : ( $is_product ? 'product' : ( $is_checkout ? 'checkout' : null ) );
 
 		if ( 'yes' !== $settings->use_spb && $is_cart ) {
-			wp_enqueue_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
-			wp_enqueue_script( 'wc-gateway-ppec-frontend-in-context-checkout', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-frontend-in-context-checkout.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
+		    wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
 			wp_localize_script( 'wc-gateway-ppec-frontend-in-context-checkout', 'wc_ppec_context',
 				array(
 					'payer_id'    => $client->get_payer_id(),
@@ -442,8 +438,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 			);
 
 		} elseif ( 'yes' === $settings->use_spb ) {
-			wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
-			wp_register_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', array( 'jquery', 'paypal-checkout-js' ), wc_gateway_ppec()->version, true );
+			wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
 
 			$data = array(
 				'environment'          => 'sandbox' === $settings->get_environment() ? 'sandbox' : 'production',

--- a/includes/class-wc-gateway-ppec-with-spb-addons.php
+++ b/includes/class-wc-gateway-ppec-with-spb-addons.php
@@ -19,7 +19,6 @@ class WC_Gateway_PPEC_With_SPB_Addons extends WC_Gateway_PPEC_With_PayPal_Addons
 	 * Display PayPal button on the checkout page order review.
 	 */
 	public function display_paypal_button() {
-		wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
 		?>
 		<div id="woo_pp_ec_button_checkout"></div>
 		<?php
@@ -51,7 +50,7 @@ class WC_Gateway_PPEC_With_SPB_Addons extends WC_Gateway_PPEC_With_PayPal_Addons
 			$session->checkout_completed = true;
 			$session->payer_id           = $_POST['payerID'];
 			$session->token              = $_POST['paymentToken'];
-	
+
 			WC()->session->set( 'paypal', $session );
 		}
 

--- a/includes/class-wc-gateway-ppec-with-spb.php
+++ b/includes/class-wc-gateway-ppec-with-spb.php
@@ -19,7 +19,6 @@ class WC_Gateway_PPEC_With_SPB extends WC_Gateway_PPEC_With_PayPal {
 	 * Display PayPal button on the checkout page order review.
 	 */
 	public function display_paypal_button() {
-		wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
 		?>
 		<div id="woo_pp_ec_button_checkout"></div>
 		<?php
@@ -51,7 +50,7 @@ class WC_Gateway_PPEC_With_SPB extends WC_Gateway_PPEC_With_PayPal {
 			$session->checkout_completed = true;
 			$session->payer_id           = $_POST['payerID'];
 			$session->token              = $_POST['paymentToken'];
-	
+
 			WC()->session->set( 'paypal', $session );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/493#issuecomment-452268356

After landing https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/491, PayPal SPB buttons stopped rendering in the mini-cart.

The problem is that the mini-cart HTML is cached in localStorage in the client, so the code that renders it in the server doesn't always run, so we can't rely on it for enqueuing the PayPal JS files.

I've implemented 2 alternative solutions, this one and #521. Please chime in on which one you prefer.

In this PR, I reverted the changes in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/491 (so that means that the `wc-gateway-ppec-smart-payment-buttons.js` is loaded on every page, but it's small enough), and as a compromise I made the **huge** `checkout.js` file load only when needed.

To test:
* Make sure that the Simple Payment Buttons load on the checkout, cart, product pages, and any page with the mini-cart.
* Check that our code only loads the `checkout.js` file once per page load.