### PR TITLE
Add get_paypal_locales() method

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -297,13 +297,22 @@ class WC_Gateway_PPEC_Settings {
 	}
 
 	/**
+	 * Get supported locales for PayPal.
+	 *
+	 * @return array
+	 */
+	public function get_paypal_locales() {
+		return apply_filters( 'woocommerce_paypal_express_checkout_paypal_locales', $this->_supported_locales );
+	}
+
+	/**
 	 * Get locale for PayPal.
 	 *
 	 * @return string
 	 */
 	public function get_paypal_locale() {
 		$locale = get_locale();
-		if ( ! in_array( $locale, $this->_supported_locales ) ) {
+		if ( ! in_array( $locale, $this->get_paypal_locales() ) ) {
 			$locale = 'en_US';
 		}
 		return apply_filters( 'woocommerce_paypal_express_checkout_paypal_locale', $locale );


### PR DESCRIPTION
@gedex, @bor0, @dechov: 
This PR adds a `get_paypal_locales` method for getting an array of supported PayPal locales.
This can be helpful other plugins that want to use the `woocommerce_paypal_express_checkout_paypal_locale` filter.
It also applies a filter on the locales array so it is possible to quickly change the array of supported locales (as PayPal could add new supported locales).