### PR TITLE
Check if order exists before adding order actions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.6.19 - 2020-xx-xx =
+* Fix - Check if order exists before adding order actions
+
 = 1.6.18 - 2019-12-05 =
 * Fix - Send fees to PayPal as line items
 * Fix - Fix error 10426 when coupons are used

--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -40,6 +40,10 @@ class WC_Gateway_PPEC_Admin_Handler {
 
 		$order = wc_get_order( $_REQUEST['post'] );
 
+		if ( empty( $order ) ) {
+			return $actions;
+		}
+
 		$old_wc         = version_compare( WC_VERSION, '3.0', '<' );
 		$order_id       = $old_wc ? $order->id : $order->get_id();
 		$payment_method = $old_wc ? $order->payment_method : $order->get_payment_method();


### PR DESCRIPTION
Fixes #652.

To reproduce:

1. Install AutomateWoo
2. Install Subscriptions
3. Install AutomateWoo -- Subscriptions Addon
4. Ensure PP Checkout is active
5. Create a new Workflow in AutomateWoo
   - Trigger: Subscription Order Paid
   - Subscription Order type: Parent
   - Action: Trigger Order Action
   - Order Action: Generate download permissions
6. Click "Save" to save the workflow.
7. With latest master, this triggers a fatal error:

```
2019-12-20T05:31:57+00:00 CRITICAL Uncaught Error: Call to a member function get_id() on bool in /nas/content/live/seventhrstage/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/includes/class-wc-gateway-ppec-admin-handler.php:44
Stack trace:
#0 /nas/content/live/seventhrstage/wp-includes/class-wp-hook.php(288): WC_Gateway_PPEC_Admin_Handler->add_capture_charge_order_action(Array)
#1 /nas/content/live/seventhrstage/wp-includes/plugin.php(206): WP_Hook->apply_filters(Array, Array)
#2 /nas/content/live/seventhrstage/wp-content/plugins/automatewoo/includes/actions/order-trigger-action.php(31): apply_filters('woocommerce_ord...', Array)
#3 /nas/content/live/seventhrstage/wp-content/plugins/automatewoo/includes/abstracts/action.php(239): AutomateWoo\Action_Order_Trigger_Action->load_fields()
#4 /nas/content/live/seventhrstage/wp-content/plugins/automatewoo/includes/abstracts/action.php(222): AutomateWoo\Action->get_fields()
#5 /nas/content/live/seventhrstage/wp-content/plugins/automatewoo/includes/workflow.php(970): AutomateWoo\Action in /nas/content/live/seventhrstage/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/includes/class-wc-gateway-ppec-admin-handler.php on line 44
```

Proposed fix resolves this error by checking if order exists for given post id.