### PR TITLE
Fixes error "Trying to get property of non-object" found during onboarding wizard

### DIFF
--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -450,11 +450,10 @@ class WC_Gateway_PPEC_Plugin {
 	 * @return bool
 	 */
 	public static function needs_shipping() {
-		$cart_contents  = WC()->cart->cart_contents;
 		$needs_shipping = false;
 
-		if ( ! empty( $cart_contents ) ) {
-			foreach ( $cart_contents as $cart_item_key => $values ) {
+		if ( ! empty( WC()->cart->cart_contents ) ) {
+			foreach ( WC()->cart->cart_contents as $cart_item_key => $values ) {
 				if ( $values['data']->needs_shipping() ) {
 					$needs_shipping = true;
 					break;


### PR DESCRIPTION
Fixes #639

### How to Reproduce

1. Run the WooCommerce setup wizard (on a fresh Woo install or [manually via the help tab](https://d.pr/i/09iGX9))
2. Make sure the PayPal gateway is selected under the Payment tab
3. Click the continue button
4. See the following error notice:

![](https://d.pr/i/Algrpd+)

### Issue

During the onboarding wizard, WooCommerce calls `WC_Countries->get_default_address_fields()` which PPEC is filtering inside [`WC_Gateway_PPEC_Checkout_Handler::filter_default_address_fields ()`](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/a6b4b195cdc41b5b94202d7acc63ad3e8abd4606/includes/class-wc-gateway-ppec-checkout-handler.php#L122)

`filter_default_address_fields` then calls [`WC_Gateway_PPEC_Plugin::needs_shipping()`](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/a6b4b195cdc41b5b94202d7acc63ad3e8abd4606/includes/class-wc-gateway-ppec-plugin.php#L452) which assumes `WC()->cart`  exists - causing the break :x:

We could look at updating `filter_default_address_fields` to not require checking `needs_shipping()` if there's no cart but that's potentially a breaking change. 

Here's the full stacktrace:

```
[07-Jan-2020 02:29:53 UTC] #0  WC_Gateway_PPEC_Plugin::needs_shipping() called at [/Users/matt/local/store/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/includes/class-wc-gateway-ppec-checkout-handler.php:127]
#1  WC_Gateway_PPEC_Checkout_Handler->filter_default_address_fields(Array ([first_name] => Array ([label] => First name,[required] => 1,[class] => Array ([0] => form-row-first),[autocomplete] => given-name,[priority] => 10),[last_name] => Array ([label] => Last name,[required] => 1,[class] => Array ([0] => form-row-last),[autocomplete] => family-name,[priority] => 20),[company] => Array ([label] => Company name,[class] => Array ([0] => form-row-wide),[autocomplete] => organization,[priority] => 30,[required] => ),[country] => Array ([type] => country,[label] => Country,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field,[2] => update_totals_on_change),[autocomplete] => country,[priority] => 40),[address_1] => Array ([label] => Street address,[placeholder] => House number and street name,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line1,[priority] => 50),[address_2] => Array ([placeholder] => Apartment, suite, unit etc. (optional),[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line2,[priority] => 60,[required] => ),[city] => Array ([label] => Town / City,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-level2,[priority] => 70),[state] => Array ([type] => state,[label] => State / County,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => state),[autocomplete] => address-level1,[priority] => 80),[postcode] => Array ([label] => Postcode / ZIP,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => postcode),[autocomplete] => postal-code,[priority] => 90))) called at [/Users/matt/local/store/wp-includes/class-wp-hook.php:288]
#2  WP_Hook->apply_filters(Array ([first_name] => Array ([label] => First name,[required] => 1,[class] => Array ([0] => form-row-first),[autocomplete] => given-name,[priority] => 10),[last_name] => Array ([label] => Last name,[required] => 1,[class] => Array ([0] => form-row-last),[autocomplete] => family-name,[priority] => 20),[company] => Array ([label] => Company name,[class] => Array ([0] => form-row-wide),[autocomplete] => organization,[priority] => 30,[required] => ),[country] => Array ([type] => country,[label] => Country,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field,[2] => update_totals_on_change),[autocomplete] => country,[priority] => 40),[address_1] => Array ([label] => Street address,[placeholder] => House number and street name,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line1,[priority] => 50),[address_2] => Array ([placeholder] => Apartment, suite, unit etc. (optional),[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line2,[priority] => 60,[required] => ),[city] => Array ([label] => Town / City,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-level2,[priority] => 70),[state] => Array ([type] => state,[label] => State / County,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => state),[autocomplete] => address-level1,[priority] => 80),[postcode] => Array ([label] => Postcode / ZIP,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => postcode),[autocomplete] => postal-code,[priority] => 90)), Array ([0] => Array ([first_name] => Array ([label] => First name,[required] => 1,[class] => Array ([0] => form-row-first),[autocomplete] => given-name,[priority] => 10),[last_name] => Array ([label] => Last name,[required] => 1,[class] => Array ([0] => form-row-last),[autocomplete] => family-name,[priority] => 20),[company] => Array ([label] => Company name,[class] => Array ([0] => form-row-wide),[autocomplete] => organization,[priority] => 30,[required] => ),[country] => Array ([type] => country,[label] => Country,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field,[2] => update_totals_on_change),[autocomplete] => country,[priority] => 40),[address_1] => Array ([label] => Street address,[placeholder] => House number and street name,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line1,[priority] => 50),[address_2] => Array ([placeholder] => Apartment, suite, unit etc. (optional),[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line2,[priority] => 60,[required] => ),[city] => Array ([label] => Town / City,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-level2,[priority] => 70),[state] => Array ([type] => state,[label] => State / County,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => state),[autocomplete] => address-level1,[priority] => 80),[postcode] => Array ([label] => Postcode / ZIP,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => postcode),[autocomplete] => postal-code,[priority] => 90)))) called at [/Users/matt/local/store/wp-includes/plugin.php:206]
#3  apply_filters(woocommerce_default_address_fields, Array ([first_name] => Array ([label] => First name,[required] => 1,[class] => Array ([0] => form-row-first),[autocomplete] => given-name,[priority] => 10),[last_name] => Array ([label] => Last name,[required] => 1,[class] => Array ([0] => form-row-last),[autocomplete] => family-name,[priority] => 20),[company] => Array ([label] => Company name,[class] => Array ([0] => form-row-wide),[autocomplete] => organization,[priority] => 30,[required] => ),[country] => Array ([type] => country,[label] => Country,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field,[2] => update_totals_on_change),[autocomplete] => country,[priority] => 40),[address_1] => Array ([label] => Street address,[placeholder] => House number and street name,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line1,[priority] => 50),[address_2] => Array ([placeholder] => Apartment, suite, unit etc. (optional),[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-line2,[priority] => 60,[required] => ),[city] => Array ([label] => Town / City,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[autocomplete] => address-level2,[priority] => 70),[state] => Array ([type] => state,[label] => State / County,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => state),[autocomplete] => address-level1,[priority] => 80),[postcode] => Array ([label] => Postcode / ZIP,[required] => 1,[class] => Array ([0] => form-row-wide,[1] => address-field),[validate] => Array ([0] => postcode),[autocomplete] => postal-code,[priority] => 90))) called at [/Users/matt/local/store/wp-content/plugins/woocommerce/includes/class-wc-countries.php:709]
#4  WC_Countries->get_default_address_fields() called at [/Users/matt/local/store/wp-content/plugins/woocommerce/includes/class-wc-countries.php:1297]
#5  WC_Countries->get_country_locale() called at [/Users/matt/local/store/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php:236]
#6  WC_Admin_Setup_Wizard->get_postcodes() called at [/Users/matt/local/store/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php:214]
#7  WC_Admin_Setup_Wizard->enqueue_scripts() called at [/Users/matt/local/store/wp-includes/class-wp-hook.php:288]
#8  WP_Hook->apply_filters(, Array ([0] => )) called at [/Users/matt/local/store/wp-includes/class-wp-hook.php:312]
#9  WP_Hook->do_action(Array ([0] => )) called at [/Users/matt/local/store/wp-includes/plugin.php:478]
#10 do_action(admin_enqueue_scripts) called at [/Users/matt/local/store/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php:357]
#11 WC_Admin_Setup_Wizard->setup_wizard_header() called at [/Users/matt/local/store/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php:311]
#12 WC_Admin_Setup_Wizard->setup_wizard() called at [/Users/matt/local/store/wp-includes/class-wp-hook.php:288]
#13 WP_Hook->apply_filters(, Array ([0] => )) called at [/Users/matt/local/store/wp-includes/class-wp-hook.php:312]
#14 WP_Hook->do_action(Array ([0] => )) called at [/Users/matt/local/store/wp-includes/plugin.php:478]
#15 do_action(admin_init) called at [/Users/matt/local/store/wp-admin/admin.php:170]
#16 require_once(/Users/matt/local/store/wp-admin/admin.php) called at [/Users/matt/local/store/wp-admin/index.php:10]
#17 require(/Users/matt/local/store/wp-admin/index.php) called at [/Users/matt/.composer/vendor/weprovide/valet-plus/server.php:117]
```