### PR TITLE
Use only product attributes when adding to cart

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -72,14 +72,24 @@
 	var generate_cart = function( callback ) {
 		var data = {
 			'nonce': wc_ppec_generate_cart_context.generate_cart_nonce,
+			'attributes': {},
 		};
 
 		var field_pairs = form.serializeArray();
+
 		for ( var i = 0; i < field_pairs.length; i++ ) {
 			// Prevent the default WooCommerce PHP form handler from recognizing this as an "add to cart" call
 			if ( 'add-to-cart' === field_pairs[ i ].name ) {
 				field_pairs[ i ].name = 'ppec-add-to-cart';
 			}
+
+			// Save attributes as a separate prop in `data` object,
+			// so that `attributes` can be used later on when adding a variable product to cart
+			if ( -1 !== field_pairs[ i ].name.indexOf( 'attribute_' ) ) {
+				data.attributes[ field_pairs[ i ].name ] = field_pairs[ i ].value;
+				continue;
+			}
+
 			data[ field_pairs[ i ].name ] = field_pairs[ i ].value;
 		}
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -86,7 +86,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 			wc_empty_cart();
 
 			if ( $product->is_type( 'variable' ) ) {
-				$attributes = array_map( 'wc_clean', $_POST );
+				$attributes = array_map( 'wc_clean', $_POST['attributes'] );
+
 
 				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 					$variation_id = $product->get_matching_variation( $attributes );


### PR DESCRIPTION
Fixes #534

The changes in this PR also do not regress the fix for #522, fixed originally in #523.

# Steps to repro the original problem:
1. Create a product with attributes
2. Go to the single product page, select some attributes
3. Use the 'buy now' button
4. See that the nonce and all other form fields are exposed during and after making the purchase.

What the customer sees during and after the purchas:

<img width="375" alt="during-bunch-of-props" src="https://user-images.githubusercontent.com/11487924/53306941-3e512800-3861-11e9-9240-2675b5aab1e8.png">

What the store owner sees:

<img width="887" alt="after-purchase-bunch-of-extra-info" src="https://user-images.githubusercontent.com/11487924/53306942-414c1880-3861-11e9-9d74-845ddba5ec12.png">

# Description of changes

What was happening is that we were sending multiple unwanted properties as attributes in the 4th argument to `add_to_cart` call in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/471370c66cd9893120e7572483ae3473ccc9beed/includes/class-wc-gateway-ppec-cart-handler.php#L98

The `$attributes` variable seen there looked like this for a product with attributes:

```
Array (
    [nonce] => 413e2698ad
    [attribute_colour] => gold
    [attribute_size] => small
    [quantity] => 1
    [ppec-add-to-cart] => 61
    [product_id] => 61
    [variation_id] => 74
)
```

Now, it looks like this:

```
Array (
    [nonce] => 413e2698ad
    [attributes] => Array
    (
        [attribute_colour] => gold
        [attribute_size] => small
    )
    [quantity] => 1
    [ppec-add-to-cart] => 61
    [product_id] => 61
    [variation_id] => 74
)
```

Moving the attributes to their own array is done in the JS.

With this data from `$_POST`, we define `$attributes` as only the relevant part `$_POST['attributes']`. This is similar to what we did before PR #507.

# Steps to test:
- Purchase a product with add ons using the 'buy now' button on a single product page
- Purchase a product with attributes using the 'buy now' button on a single product page
- Purchase a product with attributes that don't have a variation ID per attribute combination using the 'buy now' button on a single product page as described in #522
- Purchase addon products and products with attributes using PayPal in normal checkout/cart