### PR TITLE
Check to avoid duplicate Smart Payment Button render

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -61,6 +61,11 @@
 
 		var selector = isMiniCart ? '#woo_pp_ec_button_mini_cart' : '#woo_pp_ec_button_' + wc_ppec_context.page;
 
+		// Don't render if already rendered in DOM.
+		if ( $( selector ).children().length ) {
+			return;
+		}
+
 		paypal.Button.render( {
 			env: wc_ppec_context.environment,
 			locale: wc_ppec_context.locale,


### PR DESCRIPTION
The change in https://github.com/woocommerce/woocommerce/pull/24227 would break the assumption that there is a newly mounted DOM fragment (and therefore an empty Smart Payment Button container) whenever `updated_checkout` is triggered.

The change in this PR is to make sure the `render` function can be called multiple times with a single container node without duplicate SPB renders occurring.

Can be tested by checking out the branch in https://github.com/woocommerce/woocommerce/pull/24227 and modifying a checkout field with the PayPal Checkout payment method selected. Alternatively, `jQuery( document.body ).trigger( 'updated_checkout' )` can be called from the console. In `master`, this would result in multiple sets of buttons, but in this branch there is no additional render.