### PR TITLE
Add a notice about legacy payment buttons deprecation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.6.18 - 2019-x-x =
 * Fix - Send fees to PayPal as line items
+* Add - Notice about legacy payment buttons deprecation
 
 = 1.6.17 - 2019-08-08 =
 * Update - WooCommerce 3.7 compatibility

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -234,7 +234,7 @@ class WC_Gateway_PPEC_Plugin {
 		}
 
 		$setting_link = $this->get_admin_setting_link();
-		$message = sprintf( __( '<p>PayPal&nbsp;Checkout with new <strong>Smart&nbsp;Payment&nbsp;Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be deprecated and removed</strong> in the <strong>next</strong> release. Upgrade to Smart&nbsp;Payment&nbsp;Buttons in the <a href="%s">PayPal&nbsp;Checkout settings</a>.</p>', 'woocommerce-gateway-paypal-express-checkout' ), esc_url( $setting_link ) );
+		$message = sprintf( __( '<p>PayPal Checkout with new <strong>Smart Payment Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be removed</strong> in the <strong>next release</strong>. Please upgrade to Smart Payment Buttons on the <a href="%s">PayPal Checkout settings page</a>.</p>', 'woocommerce-gateway-paypal-express-checkout' ), esc_url( $setting_link ) );
 		?>
 		<div class="notice notice-error">
 			<?php echo wp_kses( $message, array( 'a' => array( 'href' => array() ), 'strong' => array(), 'p' => array() ) ); ?>

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -233,26 +233,13 @@ class WC_Gateway_PPEC_Plugin {
 			return;
 		}
 
-		if ( 'yes' !== get_option( 'wc_gateway_ppec_spb_notice_dismissed', 'no' ) ) {
-			$setting_link = $this->get_admin_setting_link();
-			$message = sprintf( __( '<p>PayPal&nbsp;Checkout with new <strong>Smart&nbsp;Payment&nbsp;Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be deprecated and removed</strong> in future releases. Upgrade to Smart&nbsp;Payment&nbsp;Buttons in the <a href="%s">PayPal&nbsp;Checkout settings</a>.</p>', 'woocommerce-gateway-paypal-express-checkout' ), esc_url( $setting_link ) );
-			?>
-			<div class="notice notice-warning is-dismissible ppec-dismiss-spb-notice">
-				<?php echo wp_kses( $message, array( 'a' => array( 'href' => array() ), 'strong' => array(), 'p' => array() ) ); ?>
-			</div>
-			<script>
-			( function( $ ) {
-				$( '.ppec-dismiss-spb-notice' ).on( 'click', '.notice-dismiss', function() {
-					jQuery.post( "<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>", {
-						action: "ppec_dismiss_notice_message",
-						dismiss_action: "ppec_dismiss_spb_notice",
-						nonce: "<?php echo esc_js( wp_create_nonce( 'ppec_dismiss_notice' ) ); ?>"
-					} );
-				} );
-			} )( jQuery );
-			</script>
-			<?php
-		}
+		$setting_link = $this->get_admin_setting_link();
+		$message = sprintf( __( '<p>PayPal&nbsp;Checkout with new <strong>Smart&nbsp;Payment&nbsp;Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be deprecated and removed</strong> in the <strong>next</strong> release. Upgrade to Smart&nbsp;Payment&nbsp;Buttons in the <a href="%s">PayPal&nbsp;Checkout settings</a>.</p>', 'woocommerce-gateway-paypal-express-checkout' ), esc_url( $setting_link ) );
+		?>
+		<div class="notice notice-error">
+			<?php echo wp_kses( $message, array( 'a' => array( 'href' => array() ), 'strong' => array(), 'p' => array() ) ); ?>
+		</div>
+		<?php
 	}
 
 	/**
@@ -273,9 +260,6 @@ class WC_Gateway_PPEC_Plugin {
 				break;
 			case 'ppec_dismiss_prompt_to_connect':
 				update_option( 'wc_gateway_ppec_prompt_to_connect_message_dismissed', 'yes' );
-				break;
-			case 'ppec_dismiss_spb_notice':
-				update_option( 'wc_gateway_ppec_spb_notice_dismissed', 'yes' );
 				break;
 		}
 		wp_die();

--- a/languages/woocommerce-gateway-paypal-express-checkout.pot
+++ b/languages/woocommerce-gateway-paypal-express-checkout.pot
@@ -9,9 +9,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-10-17T15:40:55+00:00\n"
+"POT-Creation-Date: 2019-11-18T13:52:00+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.3.0\n"
+"X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: woocommerce-gateway-paypal-express-checkout\n"
 
 #. Plugin Name of the plugin
@@ -481,35 +481,35 @@ msgstr ""
 msgid "%s in WooCommerce Gateway PayPal Checkout plugin can only be called once"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:238
-msgid "<p>PayPal&nbsp;Checkout with new <strong>Smart&nbsp;Payment&nbsp;Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be deprecated and removed</strong> in future releases. Upgrade to Smart&nbsp;Payment&nbsp;Buttons in the <a href=\"%s\">PayPal&nbsp;Checkout settings</a>.</p>"
+#: includes/class-wc-gateway-ppec-plugin.php:237
+msgid "<p>PayPal&nbsp;Checkout with new <strong>Smart&nbsp;Payment&nbsp;Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be deprecated and removed</strong> in the <strong>next</strong> release. Upgrade to Smart&nbsp;Payment&nbsp;Buttons in the <a href=\"%s\">PayPal&nbsp;Checkout settings</a>.</p>"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:291
+#: includes/class-wc-gateway-ppec-plugin.php:275
 msgid "WooCommerce Gateway PayPal Checkout requires WooCommerce to be activated"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:295
+#: includes/class-wc-gateway-ppec-plugin.php:279
 msgid "WooCommerce Gateway PayPal Checkout requires WooCommerce version 2.5 or greater"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:299
+#: includes/class-wc-gateway-ppec-plugin.php:283
 msgid "WooCommerce Gateway PayPal Checkout requires cURL to be installed on your server"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:302
+#: includes/class-wc-gateway-ppec-plugin.php:286
 msgid "WooCommerce Gateway PayPal Checkout requires OpenSSL >= 1.0.1 to be installed on your server"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:329
+#: includes/class-wc-gateway-ppec-plugin.php:313
 msgid "PayPal Checkout is almost ready. To get started, <a href=\"%s\">connect your PayPal account</a>."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:451
+#: includes/class-wc-gateway-ppec-plugin.php:435
 msgid "Settings"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:454
+#: includes/class-wc-gateway-ppec-plugin.php:438
 msgid "Docs"
 msgstr ""
 

--- a/languages/woocommerce-gateway-paypal-express-checkout.pot
+++ b/languages/woocommerce-gateway-paypal-express-checkout.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-11-18T13:52:00+00:00\n"
+"POT-Creation-Date: 2019-11-20T17:08:08+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: woocommerce-gateway-paypal-express-checkout\n"
@@ -482,7 +482,7 @@ msgid "%s in WooCommerce Gateway PayPal Checkout plugin can only be called once"
 msgstr ""
 
 #: includes/class-wc-gateway-ppec-plugin.php:237
-msgid "<p>PayPal&nbsp;Checkout with new <strong>Smart&nbsp;Payment&nbsp;Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be deprecated and removed</strong> in the <strong>next</strong> release. Upgrade to Smart&nbsp;Payment&nbsp;Buttons in the <a href=\"%s\">PayPal&nbsp;Checkout settings</a>.</p>"
+msgid "<p>PayPal Checkout with new <strong>Smart Payment Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be removed</strong> in the <strong>next release</strong>. Please upgrade to Smart Payment Buttons on the <a href=\"%s\">PayPal Checkout settings page</a>.</p>"
 msgstr ""
 
 #: includes/class-wc-gateway-ppec-plugin.php:275

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 
 = 1.6.18 - 2019-x-x =
 * Fix - Send fees to PayPal as line items
+* Add - Notice about legacy payment buttons deprecation
 
 = 1.6.17 - 2019-08-08 =
 * Update - WooCommerce 3.7 compatibility


### PR DESCRIPTION
Fixes #578 

We actually already had a notice implemented [here](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/commit/a8a8b56fe739b26f01ddb73420ff200c04c7fcd2):
<img width="1494" alt="Screenshot 2019-11-18 at 13 33 20" src="https://user-images.githubusercontent.com/800604/69058024-c76d4800-0a0a-11ea-939e-6bb01ed9acb8.png">
It was shown if:
* PPEC is enabled
* Smart Payment Buttons are disabled
* `wc_gateway_ppec_spb_notice_dismissed` option is not in the db or is not set to `yes`

I changed the notice to the following to emphasize that the buttons are going away in the next release:
<img width="1503" alt="Screenshot 2019-11-18 at 13 56 49" src="https://user-images.githubusercontent.com/800604/69058287-4b273480-0a0b-11ea-9da0-e465c3d77043.png">
It is still shown if PPEC is enabled but the buttons are disabled, but now it is also red and not dismissible. The only way to get rid of it is to enable Smart Payment Buttons.
