### PR TITLE
Avoid SPB render error by tweaking 'allowed' funding methods' empty value

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -38,7 +38,7 @@
 	// Map funding method settings to enumerated options provided by PayPal.
 	var getFundingMethods = function( methods ) {
 		if ( ! methods ) {
-			return null;
+			return undefined;
 		}
 
 		var paypal_funding_methods = [];


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/527

A change in a recent release of PayPal's checkout.js is incompatible with the `null` value we were passing to `paypal.Button.render` for the `allowed` funding methods, breaking the rendering of the buttons. Passing `undefined` as an alternative works fine.

Can test by loading the Cart page with Smart Payment Buttons and vertical layout enabled: in this branch the buttons should render normally, while in `master` there should be no buttons and a browser console error.

_Edit:_ behavior can also be confirmed on PayPal Checkout's [demo page](https://developer.paypal.com/demo/checkout/#/pattern/vertical): `allowed: null` doesn't work, but `allowed: undefined` does.

This change brings the render call closer in line with not including the unneeded property at all (i.e. only `disallowed` is supported for vertical layout) – it is a minimal fix to solve the urgent issue.