### PR TITLE
Check if the shipping address returned from PayPal is not empty

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -513,12 +513,14 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		$customer->set_billing_state( $billing_details['state'] );
 		$customer->set_billing_country( $billing_details['country'] );
 
-		$customer->set_shipping_address( $shipping_details['address_1'] );
-		$customer->set_shipping_address_2( $shipping_details['address_2'] );
-		$customer->set_shipping_city( $shipping_details['city'] );
-		$customer->set_shipping_postcode( $shipping_details['postcode'] );
-		$customer->set_shipping_state( $shipping_details['state'] );
-		$customer->set_shipping_country( $shipping_details['country'] );
+		if ( ! empty( $shipping_details ) ) {
+			$customer->set_shipping_address( $shipping_details['address_1'] );
+			$customer->set_shipping_address_2( $shipping_details['address_2'] );
+			$customer->set_shipping_city( $shipping_details['city'] );
+			$customer->set_shipping_postcode( $shipping_details['postcode'] );
+			$customer->set_shipping_state( $shipping_details['state'] );
+			$customer->set_shipping_country( $shipping_details['country'] );
+		}
 	}
 
 	/**
@@ -981,12 +983,14 @@ class WC_Gateway_PPEC_Checkout_Handler {
 
 		$destination = $this->get_mapped_shipping_address( $checkout_details );
 
-		$packages[0]['destination']['country']   = $destination['country'];
-		$packages[0]['destination']['state']     = $destination['state'];
-		$packages[0]['destination']['postcode']  = $destination['postcode'];
-		$packages[0]['destination']['city']      = $destination['city'];
-		$packages[0]['destination']['address']   = $destination['address_1'];
-		$packages[0]['destination']['address_2'] = $destination['address_2'];
+		if ( ! empty( $destination ) ) {
+			$packages[0]['destination']['country']   = $destination['country'];
+			$packages[0]['destination']['state']     = $destination['state'];
+			$packages[0]['destination']['postcode']  = $destination['postcode'];
+			$packages[0]['destination']['city']      = $destination['city'];
+			$packages[0]['destination']['address']   = $destination['address_1'];
+			$packages[0]['destination']['address_2'] = $destination['address_2'];
+		}
 
 		return $packages;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 = 1.6.12 - 2019-* =
 * Fix - Better handling of virtual subscriptions when billing address is not required
+* Fix - Prevent errors showing when purchasing a virtual product with WP_DEBUG enabled
 
 = 1.6.11 - 2019-04-17 =
 * Fix/Performance - Prevent db option updates during bootstrap on each page load


### PR DESCRIPTION
Fixes #549 

Checks if the shipping address returned from PayPal is not empty before trying to use it to update the customer information.

To test:
* Make sure define( 'WP_DEBUG', true ); is present in wp-config.php
* Attempt to use the checkout button when purchasing any virtual product
* PayPal should not ask for shipping or billing address during checkout
* After returning to the site, no PHP notices should be shown and you should be able to complete the order