### PR TITLE
Update for WooCommerce 3.7

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: automattic, woothemes, akeda, dwainm, royho, allendav, slash1andy, woosteve, spraveenitpro, mikedmoore, fernashes, shellbeezy, danieldudzic, mikaey, fullysupportedphil, dsmithweb, corsonr, bor0, zandyring, pauldechov, robobot3000
 Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, store, sales, sell, shop, shopping, cart, checkout, configurable, paypal
 Requires at least: 4.4
-Tested up to: 5.2.0
-Stable tag: 1.6.16
+Tested up to: 5.2.2
+Stable tag: 1.6.17
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -100,6 +100,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 9. Initiate checkout from mini-cart.
 
 == Changelog ==
+
+= 1.6.17 - 2019-08-07 =
+* Update - WooCommerce 3.7 compatibility.
 
 = 1.6.16 - 2019-07-18 =
 * Fix - Don't require address for renewal of virtual subscriptions

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,19 +3,19 @@
  * Plugin Name: WooCommerce PayPal Checkout Gateway
  * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: A payment gateway for PayPal Checkout (https://www.paypal.com/us/webapps/mpp/paypal-checkout).
- * Version: 1.6.16
+ * Version: 1.6.17
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
- * Copyright: © 2018 WooCommerce / PayPal.
+ * Copyright: © 2019 WooCommerce / PayPal.
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: woocommerce-gateway-paypal-express-checkout
  * Domain Path: /languages
- * WC tested up to: 3.6
+ * WC tested up to: 3.7
  * WC requires at least: 2.6
  */
 /**
- * Copyright (c) 2018 PayPal, Inc.
+ * Copyright (c) 2019 PayPal, Inc.
  *
  * The name of the PayPal may not be used to endorse or promote products derived from this
  * software without specific prior written permission. THIS SOFTWARE IS PROVIDED ``AS IS'' AND
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'WC_GATEWAY_PPEC_VERSION', '1.6.16' );
+define( 'WC_GATEWAY_PPEC_VERSION', '1.6.17' );
 
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.


### PR DESCRIPTION
Test plan:

- [ ] Complete a test purchase using PayPal
- [ ] Complete a test purchase using a Credit Card
- [ ] As a US buyer, make sure Venmo is offered as a payment method to mobile buyers
- [ ] As a US buyer, make sure PayPal Credit is offered as a payment method
- [ ] Make sure you can authorize then capture
- [ ] Test with Smart Payment Buttons enabled (and not) (e.g. Venmo is one)
- [ ] Test with and without Checkout on Single Product
- [ ] Test with and without Enable PayPal Checkout on cart page
- [ ] Test with and without Enable PayPal Mark
- [ ] Test with and without an API Certificate
- [ ] Test with and without a PayPal Hosted Logo Image and Header Image
- [ ] Test with a tax rate that results in fractional cents and make sure purchases succeed
- [ ] Test with Subscriptions