### PR TITLE
Guard against themes applying filter with too few params

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -364,7 +364,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		<?php
 	}
 
-	public function maybe_enqueue_checkout_js( $widget_title, $widget_instance, $widget_id ) {
+	public function maybe_enqueue_checkout_js( $widget_title, $widget_instance = array(), $widget_id = null ) {
 		if ( 'woocommerce_widget_cart' === $widget_id ) {
 			$gateways = WC()->payment_gateways->get_available_payment_gateways();
 			$settings = wc_gateway_ppec()->settings;


### PR DESCRIPTION
Certain themes are applying the `widget_title` filter with fewer than the 3 params [documented](https://developer.wordpress.org/reference/hooks/widget_title/), causing PHP errors and warnings with the 1.6.7 release. This change adds default parameters to prevent this issue.

Can test by adding `apply_filters( 'widget_title', 'Widget Title' );` to your theme's `functions.php` file.

Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/524 and addresses issues in https://wordpress.org/support/topic/string-of-new-php-errors-with-version-1-6-7/