### PR TITLE
Prevent PHP errors when no billing details are present in PP response

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.6.15 - 2019-* =
+* Fix - Prevent PHP errors when no billing details are present in PP response
+
 = 1.6.14 - 2019-05-08 =
 * Fix - Failing checkout when no addons are used
 

--- a/includes/class-wc-gateway-ppec-checkout-details.php
+++ b/includes/class-wc-gateway-ppec-checkout-details.php
@@ -77,6 +77,7 @@ class PayPal_Checkout_Details {
 
 		$this->payer_details = new PayPal_Checkout_Payer_Details();
 		if ( ! $this->payer_details->loadFromGetECResponse( $getECResponse ) ) {
+			wc_gateway_ppec_log( sprintf( 'PayPal response did not include the payer billing details: %s', print_r( $getECResponse, true ) ) );
 			$this->payer_details = false;
 		}
 

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -246,6 +246,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			wc_add_notice( $e->getMessage(), 'error' );
 			return;
 		}
+		// check if the payer details have been set on the PP response before rendering them to prevent PHP errors
 		if ( empty( $checkout_details->payer_details ) ) {
 			return;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 == Changelog ==
 
+= 1.6.15 - 2019-* =
+* Fix - Prevent PHP errors when no billing details are present in PP response
+
 = 1.6.14 - 2019-05-08 =
 * Fix - Failing checkout when no addons are used
 


### PR DESCRIPTION
(Partially) fixes #561 

The error described in the issue above happens when PayPal does not return any billing details of the customer to the site. It might be a result of an issue in the API, since we weren't able to reproduce it. But we should still prevent the site from blowing up with PHP notices and this PR does that.

To test:
* enable debug logging
* add `return false;` at line 454 in `includes/class-wc-gateway-ppec-checkout-details.php`
* attempt to checkout
* no php errors should be visible when returning from PayPal
* the checkout should still not be possible because the billing fields are required
* there should be a message in the logs `PayPal response did not include the payer billing details` and the response