### PR TITLE
Add hook on payment error.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.6.15 - 2019-* =
 * Fix - Prevent PHP errors when no billing details are present in PP response
 * Fix - Require billing address for virtual products when enabled
+* Add - Hook when a payment error occurs
 
 = 1.6.14 - 2019-05-08 =
 * Fix - Failing checkout when no addons are used

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -173,6 +173,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 						'redirect' => wc_gateway_ppec()->settings->get_paypal_redirect_url( $session->token, true ),
 					);
 				} else {
+					do_action( 'wc_gateway_ppec_process_payment_error', $e, $order );
 					wc_add_notice( $e->getMessage(), 'error' );
 				}
 			}


### PR DESCRIPTION
Should payment fail for whatever reason as well as throw an exception a
hook is added so that third parties can run any routines they need to in
this scenario.

Use case for this change is we want to be able to log on any payment
error (to new relic).

Stripe has a similar hook here: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/a23615803579646973ced040cb1d114d9f5a4032/includes/class-wc-gateway-stripe.php#L851