### PR TITLE
Check for option before attempting to delete it when bootstrapping.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.6.11 - 2019-03-19 =
+* Tweak - Stop querying on every request when bootstrapping the plugin and ensure certain options are only set on admin
+
 = 1.6.10 - 2019-03-05 =
 * Fix - Use only product attributes when adding to cart
 

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -161,12 +161,15 @@ class WC_Gateway_PPEC_Plugin {
 			$this->_check_credentials();
 
 			$this->_bootstrapped = true;
-			if ( false !== get_option( 'wc_gateway_ppce_bootstrap_warning_message' ) ) {
-				delete_option( 'wc_gateway_ppce_bootstrap_warning_message' );
-			}
 
-			if ( false !== get_option( 'wc_gateway_ppce_prompt_to_connect' ) ) {
-				delete_option( 'wc_gateway_ppce_prompt_to_connect' );
+			if ( is_admin() ) {
+				if ( false !== get_option( 'wc_gateway_ppce_bootstrap_warning_message' ) ) {
+					delete_option( 'wc_gateway_ppce_bootstrap_warning_message');
+				}
+
+				if ( false !== get_option( 'wc_gateway_ppce_prompt_to_connect' ) ) {
+					delete_option( 'wc_gateway_ppce_prompt_to_connect' );
+				}
 			}
 		} catch ( Exception $e ) {
 			if ( in_array( $e->getCode(), array( self::ALREADY_BOOTSTRAPED, self::DEPENDENCIES_UNSATISFIED ) ) ) {

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -161,8 +161,13 @@ class WC_Gateway_PPEC_Plugin {
 			$this->_check_credentials();
 
 			$this->_bootstrapped = true;
-			delete_option( 'wc_gateway_ppce_bootstrap_warning_message' );
-			delete_option( 'wc_gateway_ppce_prompt_to_connect' );
+			if ( false !== get_option( 'wc_gateway_ppce_bootstrap_warning_message' ) ) {
+				delete_option( 'wc_gateway_ppce_bootstrap_warning_message' );
+			}
+
+			if ( false !== get_option( 'wc_gateway_ppce_prompt_to_connect' ) ) {
+				delete_option( 'wc_gateway_ppce_prompt_to_connect' );
+			}
 		} catch ( Exception $e ) {
 			if ( in_array( $e->getCode(), array( self::ALREADY_BOOTSTRAPED, self::DEPENDENCIES_UNSATISFIED ) ) ) {
 				update_option( 'wc_gateway_ppce_bootstrap_warning_message', $e->getMessage() );


### PR DESCRIPTION
Check the options at bootstrap time before deleting them. As
get_option() is cached it can provide a small performance boost, or at
least can protect against a query occurring per request un-necessarily.