### PR TITLE
Add filter for PayPal redirect URL

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -177,7 +177,7 @@ class WC_Gateway_PPEC_Settings {
 			$url .= '#/checkout/chooseCreditOffer';
 		}
 
-		return $url;
+		return apply_filters( 'woocommerce_paypal_express_checkout_paypal_redirect_url', $url );
 	}
 
 	public function get_set_express_checkout_shortcut_params( $buckets = 1 ) {


### PR DESCRIPTION
Hi,

I have encountered a scenario where despite Guest Checkout being enabled, the customer was directed from the WooCommerce checkout to:

```
/checkoutnow?token=TOKEN&useraction=commit
```

which was then redirected to:

```
/checkoutnow?token=TOKEN&useraction=commit#/checkout/signup
```

instead of to `#/checkout/guest`, as was being expected since the PPEC plugin Landing Page had been configured to “Billing (Non-PayPal account)”.

On other occasions the customer was redirected correctly to `#/checkout/guest`, but an automatic client redirection to `#/checkout/signup` was triggered in the client as soon as the customer changed the credit-card country.

Through experimentation it was observed that setting the credit-card country to some countries, e.g. US/UK, always triggered a redirect to `#/checkout/guest`, whereas other specific countries, e.g. Malta, always triggered a redirect to `#/checkout/signup`.

In the end, the only reliable way I found to  work around this issue was to hardcode the `#/checkout/guest` fragment in the PPEC plugin.

By exposing the `woocommerce_paypal_express_checkout_paypal_redirect_url` filter I am introducing in this PR, it would be possible to implement such a customization from outside the PPEC plugin.

Thank you.