### PR TITLE
Use the currency of the order when creating a reference transaction

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -1002,7 +1002,7 @@ class WC_Gateway_PPEC_Client {
 			'SHIPDISCAMT'   => $details['ship_discount_amount'],
 			'INSURANCEAMT'  => 0,
 			'HANDLINGAMT'   => 0,
-			'CURRENCYCODE'  => get_woocommerce_currency(),
+			'CURRENCYCODE'  => $old_wc ? $order->order_currency : $order->get_currency(),
 			'NOTIFYURL'     => WC()->api_request_url( 'WC_Gateway_PPEC' ),
 			'PAYMENTACTION' => $settings->get_paymentaction(),
 			'INVNUM'        => $settings->invoice_prefix . $order->get_order_number(),


### PR DESCRIPTION
In stores with multiple currencies setup it is possible that an order was originally charged in a different currency to the store's base currency.

To ensure we always charge in the same currency, use the currency from the order rather than the store.

Fixes #607

**To Replicate the Issue**
Follow these steps without the code from this PR:
1. Install and configure a multi-currency plugin like [WooCommerce Multi-Currency](https://woocommerce.com/products/multi-currency/).
2. Purchase a subscription in a different currency to the store's base currency. For example, my store has a currency of GBP and I purchased a subscription in EUR.
3. Go to the seller's dashboard and see that the payment was made in the expected currency. 
4. Renew the subscription (Find "Subscription" order and on that detail screen `Subscription actions > Process renewal > Click Update`)
5. Go to the seller's dashboard and see that the payment was made in the store's currency, not the subscription's currency.

**To Test**
Apply this branch and repeat steps 4 and 5. The new payment should be in the original currency used to pay for the subscription.

**Outstanding Work**

* What happens if no payment is made for the initial subscription? For example, if it has a free trial.
* As noted in the original issue, `get_woocommerce_currency` is used in a few other places ([#](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/17a92814268d5fdd0b36ba5e288917b0b4bf766b/includes/class-wc-gateway-ppec-client.php#L290), [#](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/17a92814268d5fdd0b36ba5e288917b0b4bf766b/includes/class-wc-gateway-ppec-client.php#L884)). It would be good to test these out and ensure we don't need to make similar changes there (or at least make new issues to come back to later if required).
* There's a chance this refund error message ([#](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/b7132136505e4365639156f5927960752fc7fc58/includes/abstracts/abstract-wc-gateway-ppec.php#L429)) could show the wrong currency symbol
