### PR TITLE
Handle subscription payment change

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -366,7 +366,9 @@ class WC_Gateway_PPEC_Client {
 			$query_args['create-billing-agreement'] = 'true';
 		}
 
-		return add_query_arg( $query_args, wc_get_checkout_url() );
+		$url = add_query_arg( $query_args, wc_get_checkout_url() );
+		$order_id = $context_args['order_id'];
+		return apply_filters( 'woocommerce_paypal_express_checkout_set_express_checkout_params_get_return_url', $url, $order_id);
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -255,7 +255,7 @@ class WC_Gateway_PPEC_Client {
 		$params['PAGESTYLE'] = $settings->page_style;
 		$params['BRANDNAME'] = $settings->get_brand_name();
 		$params['RETURNURL'] = $this->_get_return_url( $args );
-		$params['CANCELURL'] = $this->_get_cancel_url();
+		$params['CANCELURL'] = $this->_get_cancel_url( $args );
 
 		if ( wc_gateway_ppec_is_using_credit() ) {
 			$params['USERSELECTEDFUNDINGSOURCE'] = 'Finance';
@@ -380,8 +380,10 @@ class WC_Gateway_PPEC_Client {
 	 *
 	 * @return string Cancel URL
 	 */
-	protected function _get_cancel_url() {
-		return add_query_arg( 'woo-paypal-cancel', 'true', wc_get_cart_url() );
+	protected function _get_cancel_url( $context_args ) {
+		$url = add_query_arg( 'woo-paypal-cancel', 'true', wc_get_cart_url() );
+		$order_id = $context_args['order_id'];
+		return apply_filters( 'woocommerce_paypal_express_checkout_set_express_checkout_params_get_cancel_url', $url, $order_id );
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-with-paypal-addons.php
+++ b/includes/class-wc-gateway-ppec-with-paypal-addons.php
@@ -39,6 +39,15 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 
 		add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, array( $this, 'scheduled_subscription_payment' ), 10, 2 );
 		add_action( 'woocommerce_subscription_failing_payment_method_' . $this->id, array( $this, 'update_failing_payment_method' ) );
+
+		// When changing the payment method for a WooCommerce Subscription to PayPal Checkout, let WooCommerce Subscription
+		// know that the payment method for that subscription should not be changed immediately. Instead, it should
+		// wait for the IPN notification, after the user confirmed the payment method change with PayPal.
+		add_filter( 'woocommerce_subscriptions_update_payment_via_pay_shortcode', array( $this, 'indicate_async_payment_method_update' ), 10, 3 );
+
+		// Add extra parameter when updating the subscription payment method to PayPal.
+		add_filter( 'woocommerce_paypal_express_checkout_set_express_checkout_params_get_return_url', array( $this, 'add_query_param_to_url_subscription_payment_method_change' ), 10, 2 );
+		add_filter( 'woocommerce_paypal_express_checkout_set_express_checkout_params_get_cancel_url', array( $this, 'add_query_param_to_url_subscription_payment_method_change' ), 10, 2 );
 	}
 
 	/**
@@ -55,6 +64,31 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 	}
 
 	/**
+	 * Checks whether the order associated with the given order_id is
+	 * for changing a payment method for a WooCommerce Subscription.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param int $order_id Order ID.
+	 *
+	 * @return bool Returns true if the order is changing the payment method for a subscription.
+	 */
+	private function is_order_changing_payment_method_for_subscription( $order_id ) {
+		$order = wc_get_order( $order_id );
+		return (
+			is_callable( array( $order, 'get_type' ) )
+			&& 'shop_subscription' === $order->get_type()
+			&& isset( $_POST['_wcsnonce'] )
+			&& wp_verify_nonce( sanitize_key( $_POST['_wcsnonce'] ), 'wcs_change_payment_method' )
+			&& isset( $_POST['woocommerce_change_payment'] )
+			&& $order->get_id() === absint( $_POST['woocommerce_change_payment'] )
+			&& isset( $_GET['key'] )
+			&& $order->get_order_key() === $_GET['key']
+			&& 0 === $order->get_total() // WooCommerce Subscriptions uses $0 orders to update payment method for the subscription.
+		);
+	}
+
+	/**
 	 * Process payment.
 	 *
 	 * @since 1.2.0
@@ -65,6 +99,11 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 	 */
 	public function process_payment( $order_id ) {
 		if ( $this->is_subscription( $order_id ) ) {
+			// Is this a subscription payment method change?
+			if ( $this->is_order_changing_payment_method_for_subscription( $order_id ) ) {
+				return $this->change_subscription_payment_method( $order_id );
+			}
+			// Otherwise, it's a subscription payment.
 			return $this->process_subscription( $order_id );
 		}
 
@@ -200,5 +239,77 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 	 */
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
 		update_post_meta( is_callable( array( $subscription, 'get_id' ) ) ? $subscription->get_id() : $subscription->id, '_ppec_billing_agreement_id', $renewal_order->ppec_billing_agreement_id );
+	}
+
+	/**
+	 * Indicate to WooCommerce Subscriptions that the payment method change for PayPal Checkout
+	 * should be asynchronous.
+	 *
+	 * WC_Subscriptions_Change_Payment_Gateway::change_payment_method_via_pay_shortcode uses the
+	 * result to decide whether or not to change the payment method information on the subscription
+	 * right away or not.
+	 *
+	 * In our case, the payment method will not be updated until after the user confirms the
+	 * payment method change with PayPal. Once that's done, we'll take care of finishing
+	 * the payment method update with the subscription.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param bool            $should_update Current value of whether the payment method should be updated immediately.
+	 * @param string          $new_payment_method The new payment method name.
+	 * @param WC_Subscription $subscription The subscription whose payment method is being updated.
+	 *
+	 * @return boolean
+	 */
+	public function indicate_async_payment_method_update( $should_update, $new_payment_method, $subscription ) {
+		if ( 'ppec_paypal' === $new_payment_method ) {
+			$update = false;
+		}
+		return $update;
+	}
+
+	/**
+	 * Start the process to update the payment method for a WooCommerce Subscriptions.
+	 *
+	 * This function is called by `process_payment` when changing a payment method for WooCommerce Subscriptions.
+	 * When it's successful, `WC_Subscriptions_Change_Payment_Gateway::change_payment_method_via_pay_shortcode` will
+	 * redirect to the redirect URL provided and the user will be prompted to confirm the payment update.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param int $order_id Order ID.
+	 *
+	 * @return array Array used by WC_Subscriptions_Change_Payment_Gateway::change_payment_method_via_pay_shortcode.
+	 */
+	public function change_subscription_payment_method( $order_id ) {
+		try {
+			return array(
+				'result'   => 'success',
+				'redirect' => wc_gateway_ppec()->checkout->start_checkout_from_order( $order_id, false ),
+			);
+		} catch ( PayPal_API_Exception $e ) {
+			wc_add_notice( $e->getMessage(), 'error' );
+			return array(
+				'result' => 'failure',
+			);
+		}
+	}
+
+	/**
+	 * Add query param to return and cancel URLs when making a payment change for
+	 * a WooCommerce Subscription.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $url The original URL.
+	 * @param int    $order_id Order ID.
+	 *
+	 * @return string The new URL.
+	 */
+	public function add_query_param_to_url_subscription_payment_method_change( $url, $order_id ) {
+		if ( $this->is_order_changing_payment_method_for_subscription( $order_id ) ) {
+			return add_query_arg( 'update_subscription_payment_method', 'true', $url );
+		}
+		return $url;
 	}
 }

--- a/includes/class-wc-gateway-ppec-with-paypal-addons.php
+++ b/includes/class-wc-gateway-ppec-with-paypal-addons.php
@@ -43,7 +43,7 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 		// When changing the payment method for a WooCommerce Subscription to PayPal Checkout, let WooCommerce Subscription
 		// know that the payment method for that subscription should not be changed immediately. Instead, it should
 		// wait for the IPN notification, after the user confirmed the payment method change with PayPal.
-		add_filter( 'woocommerce_subscriptions_update_payment_via_pay_shortcode', array( $this, 'indicate_async_payment_method_update' ), 10, 3 );
+		add_filter( 'woocommerce_subscriptions_update_payment_via_pay_shortcode', array( $this, 'indicate_async_payment_method_update' ), 10, 2 );
 
 		// Add extra parameter when updating the subscription payment method to PayPal.
 		add_filter( 'woocommerce_paypal_express_checkout_set_express_checkout_params_get_return_url', array( $this, 'add_query_param_to_url_subscription_payment_method_change' ), 10, 2 );
@@ -255,17 +255,16 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 	 *
 	 * @since 1.7.0
 	 *
-	 * @param bool            $should_update Current value of whether the payment method should be updated immediately.
-	 * @param string          $new_payment_method The new payment method name.
-	 * @param WC_Subscription $subscription The subscription whose payment method is being updated.
+	 * @param bool   $should_update Current value of whether the payment method should be updated immediately.
+	 * @param string $new_payment_method The new payment method name.
 	 *
-	 * @return boolean
+	 * @return bool Whether the subscription's payment method should be updated on checkout or async when a response is returned.
 	 */
-	public function indicate_async_payment_method_update( $should_update, $new_payment_method, $subscription ) {
+	public function indicate_async_payment_method_update( $should_update, $new_payment_method ) {
 		if ( 'ppec_paypal' === $new_payment_method ) {
-			$update = false;
+			$should_update = false;
 		}
-		return $update;
+		return $should_update;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #551 

# Steps to test changes (happy path only, non-happy path is similar)

1. Create a subscription
2. Navigate to the subscription in the My Account page.
3. Click 'Change payment'.
4. Select PayPal Checkout
5. See that you are able to update the subscription payment method

# How the process works
- WooCommerce Subscription uses the function `WC_Subscriptions_Change_Payment_Gateway::change_payment_method_via_pay_shortcode` to handle payment changes, with a $0 charge
- This calls `process_payment` in our gateway
- We decide whether or not it's a subscription payment method change in `is_order_changing_payment_method_for_subscription` https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/640/files#diff-825815001892595d50e5e5eaacce96b5R76
- If it's a payment change, in `change_subscription_payment_method()` we send back the array expected by `WC_Subscriptions_Change_Payment_Gateway::change_payment_method_via_pay_shortcode`, including a redirect link to PayPal created by calling `wc_gateway_ppec()->checkout->start_checkout_from_order()`
- If `start_checkout_from_order` was successful (no exceptions were thrown), the array contains a redirect URL which `change_payment_method_via_pay_shortcode` redirects to
- At this point the user confirms with PayPal or cancels with paypal
- PayPal redirects back to the site using `RETURNURL` or `CANCELURL`, to which we added the query arg `update_subscription_payment_method ` in the hook `add_query_param_to_url_subscription_payment_method_change`
- When returning to the site, we handle a successful subscription payment change in `handle_subscription_payment_change_success`, which includes:
  - creating the billing agreement id
  - handling any exceptions by redirecting the user with an error
  - updating the payment method(s) using `update_payment_method` and `will_subscription_update_all_payment_methods`
  -  clearing all wc notices (this is to clear any errant notices from WooCommerce Subscriptions)
  - redirecting the user with a notice
- When returning to the site, we handle a successful subscription payment change in `handle_subscription_payment_change_failure` by doing nothing & redirecting the user with an error message

h/t @james-allan for outlining how the payment method change works in WooCommerce Subscriptions & with PayPal Standard 🙌 