### PR TITLE
Require billing address for virtual products when enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.6.15 - 2019-* =
 * Fix - Prevent PHP errors when no billing details are present in PP response
+* Fix - Require billing address for virtual products when enabled
 
 = 1.6.14 - 2019-05-08 =
 * Fix - Failing checkout when no addons are used

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -128,7 +128,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			return $fields;
 		}
 
-		if ( method_exists( WC()->cart, 'needs_shipping' ) && ! WC()->cart->needs_shipping() ) {
+		if ( method_exists( WC()->cart, 'needs_shipping' ) && ! WC()->cart->needs_shipping() && 'no' === wc_gateway_ppec()->settings->require_billing ) {
 			$not_required_fields = array( 'address_1', 'city', 'postcode', 'country' );
 			foreach ( $not_required_fields as $not_required_field ) {
 				if ( array_key_exists( $not_required_field, $fields ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 = 1.6.15 - 2019-* =
 * Fix - Prevent PHP errors when no billing details are present in PP response
+* Fix - Require billing address for virtual products when enabled
 
 = 1.6.14 - 2019-05-08 =
 * Fix - Failing checkout when no addons are used


### PR DESCRIPTION
Fixes #569 

The billing address fields should remain required when the corresponding option is set in the admin panel.

To test:
* Use a regular merchant account with no address required option set
* Add only virtual products to the cart
* Open the checkout page
* The billing address fields (street, city, postcode) should not be required: <img width="468" alt="Screenshot 2019-05-09 at 15 47 48" src="https://user-images.githubusercontent.com/800604/57462984-d0b67480-7271-11e9-8009-6d811b4f21eb.png">
* Use a merchant with the billing address option enabled (reach out if you need sandbox credentials for such an account) or manipulate the database to force the "Require Billing Address" option to true
* Ensure the option is set
* With virtual products only in the cart, open the checkout page
* The billing address fields should be required: <img width="458" alt="Screenshot 2019-05-09 at 15 51 41" src="https://user-images.githubusercontent.com/800604/57463277-5d613280-7272-11e9-9532-214dd2bd4b85.png">
* Disabling the option should make the fields not required again