### PR TITLE
add filter woocommerce_paypal_express_checkout_hide_button_on_product_page

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -271,7 +271,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 	public function display_paypal_button_product() {
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) ) {
+		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || apply_filters( 'woocommerce_paypal_express_checkout_hide_button_on_product_page', false, $product ) ) {
 			return;
 		}
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -269,6 +269,9 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * @since 1.4.0
 	 */
 	public function display_paypal_button_product() {
+		
+		global $product;
+		
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || apply_filters( 'woocommerce_paypal_express_checkout_hide_button_on_product_page', false, $product ) ) {


### PR DESCRIPTION
Closes #554.

Some products (for example: Name Your Price products) cannot support payment buttons on the page and for now they need to be hidden. 