### PR TITLE
Fix call to a member function has_session() on null

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.6.18 - 2019-x-x =
 * Fix - Send fees to PayPal as line items
 * Fix - Fix error 10426 when coupons are used
+* Fix - Call to a member function has_session() on null
 * Add - Notice about legacy payment buttons deprecation
 
 = 1.6.17 - 2019-08-08 =

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -509,13 +509,15 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * Creates a customer session if one is not already active.
 	 */
 	public function ensure_session() {
+		// TODO: this tries to replicate Woo core functionality of checking for frontend requests.
+		// It can be removed once we drop support for pre-3.5 versions.
 		$frontend = ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! defined( 'REST_REQUEST' );
 
 		if ( ! $frontend ) {
 			return;
 		}
 
-		if ( ! WC()->session->has_session() ) {
+		if ( ! empty( WC()->session ) && ! WC()->session->has_session() ) {
 			WC()->session->set_customer_session_cookie( true );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please use this to inform us about bugs, or make contributions via PRs.
 = 1.6.18 - 2019-x-x =
 * Fix - Send fees to PayPal as line items
 * Fix - Fix error 10426 when coupons are used
+* Fix - Call to a member function has_session() on null
 * Add - Notice about legacy payment buttons deprecation
 
 = 1.6.17 - 2019-08-08 =


### PR DESCRIPTION
Fixes #580 

The only way in which I could reproduce this was to add the following filter:
```
add_filter( 'woocommerce_is_rest_api_request', function ( $a ) {
	return true;
} );
```

Technically it's possible to add a plugin that modifies the REST paths and leads to this. 

The fix is both to use the same method as WC core is using to check for frontend requests (if REST is detected, then session is set to `null`). The `is_rest_api_request ` method was set to public only in the recent versions of core, so then we fall back to checking if session is not empty/falsey.