### PR TITLE
Avoid broken confirmation screen edge case after 10486 redirect

### DIFF
--- a/assets/js/wc-gateway-ppec-order-review.js
+++ b/assets/js/wc-gateway-ppec-order-review.js
@@ -2,6 +2,7 @@
 	'use strict';
 
 	$( 'form.checkout' ).on( 'click', 'input[name="payment_method"]', function() {
+		// Avoid toggling submit button if on confirmation screen
 		if ( $( '#payment' ).find( '.wc-gateway-ppec-cancel' ).length ) {
 			return;
 		}

--- a/assets/js/wc-gateway-ppec-order-review.js
+++ b/assets/js/wc-gateway-ppec-order-review.js
@@ -2,6 +2,10 @@
 	'use strict';
 
 	$( 'form.checkout' ).on( 'click', 'input[name="payment_method"]', function() {
+		if ( $( '#payment' ).find( '.wc-gateway-ppec-cancel' ).length ) {
+			return;
+		}
+
 		var isPPEC = $( this ).is( '#payment_method_ppec_paypal' );
 		$( '#place_order' ).toggle( ! isPPEC );
 		$( '#woo_pp_ec_button_checkout' ).toggle( isPPEC );

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -246,6 +246,12 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			wc_add_notice( $e->getMessage(), 'error' );
 			return;
 		}
+
+		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+			$fields = WC()->checkout->checkout_fields['billing'];
+		} else {
+			$fields = WC()->checkout->get_checkout_fields( 'billing' );
+		}
 		?>
 		<h3><?php _e( 'Billing details', 'woocommerce-gateway-paypal-express-checkout' ); ?></h3>
 		<ul>
@@ -257,21 +263,14 @@ class WC_Gateway_PPEC_Checkout_Handler {
 
 			<?php if ( ! empty( $checkout_details->payer_details->email ) ) : ?>
 				<li><strong><?php _e( 'Email:', 'woocommerce-gateway-paypal-express-checkout' ) ?></strong> <?php echo esc_html( $checkout_details->payer_details->email ); ?></li>
+			<?php else : ?>
+				<li><?php woocommerce_form_field( 'billing_email', $fields['billing_email'], WC()->checkout->get_value( 'billing_email' ) ); ?></li>
 			<?php endif; ?>
 
 			<?php if ( ! empty( $checkout_details->payer_details->phone_number ) ) : ?>
 				<li><strong><?php _e( 'Phone:', 'woocommerce-gateway-paypal-express-checkout' ) ?></strong> <?php echo esc_html( $checkout_details->payer_details->phone_number ); ?></li>
 			<?php elseif ( 'yes' === wc_gateway_ppec()->settings->require_phone_number ) : ?>
-				<li>
-				<?php
-				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-					$fields = WC()->checkout->checkout_fields['billing'];
-				} else {
-					$fields = WC()->checkout->get_checkout_fields( 'billing' );
-				}
-				woocommerce_form_field( 'billing_phone', $fields['billing_phone'], WC()->checkout->get_value( 'billing_phone' ) );
-				?>
-				</li>
+				<li><?php woocommerce_form_field( 'billing_phone', $fields['billing_phone'], WC()->checkout->get_value( 'billing_phone' ) ); ?></li>
 			<?php endif; ?>
 		</ul>
 		<?php

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -210,7 +210,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			// Set flag so that WC copies billing to shipping
 			$_POST['ship_to_different_address'] = 0;
 
-			$copyable_keys = array( 'address_1', 'address_2', 'city', 'state', 'postcode', 'country' );
+			$copyable_keys = array( 'first_name', 'last_name', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country' );
 			foreach ( $copyable_keys as $copyable_key ) {
 				if ( array_key_exists( $copyable_key, $shipping_details ) ) {
 					$billing_details[ $copyable_key ] = $shipping_details[ $copyable_key ];

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -129,7 +129,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		}
 
 		if ( method_exists( WC()->cart, 'needs_shipping' ) && ! WC()->cart->needs_shipping() && 'no' === wc_gateway_ppec()->settings->require_billing ) {
-			$not_required_fields = array( 'address_1', 'city', 'postcode', 'country' );
+			$not_required_fields = array( 'first_name', 'last_name', 'company', 'address_1', 'address_2', 'city', 'postcode', 'country' );
 			foreach ( $not_required_fields as $not_required_field ) {
 				if ( array_key_exists( $not_required_field, $fields ) ) {
 					$fields[ $not_required_field ]['required'] = false;

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -246,16 +246,12 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			wc_add_notice( $e->getMessage(), 'error' );
 			return;
 		}
-		// check if the payer details have been set on the PP response before rendering them to prevent PHP errors
-		if ( empty( $checkout_details->payer_details ) ) {
-			return;
-		}
 		?>
 		<h3><?php _e( 'Billing details', 'woocommerce-gateway-paypal-express-checkout' ); ?></h3>
 		<ul>
-			<?php if ( $checkout_details->payer_details->billing_address ) : ?>
+			<?php if ( ! empty( $checkout_details->payer_details->billing_address ) ) : ?>
 				<li><strong><?php _e( 'Address:', 'woocommerce-gateway-paypal-express-checkout' ) ?></strong></br><?php echo WC()->countries->get_formatted_address( $this->get_mapped_billing_address( $checkout_details ) ); ?></li>
-			<?php else : ?>
+			<?php elseif ( ! empty( $checkout_details->payer_details->first_name ) && ! empty( $checkout_details->payer_details->last_name ) ) : ?>
 				<li><strong><?php _e( 'Name:', 'woocommerce-gateway-paypal-express-checkout' ) ?></strong> <?php echo esc_html( $checkout_details->payer_details->first_name . ' ' . $checkout_details->payer_details->last_name ); ?></li>
 			<?php endif; ?>
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/561

As described in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/561#issuecomment-508274372, there are some broken edge cases around visiting the Checkout screen after a redirect to PayPal. I've reproduced them specifically for the redirect upon receiving a 10486 error, and I'm not sure whether there are other ways to reproduce such issues and/or if all have been addressed, but this is meant to fix the main issue as I've been able to reproduce it.

<img width="613" alt="Screen Shot 2019-07-09 at 1 43 44 PM" src="https://user-images.githubusercontent.com/1867547/60911374-f7ccfa80-a250-11e9-9b78-9ea29af955d0.png">

- https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/commit/7a9877caead9e956317384933c127dfc8852f6a3 adds first name and last name to the fields copied from the shipping address, so that they have values even if the billing address hasn't come back from PayPal. However, this **doesn't help for virtual products**.
- https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/commit/976141b3d30e7b810f341315d2418d4afba6067c don't hide "Billing details" on checkout page, partially reverting https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/567 – instead, check for data before displaying
- https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/commit/8c66656d347240dce1b26664d21fe684fd43e479 shows an email field if no email value is present in the session, <s>which also partially addresses https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/587 – a high priority issue with an unknown cause (seemingly on PayPal's side) – by still allowing the customer to re-enter the email address and proceed</s> (_edit_: this may be resolved now).
- https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/commit/0a52e16275285425ca178237518dbfab7338fc07 addresses case of going Back via browser button after redirect on Checkout screen, which would result in a cached Checkout form but hidden submit button due to JS toggle intended for Smart Payment Buttons.

Spent some time trying to address remaining cases but kind of got lost in a rabbit hole around how required fields are manipulated in this extension (incl. https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/426). I also realized there can be validation errors without matching input fields in the normal flow [[screenshot](https://cloudup.com/ct0KAzUVVei)] if company or address_2 fields are required (in Customizer » WooCommerce » Checkout).

Is there reason not to add first_name and last_name (not to mention address_2 and probably company) to `not_required_fields`? Otherwise we might want to conditionally display those form fields on the confirmation screen.

To test / reproduce in `master`:
- Add `'AMT' => '104.86'` to `get_do_express_checkout_params` to trigger 10486 error after continuing from modal and confirming payment
- Check out, either:
  - with PayPal from Single Product or Cart, then after redirect navigate to /checkout
  - from Checkout screen, then after redirect go Back to Checkout with the browser (bypassing Cancel mechanism)
- In `master`, the confirmation screen's Continue button triggers validation errors for Billing First name, Last name, and Email fields, which aren't available for input
  - Note: the PHP notices were fixed in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/567

Testing with "Require Phone Number" setting enabled.