### PR TITLE
Better handling of virtual subs when billing address is not required

### DIFF
--- a/includes/class-wc-gateway-ppec-with-paypal-addons.php
+++ b/includes/class-wc-gateway-ppec-with-paypal-addons.php
@@ -46,7 +46,7 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 	/**
 	 * Filter for Subscriptions info tooltip html for this gateway
 	 *
-	 * @since 1.6.11
+	 * @since 1.6.12
 	 *
 	 * @param string             $html HTML of the tooltip
 	 * @param WC_Payment_Gateway $gateway Payment gateway to filter for
@@ -70,7 +70,7 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 	/**
 	 * Filter determining whether to show this gateway during checkout
 	 *
-	 * @since 1.6.11
+	 * @since 1.6.12
 	 *
 	 * @param array $gateways Array of payment gateways
 	 *
@@ -86,7 +86,7 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 	/**
 	 * Checks if smart payment buttons can be displayed during the checkout
 	 *
-	 * @since 1.6.11
+	 * @since 1.6.12
 	 *
 	 * @return bool True if buttons can be displayed
 	 */

--- a/includes/class-wc-gateway-ppec-with-spb-addons.php
+++ b/includes/class-wc-gateway-ppec-with-spb-addons.php
@@ -19,6 +19,9 @@ class WC_Gateway_PPEC_With_SPB_Addons extends WC_Gateway_PPEC_With_PayPal_Addons
 	 * Display PayPal button on the checkout page order review.
 	 */
 	public function display_paypal_button() {
+		if ( ! $this->should_display_buttons_at_checkout() ) {
+			return;
+		}
 		wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
 		?>
 		<div id="woo_pp_ec_button_checkout"></div>
@@ -51,7 +54,7 @@ class WC_Gateway_PPEC_With_SPB_Addons extends WC_Gateway_PPEC_With_PayPal_Addons
 			$session->checkout_completed = true;
 			$session->payer_id           = $_POST['payerID'];
 			$session->token              = $_POST['paymentToken'];
-	
+
 			WC()->session->set( 'paypal', $session );
 		}
 

--- a/includes/class-wc-gateway-ppec-with-spb.php
+++ b/includes/class-wc-gateway-ppec-with-spb.php
@@ -19,6 +19,9 @@ class WC_Gateway_PPEC_With_SPB extends WC_Gateway_PPEC_With_PayPal {
 	 * Display PayPal button on the checkout page order review.
 	 */
 	public function display_paypal_button() {
+		if ( ! $this->should_display_buttons_at_checkout() ) {
+			return;
+		}
 		wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
 		?>
 		<div id="woo_pp_ec_button_checkout"></div>
@@ -51,7 +54,7 @@ class WC_Gateway_PPEC_With_SPB extends WC_Gateway_PPEC_With_PayPal {
 			$session->checkout_completed = true;
 			$session->payer_id           = $_POST['payerID'];
 			$session->token              = $_POST['paymentToken'];
-	
+
 			WC()->session->set( 'paypal', $session );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 == Changelog ==
 
+= 1.6.12 - 2019-* =
+* Fix - Better handling of virtual subscriptions when billing address is not required
+
 = 1.6.11 - 2019-04-17 =
 * Fix/Performance - Prevent db option updates during bootstrap on each page load
 * Tweak = WC 3.6 compatibiliy.


### PR DESCRIPTION
Fixes #545 

Modifies the Subscriptions tooltip if "Require billing address" option is not set:
<img width="411" alt="Screenshot 2019-04-02 at 12 15 01" src="https://user-images.githubusercontent.com/800604/55398824-6824fb00-5541-11e9-90e7-c737d52063d7.png">

Removes PPEC from the available payment methods if the above option is not set and if the cart contains any virtual subscriptions.

To test:
* Verify that the tooltip appears on the settings page
* Create a virtual subscription and a shippable subscription products
* Attempt to checkout the virtual subscription - PPEC buttons should not appear at any point during the checkout
* Attempt to checkout the shippable subscription - PPEC buttons should appear
* Enable the "Require billing address" setting (for testing purposes I edited `woocommerce_ppec_paypal_settings` in `wp_options` in the database)
* The tooltip of the settings page should not show any changes
* Attempting to purchase a virtual subscription should show the PPEC buttons