### PR TITLE
Add CURRENCYCODE param to capture_payment

### DIFF
--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -163,6 +163,7 @@ class WC_Gateway_PPEC_Admin_Handler {
 				$params['AUTHORIZATIONID'] = $trans_id;
 				$params['AMT'] = floatval( $order_total );
 				$params['COMPLETETYPE'] = 'Complete';
+				$params['CURRENCYCODE'] = get_woocommerce_currency();
 
 				$result = wc_gateway_ppec()->client->do_express_checkout_capture( $params );
 


### PR DESCRIPTION
I have experienced the follow error:
`
WC_Gateway_PPEC_Client::_process_response: acknowleged response body: Array
(
    [AUTHORIZATIONID] => 3ND10104P6581550E
    [TIMESTAMP] => 2019-04-07T04:40:52Z
    [CORRELATIONID] => d71f885734e63
    [ACK] => Failure
    [VERSION] => 120.0
    [BUILD] => 52346509
    [L_ERRORCODE0] => 10613
    [L_SHORTMESSAGE0] => Currency mismatch.
    [L_LONGMESSAGE0] => Currency of capture must be the same as currency of authorization.
    [L_SEVERITYCODE0] => Error
)
`

Its due the missing param on capture method. The default value of the param according to documentation is USD, but I'm using EUR. 
The addition of this line correct the request.