### PR TITLE
Replace deprecated checkout.js to fix broken smart buttons

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -42,6 +42,7 @@
 
 		var selector     = isMiniCart ? '#woo_pp_ec_button_mini_cart' : '#woo_pp_ec_button_' + wc_ppec_context.page;
 		var fromCheckout = 'checkout' === wc_ppec_context.page && ! isMiniCart;
+		const return_url = wc_ppec_context[ prefix + 'return_url' ];
 
 		// Don't render if already rendered in DOM.
 		if ( $( selector ).children().length ) {
@@ -113,12 +114,13 @@
 				if ( fromCheckout ) {
 					// Pass data necessary for authorizing payment to back-end.
 					$( 'form.checkout' )
-						.append( $( '<input type="hidden" name="paymentToken" /> ' ).attr( 'value', data.paymentToken ) )
+						.append( $( '<input type="hidden" name="paymentToken" /> ' ).attr( 'value', data.orderID ) )
 						.append( $( '<input type="hidden" name="payerID" /> ' ).attr( 'value', data.payerID ) )
 						.submit();
 				} else {
 					// Navigate to order confirmation URL specified in original request to PayPal from back-end.
-					return actions.redirect();
+					const query_args = `?woo-paypal-return=true&token=${ data.orderID }&PayerID=${ data.payerID }`
+					return actions.redirect( return_url + query_args );
 				}
 			},
 

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -42,7 +42,8 @@
 
 		var selector     = isMiniCart ? '#woo_pp_ec_button_mini_cart' : '#woo_pp_ec_button_' + wc_ppec_context.page;
 		var fromCheckout = 'checkout' === wc_ppec_context.page && ! isMiniCart;
-		const return_url = wc_ppec_context[ prefix + 'return_url' ];
+		// Don't use `prefix + 'return_url'` since `return_url` is same in all cases.
+		const return_url = wc_ppec_context[ 'return_url' ];
 
 		// Don't render if already rendered in DOM.
 		if ( $( selector ).children().length ) {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -459,22 +459,30 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		} elseif ( 'yes' === $settings->use_spb ) {
 			// TODO: Add client ID.
-			$environment = 'sandbox' === $settings->get_environment() ? 'sb' : '<client_id>';
+			$client_id = 'sandbox' === $settings->get_environment() ? 'sb' : '<client_id>';
 			// TODO: Add commit true/false.
 			// TODO: Pass disable-funding.
 			// TODO: Pass disable-card.
+			$script_url = add_query_arg( array(
+				'client-id' => $client_id,
+				'locale'    => $settings->get_paypal_locale(),
+			), 'https://www.paypal.com/sdk/js' );
 			wp_register_script(
 				'paypal-checkout-js',
-				'https://www.paypal.com/sdk/js?client-id=' . $environment . '&locale=' . $settings->get_paypal_locale(),
+				$script_url,
 				array(),
 				null,
 				true
 			);
-			wp_register_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', array( 'jquery', 'paypal-checkout-js' ), wc_gateway_ppec()->version, true );
+			wp_register_script(
+				'wc-gateway-ppec-smart-payment-buttons',
+				wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js',
+				array( 'jquery', 'paypal-checkout-js' ),
+				wc_gateway_ppec()->version,
+				true
+			);
 
 			$data = array(
-				'environment'          => 'sandbox' === $settings->get_environment() ? 'sandbox' : 'production',
-				'locale'               => $settings->get_paypal_locale(),
 				'page'                 => $page,
 				'button_color'         => $settings->button_color,
 				'button_shape'         => $settings->button_shape,

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -458,7 +458,18 @@ class WC_Gateway_PPEC_Cart_Handler {
 			);
 
 		} elseif ( 'yes' === $settings->use_spb ) {
-			wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
+			// TODO: Add client ID.
+			$environment = 'sandbox' === $settings->get_environment() ? 'sb' : '<client_id>';
+			// TODO: Add commit true/false.
+			// TODO: Pass disable-funding.
+			// TODO: Pass disable-card.
+			wp_register_script(
+				'paypal-checkout-js',
+				'https://www.paypal.com/sdk/js?client-id=' . $environment . '&locale=' . $settings->get_paypal_locale(),
+				array(),
+				null,
+				true
+			);
 			wp_register_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', array( 'jquery', 'paypal-checkout-js' ), wc_gateway_ppec()->version, true );
 
 			$data = array(

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -480,6 +480,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				'button_shape'         => $settings->button_shape,
 				'start_checkout_nonce' => wp_create_nonce( '_wc_ppec_start_checkout_nonce' ),
 				'start_checkout_url'   => WC_AJAX::get_endpoint( 'wc_ppec_start_checkout' ),
+				'return_url'           => wc_get_checkout_url(),
 			);
 
 			if ( ! is_null(  $page ) ) {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -458,11 +458,28 @@ class WC_Gateway_PPEC_Cart_Handler {
 			);
 
 		} elseif ( 'yes' === $settings->use_spb ) {
-			// TODO: Add client ID.
+			/** 
+			 * TODO: Add client ID retrieved from DB. For implementation details see:
+			 *       https://developer.paypal.com/docs/checkout/integrate/#2-add-the-paypal-script-to-your-web-page
+			 *       For details about client IDs, see:
+			 *       https://developer.paypal.com/docs/checkout/reference/customize-sdk/#client-id
+			 * 
+			 * According to @dechov we might not have the client id stored yet. - @reykjalin
+			 */
 			$client_id = 'sandbox' === $settings->get_environment() ? 'sb' : '<client_id>';
-			// TODO: Add commit true/false.
-			// TODO: Pass disable-funding.
-			// TODO: Pass disable-card.
+			/**
+			 * There are several query arguments missing in the `$script_url`:
+			 * 
+			 * - commit: true/false - Determines whether to show the "Pay now" or "Continue" button
+			 *                        in checkout flow.
+			 *                        Details here: https://developer.paypal.com/docs/checkout/reference/customize-sdk/#commit
+			 * - disable-funding    - Comma separated list of values that correspond to disabled funding sources.
+			 *                        For details see:
+			 *                        https://developer.paypal.com/docs/checkout/reference/customize-sdk/#disable-funding
+			 * - disable-card:      - Comma separated list of values that correspond to disabled cards.
+			 *                        For details see:
+			 *                        https://developer.paypal.com/docs/checkout/reference/customize-sdk/#disable-card
+			 */
 			$script_url = add_query_arg( array(
 				'client-id' => $client_id,
 				'locale'    => $settings->get_paypal_locale(),


### PR DESCRIPTION
Fixes #626.

According to https://developer.paypal.com/docs/checkout/reference/upgrade-integration the old `checkout.js` script we were using (`paypalobjects.com/api/checkout.js`) has been deprecated, and we need to use the new script, provided at `paypal.com/sdk/js`.

The issue reported in #581 was an error coming from the deprecated `checkout.js` script, and using the new script fixes that issue.

There are more uses of the deprecated script, but for now this seems to address the most pressing issues.

Using the new script changes several things about how the API is used. For example, the `environment` is no longer passed as a parameter, instead you provide a client ID when you load the new script and that is used to automatically detect your environment.
Several other parameters are passed in this way when you load the script.

**Changes proposed in this pull request:**

- Use the new JavaScript file provided by PayPal to fix issues with the deprecated `checkout.js` script.

**Testing instructions:**

1. Install and activate plugin.
1. Go to plugin settings and allow credit cards.
1. Add an item to the cart.
1. Go to cart page.
1. Ensure smart buttons are clickable.
1. Process payment using smart buttons.

Test the functionality of the regular PayPal and PayPal Credit buttons as well.