### PR TITLE
Remove option writes during bootstrap

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.6.11 - 2019-xx-xx =
+* Fix/Performance - Prevent db option updates during bootstrap on each page load
+
 = 1.6.10 - 2019-03-05 =
 * Fix - Use only product attributes when adding to cart
 

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -161,15 +161,13 @@ class WC_Gateway_PPEC_Plugin {
 			$this->_check_credentials();
 
 			$this->_bootstrapped = true;
-			delete_option( 'wc_gateway_ppce_bootstrap_warning_message' );
-			delete_option( 'wc_gateway_ppce_prompt_to_connect' );
 		} catch ( Exception $e ) {
 			if ( in_array( $e->getCode(), array( self::ALREADY_BOOTSTRAPED, self::DEPENDENCIES_UNSATISFIED ) ) ) {
-				update_option( 'wc_gateway_ppce_bootstrap_warning_message', $e->getMessage() );
+				$this->bootstrap_warning_message = $e->getMessage();
 			}
 
 			if ( self::NOT_CONNECTED === $e->getCode() ) {
-				update_option( 'wc_gateway_ppce_prompt_to_connect', $e->getMessage() );
+				$this->prompt_to_connect = $e->getMessage();
 			}
 
 			add_action( 'admin_notices', array( $this, 'show_bootstrap_warning' ) );
@@ -177,7 +175,7 @@ class WC_Gateway_PPEC_Plugin {
 	}
 
 	public function show_bootstrap_warning() {
-		$dependencies_message = get_option( 'wc_gateway_ppce_bootstrap_warning_message', '' );
+		$dependencies_message = isset( $this->bootstrap_warning_message ) ? $this->bootstrap_warning_message : null;
 		if ( ! empty( $dependencies_message ) && 'yes' !== get_option( 'wc_gateway_ppec_bootstrap_warning_message_dismissed', 'no' ) ) {
 			?>
 			<div class="notice notice-warning is-dismissible ppec-dismiss-bootstrap-warning-message">
@@ -199,7 +197,7 @@ class WC_Gateway_PPEC_Plugin {
 			<?php
 		}
 
-		$prompt_connect = get_option( 'wc_gateway_ppce_prompt_to_connect', '' );
+		$prompt_connect = isset( $this->prompt_to_connect ) ? $this->prompt_to_connect : null;
 		if ( ! empty( $prompt_connect ) && 'yes' !== get_option( 'wc_gateway_ppec_prompt_to_connect_message_dismissed', 'no' ) ) {
 			?>
 			<div class="notice notice-warning is-dismissible ppec-dismiss-prompt-to-connect-message">


### PR DESCRIPTION
It was pretty straightforward to just switch out the option writes for saving to internal values, as mentioned in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/539#issuecomment-474100787. These options were only used in one location, hooked onto `admin_notices`. This PR simply replaces them with class properties.

Testing:

The easiest way to test is to make manual edits in `_check_dependencies()` and `_check_credentials()` to just force the exceptions to be thrown / not thrown. Then just reload the admin and ensure the correct notices show up.

CC @laurendavissmith  / @superdav42 