### PR TITLE
Fixed plugin bootstrap invalidates options cache on every page view.

### DIFF
--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -161,8 +161,12 @@ class WC_Gateway_PPEC_Plugin {
 			$this->_check_credentials();
 
 			$this->_bootstrapped = true;
-			delete_option( 'wc_gateway_ppce_bootstrap_warning_message' );
-			delete_option( 'wc_gateway_ppce_prompt_to_connect' );
+			if ( NULL !== get_option( 'wc_gateway_ppce_bootstrap_warning_message', NULL ) ) {
+				delete_option( 'wc_gateway_ppce_bootstrap_warning_message' );
+			}
+			if ( NULL !== get_option( 'wc_gateway_ppce_prompt_to_connect', NULL ) ) {
+				delete_option( 'wc_gateway_ppce_prompt_to_connect' );
+			}
 		} catch ( Exception $e ) {
 			if ( in_array( $e->getCode(), array( self::ALREADY_BOOTSTRAPED, self::DEPENDENCIES_UNSATISFIED ) ) ) {
 				update_option( 'wc_gateway_ppce_bootstrap_warning_message', $e->getMessage() );


### PR DESCRIPTION
Problem
* The plugin woocommerce-gateway-paypal-express-checkout unconditionally deletes options on every page view, which causes the whole options cache of all autoload options to be regenerated on every page view.

Proposed solution
1. Only delete the options if they exist.
