### PR TITLE
Add a filter to enable (or disable) Billing Agreement

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -1033,7 +1033,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			}
 		}
 
-		return $needs_billing_agreement;
+		return apply_filters( 'woocommerce_paypal_express_checkout_needs_billing_agreement', $needs_billing_agreement );
 	}
 
 	/**


### PR DESCRIPTION
Hi there

For now, Billing Agreement can be used only with WooCommerce Subscription. 

By adding a filter, other people (like me ^^) could easily enable Billing Agreement without need to use WooCommerce Subscription or hard coding the plugin core :/