### PR TITLE
add discounts to subtotal before rounding. fix #562

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -460,7 +460,7 @@ class WC_Gateway_PPEC_Client {
 		$discounts     = WC()->cart->get_cart_discount_total();
 
 		$details = array(
-			'total_item_amount' => round( WC()->cart->cart_contents_total, $decimals ) + $discounts,
+			'total_item_amount' => round( WC()->cart->cart_contents_total + $discounts, $decimals ),
 			'order_tax'         => round( WC()->cart->tax_total + WC()->cart->shipping_tax_total, $decimals ),
 			'shipping'          => round( WC()->cart->shipping_total, $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_cart(),
@@ -658,7 +658,7 @@ class WC_Gateway_PPEC_Client {
 		$discounts     = $order->get_total_discount();
 
 		$details = array(
-			'total_item_amount' => round( $order->get_subtotal(), $decimals ) + $discounts,
+			'total_item_amount' => round( $order->get_subtotal() + $discounts, $decimals ),
 			'order_tax'         => round( $order->get_total_tax(), $decimals ),
 			'shipping'          => round( ( version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_total_shipping() : $order->get_shipping_total() ), $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_order( $order ),


### PR DESCRIPTION
Fix PayPal API errors 10426 and 10413 with "Number of Decimals" set to 4 and discount coupon applied woocommerce#562
Add discounts to subtotal before rounding to avoid issues with too many decimal digits