### PR TITLE
Render the PayPal buttons in the mini cart

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -28,6 +28,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		} else {
 			add_action( 'woocommerce_widget_shopping_cart_buttons', array( $this, 'display_mini_paypal_button' ), 20 );
 		}
+		add_action( 'widget_title', array( $this, 'maybe_enqueue_checkout_js' ), 10, 3 );
 
 		if ( 'yes' === wc_gateway_ppec()->settings->checkout_on_single_product_enabled ) {
 			add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'display_paypal_button_product' ), 1 );
@@ -350,8 +351,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		}
 		?>
 
-		<?php if ( 'yes' === $settings->use_spb ) :
-			wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' ); ?>
+		<?php if ( 'yes' === $settings->use_spb ) : ?>
 		<p class="woocommerce-mini-cart__buttons buttons wcppec-cart-widget-spb">
 			<span id="woo_pp_ec_button_mini_cart"></span>
 		</p>
@@ -363,6 +363,17 @@ class WC_Gateway_PPEC_Cart_Handler {
 		<?php endif; ?>
 		<?php
 	}
+
+	public function maybe_enqueue_checkout_js( $widget_title, $widget_instance, $widget_id ) {
+		if ( 'woocommerce_widget_cart' === $widget_id ) {
+			$gateways = WC()->payment_gateways->get_available_payment_gateways();
+			$settings = wc_gateway_ppec()->settings;
+			if ( isset( $gateways['ppec_paypal'] ) && 'yes' === $settings->cart_checkout_enabled && 'yes' === $settings->use_spb ) {
+				wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
+			}
+        }
+		return $widget_title;
+    }
 
 	/**
 	 * Convert from settings to values expected by PayPal Button API:


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/493#issuecomment-452268356

After landing https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/491, PayPal SPB buttons stopped rendering in the mini-cart.

The problem is that the mini-cart HTML is cached in localStorage in the client, so the code that renders it in the server doesn't always run, so we can't rely on it for enqueuing the PayPal JS files.

I've implemented 2 alternative solutions, this one and #520. Please chime in on which one you prefer.

In this PR, I made sure that the `wc-gateway-ppec-smart-payment-buttons` JS script is loaded whenever the mini-cart widget is rendered, by hooking into the `widget_title` hook.

To test:
* Make sure that the Simple Payment Buttons load on the checkout, cart, product pages, and any page with the mini-cart.