### PR TITLE
Use order currency when renewing subscription

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Fix error 10426 when coupons are used
 * Fix - Call to a member function has_session() on null
 * Add - Notice about legacy payment buttons deprecation
+* Fix - Use order currency when renewing subscription instead of store currency
 
 = 1.6.17 - 2019-08-08 =
 * Update - WooCommerce 3.7 compatibility

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -1047,7 +1047,7 @@ class WC_Gateway_PPEC_Client {
 			'SHIPDISCAMT'   => $details['ship_discount_amount'],
 			'INSURANCEAMT'  => 0,
 			'HANDLINGAMT'   => 0,
-			'CURRENCYCODE'  => get_woocommerce_currency(),
+			'CURRENCYCODE'  => $old_wc ? $order->order_currency : $order->get_currency(),
 			'NOTIFYURL'     => WC()->api_request_url( 'WC_Gateway_PPEC' ),
 			'PAYMENTACTION' => $settings->get_paymentaction(),
 			'INVNUM'        => $settings->invoice_prefix . $order->get_order_number(),

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 * Fix - Fix error 10426 when coupons are used
 * Fix - Call to a member function has_session() on null
 * Add - Notice about legacy payment buttons deprecation
+* Fix - Use order currency when renewing subscription instead of store currency
 
 = 1.6.17 - 2019-08-08 =
 * Update - WooCommerce 3.7 compatibility


### PR DESCRIPTION
Fixes #607 

## Steps to reproduce

I was not able to reproduce this with any currency-switching plugin. In fact, it looks like the pro version of `WooCommerce Price Based on Country` correctly filters the currency when renewing. So, here are steps to reproduce by manually switching the site currency:

0) You may want to change your PayPal sandbox merchant account settings to automatically allow multicurrency purchases. You can do that by logging in to https://sandbox.paypal.com using your sandbox merchant account. Then go to https://www.sandbox.paypal.com/businessmanage/preferences/payments which is found at Settings Gear Icon > Account Settings > Payment preferences (in the sidebar) > Block payments (click the update link). Select "Yes, accept and convert them to U.S. Dollars." on that page after the JS is fully loaded. It'll save the settings inline.
1) Check out with a subscription
2) Change your store currency to something different at WooCommerce > Settings > General (`wp-admin/admin.php?page=wc-settings`)
3) Renew the subscription manually using the 'Process renewal' in the 'Subscription actions' drop down menu

In the master branch, you'll see the renewal order go through in the store currency. In this branch, you'll see it go through using the original order currency.

You can check this in your sandbox paypal dashboard: https://www.sandbox.paypal.com/listing/transactions

<img width="1175" alt="renewal-sub-transactions" src="https://user-images.githubusercontent.com/11487924/69099117-fba33180-0a27-11ea-85bd-174813de641b.png">

## Notes and considerations

I think it's safe to assume that the renewal transaction should happen using the same currency as the original transaction.

Are there scenarios where this isn't true? If so, it's likely the store owner is using some fancy way of renewing, and they should be able to change the currency using that fancy way.

`get_do_reference_transaction_params` isn't used elsewhere, so we don't have to worry about it.

There are no other places where we try to figure out the subscription currency code, so this is a complete solution 👍