### PR TITLE
Skip wasteful render on initial Checkout page load

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -151,7 +151,9 @@
 
 	// Render cart, single product, or checkout buttons.
 	if ( wc_ppec_context.page ) {
-		render();
+		if ( 'checkout' !== wc_ppec_context.page ) {
+			render();
+		}
 		$( document.body ).on( 'updated_cart_totals updated_checkout', render.bind( this, false ) );
 	}
 


### PR DESCRIPTION
Avoids costly (150+ ms in my profiler) Smart Payment Button render on every Checkout page load, since the `updated_checkout` event is always called when the order review section is actually ready (after an AJAX request, currently). So, it was always being called one unnecessary time before that.