### PR TITLE
Fix #602 - No request executed for update_billing_agreement method

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -954,6 +954,8 @@ class WC_Gateway_PPEC_Client {
 			'VERSION'     => self::API_VERSION,
 			'REFERENCEID' => $billing_agreement_id,
 		);
+
+		return $this->_request( $params );
 	}
 
 	/**


### PR DESCRIPTION
To fix => https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/602