### PR TITLE
Add filter for paypal button on products

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -275,6 +275,10 @@ class WC_Gateway_PPEC_Cart_Handler {
 			return;
 		}
 
+		if ( apply_filters( 'woocommerce_paypal_express_checkout_hide_button_on_product_page', false ) ) {
+			return;
+		}
+
 		$settings = wc_gateway_ppec()->settings;
 
 		$express_checkout_img_url = apply_filters( 'woocommerce_paypal_express_checkout_button_img_url', sprintf( 'https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-%s.png', $settings->button_size ) );


### PR DESCRIPTION
Closes #554 

To test, do something like this:

```
function hello_hide( $hide ) {
	if ( function_exists( 'is_product' ) && is_product() ) {
		global $product;
		$product_name = $product->get_name( 'edit' );
		if ( FALSE === stristr( $product_name, 'HIDE' ) ) {
			return $hide;
		} else {
			return true;
		}
	}

	return $hide;	
}

add_filter( 'woocommerce_paypal_express_checkout_hide_button_on_product_page' , 'hello_hide' );
```