### PR TITLE
Add CURRENCYCODE do capture_payment

### DIFF
--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -162,6 +162,7 @@ class WC_Gateway_PPEC_Admin_Handler {
 
 				$params['AUTHORIZATIONID'] = $trans_id;
 				$params['AMT'] = floatval( $order_total );
+				$params['CURRENCYCODE'] = get_woocommerce_currency();
 				$params['COMPLETETYPE'] = 'Complete';
 
 				$result = wc_gateway_ppec()->client->do_express_checkout_capture( $params );

--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -162,7 +162,7 @@ class WC_Gateway_PPEC_Admin_Handler {
 
 				$params['AUTHORIZATIONID'] = $trans_id;
 				$params['AMT'] = floatval( $order_total );
-				$params['CURRENCYCODE'] = get_woocommerce_currency();
+				$params['CURRENCYCODE'] = $old_wc ? $order->order_currency : $order->get_currency();
 				$params['COMPLETETYPE'] = 'Complete';
 
 				$result = wc_gateway_ppec()->client->do_express_checkout_capture( $params );


### PR DESCRIPTION
The missing CURRENCYCODE in capture_payment cause a error after payment authorization has been accepted:
WC_Gateway_PPEC_Client::_process_response: acknowleged response body: Array
(
    [AUTHORIZATIONID] => 2YC66033TH9230743
    [TIMESTAMP] => 2019-02-07T11:41:21Z
    [CORRELATIONID] => 31a70f4754928
    [ACK] => Failure
    [VERSION] => 120.0
    [BUILD] => 000000
    [L_ERRORCODE0] => 10613
    [L_SHORTMESSAGE0] => Currency mismatch.
    [L_LONGMESSAGE0] => Currency of capture must be the same as currency of authorization.
    [L_SEVERITYCODE0] => Error
)

Adding the CURRENCYCODE to params fix the problem.