### PR TITLE
Improve plugin description

### DIFF
--- a/languages/woocommerce-gateway-paypal-express-checkout.pot
+++ b/languages/woocommerce-gateway-paypal-express-checkout.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-14T03:56:04+02:00\n"
+"POT-Creation-Date: 2019-10-17T15:40:55+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: woocommerce-gateway-paypal-express-checkout\n"
@@ -23,7 +23,7 @@ msgid "https://woocommerce.com/products/woocommerce-gateway-paypal-express-check
 msgstr ""
 
 #. Description of the plugin
-msgid "A payment gateway for PayPal Checkout (https://www.paypal.com/us/webapps/mpp/paypal-checkout)."
+msgid "Accept all major credit and debit cards, plus Venmo and PayPal Credit in the US, presenting options in a customizable stack of payment buttons. Fast, seamless, and flexible."
 msgstr ""
 
 #. Author of the plugin

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WooCommerce PayPal Checkout Gateway
  * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
- * Description: A payment gateway for PayPal Checkout (https://www.paypal.com/us/webapps/mpp/paypal-checkout).
+ * Description: Accept all major credit and debit cards, plus Venmo and PayPal Credit in the US, presenting options in a customizable stack of payment buttons. Fast, seamless, and flexible.
  * Version: 1.6.17
  * Author: WooCommerce
  * Author URI: https://woocommerce.com


### PR DESCRIPTION
A small change to improve the description of the plugin as it appears in the "Installed Plugins" page of wp-admin.

@californiakat, this reads well to me but wanted to check you're still happy with the new description now that you can see it in place?
![image](https://user-images.githubusercontent.com/686419/67025630-431f6080-f0fe-11e9-866d-d377160dd06a.png)

**To Test**
Navigate to the "Installed Plugins" page and ensure the plugin description matches the proposed test in #605.

Fixes #605.