### PR TITLE
Keep variation attributes when they are added to the cart

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -94,7 +94,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 					$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 				}
 
-				WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id );
+				WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
 			} else {
 				WC()->cart->add_to_cart( $product->get_id(), $qty );
 			}


### PR DESCRIPTION
## Proposed changes

Include `$attributes` in the `add_to_cart` call within `WC_Gateway_PPEC_Cart_Handler::wc_ajax_generate_cart()`. This way variations with "Any" attribute will work correctly.

## Testing instructions

1. Create a variable clothing product.
2. Add attributes for both color and size.
3. Add individual variations for every size but without specifying colors.
4. Open the product page, select variations and click the PayPal button. Completing the payment is not required.
5. Navigate to the cart and verify that the selected color is actually added to the cart, instead of just the size.

Fixes #522