### PR TITLE
Fix error 10426 when coupons are used

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.6.18 - 2019-x-x =
 * Fix - Send fees to PayPal as line items
+* Fix - Fix error 10426 when coupons are used
 * Add - Notice about legacy payment buttons deprecation
 
 = 1.6.17 - 2019-08-08 =

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -462,7 +462,7 @@ class WC_Gateway_PPEC_Client {
 		$discounts     = WC()->cart->get_cart_discount_total();
 
 		$details = array(
-			'total_item_amount' => round( WC()->cart->cart_contents_total + WC()->cart->fee_total, $decimals ) + $discounts,
+			'total_item_amount' => round( WC()->cart->cart_contents_total + $discounts + WC()->cart->fee_total, $decimals ),
 			'order_tax'         => round( WC()->cart->tax_total + WC()->cart->shipping_tax_total, $decimals ),
 			'shipping'          => round( WC()->cart->shipping_total, $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_cart(),
@@ -602,10 +602,10 @@ class WC_Gateway_PPEC_Client {
 		$details['ship_discount_amount'] = 0;
 
 		// AMT
-		$details['order_total']       = $details['order_total'] - $discounts;
+		$details['order_total']       = round( $details['order_total'] - $discounts, $decimals );
 
 		// ITEMAMT
-		$details['total_item_amount'] = $details['total_item_amount'] - $discounts;
+		$details['total_item_amount'] = round( $details['total_item_amount'] - $discounts, $decimals );
 
 		// If the totals don't line up, adjust the tax to make it work (it's
 		// probably a tax mismatch).

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 = 1.6.18 - 2019-x-x =
 * Fix - Send fees to PayPal as line items
+* Fix - Fix error 10426 when coupons are used
 * Add - Notice about legacy payment buttons deprecation
 
 = 1.6.17 - 2019-08-08 =


### PR DESCRIPTION
Fixes #562 
Fixes #633 

Rounds the `total_item_amount` and `order_total` after applying the discounts.

To test:
1. Add a product with price 89.99
2. Create a coupon with 99% discount
3. Attempt to go through PayPal checkout product from 1. with coupon from 2.
4. The PP window should open and you should be able to complete the checkout
or:
1. Repeat steps 1-2 above
2. Set the number of decimal places to 4
3. Checkout should still work