### PR TITLE
Filter button display on a per-product basis. Closes #554

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -269,9 +269,10 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * @since 1.4.0
 	 */
 	public function display_paypal_button_product() {
+		global $product;
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) ) {
+		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || apply_filters( 'woocommerce_paypal_express_checkout_hide_button_on_product_page', false, $product ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Closes #554 

Can be used like so:

```
/**
 * Disable PayPal buttons on NYP products.
 */
function kia_disable_paypal_buttons_for_nyp( $hide, $product ) {
	global $product;
	if( class_exists( 'WC_Name_Your_Price_Helpers' ) && ( WC_Name_Your_Price_Helpers::is_nyp( $product ) || WC_Name_Your_Price_Helpers::has_nyp( $product ) ) ) {
		$hide = true;
	}
	return $hide;
}
add_filter( 'woocommerce_paypal_express_checkout_hide_button_on_product_page', 'kia_disable_paypal_buttons_for_nyp', 10, 2 );
```