### PR TITLE
Add mapping for some locales

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -48,6 +48,16 @@ class WC_Gateway_PPEC_Settings {
 		'zh_TW',
 	);
 
+	protected $_locales_map = array(
+		'de_DE_formal' => 'de_DE',
+		'ja'           => 'ja_JP',
+		'nb_NO'        => 'no_NO',
+		'nn_NO'        => 'no_NO',
+		'nl_NL_formal' => 'nl_NL',
+		'pt_PT_ao90'   => 'pt_PT',
+		'th'           => 'th_TH',
+	);
+
 	/**
 	 * Flag to indicate setting has been loaded from DB.
 	 *
@@ -303,6 +313,12 @@ class WC_Gateway_PPEC_Settings {
 	 */
 	public function get_paypal_locale() {
 		$locale = get_locale();
+
+        // Remap some locales
+        if( in_array( $locale, $this->_locales_map ) ) {
+            $locale = $this->_locales_map[ $locale ];
+        }
+
 		if ( ! in_array( $locale, $this->_supported_locales ) ) {
 			$locale = 'en_US';
 		}

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -314,10 +314,10 @@ class WC_Gateway_PPEC_Settings {
 	public function get_paypal_locale() {
 		$locale = get_locale();
 
-        // Remap some locales
-        if( in_array( $locale, $this->_locales_map ) ) {
-            $locale = $this->_locales_map[ $locale ];
-        }
+		// Remap some locales
+		if( in_array( $locale, $this->_locales_map ) ) {
+			$locale = $this->_locales_map[ $locale ];
+		}
 
 		if ( ! in_array( $locale, $this->_supported_locales ) ) {
 			$locale = 'en_US';


### PR DESCRIPTION
Maps some WordPress locales to PayPal locales.

The current WordPress locales are listed here: https://make.wordpress.org/polyglots/teams/
The current PayPal locales are listed here: https://developer.paypal.com/docs/api/reference/locale-codes/#supported-locale-codes

https://github.com/strarsis/woocommerce-gateway-paypal-express-checkout/blob/59f4db3ab60cab33752d6fad543b83f2c6c9e9d5/includes/class-wc-gateway-ppec-settings.php#L51-L59