### PR TITLE
Add locales and mapping

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -60,6 +60,46 @@ class WC_Gateway_PPEC_Settings {
 	);
 
 	/**
+	 * Mapping between WP locale codes and PayPal locale codes
+	 *
+	 * @var bool
+	 */
+	protected $_locales_mapping = array(
+		'ar'             => 'ar_EG',
+		'arq'            => 'ar_EG',
+		'ary'            => 'ar_EG',
+		'de_AT'          => 'de_DE',
+		'de_CH'          => 'de_DE',
+		'de_CH_informal' => 'de_DE',
+		'de_DE_formal'   => 'de_DE',
+		'el'             => 'el_GR',
+		'es_AR'          => 'es_ES',
+		'es_CL'          => 'es_ES',
+		'es_CO'          => 'es_ES',
+		'es_CR'          => 'es_ES',
+		'es_DO'          => 'es_ES',
+		'es_GT'          => 'es_ES',
+		'es_HN'          => 'es_ES',
+		'es_MX'          => 'es_ES',
+		'es_PE'          => 'es_ES',
+		'es_PR'          => 'es_ES',
+		'es_ES'          => 'es_ES',
+		'es_UY'          => 'es_ES',
+		'es_VE'          => 'es_ES',
+		'fi'             => 'fi_FI',
+		'fr_BE'          => 'fr_FR',
+		'ja'             => 'ja_JP',
+		'nb_NO'          => 'no_NO',
+		'nn_NO'          => 'no_NO',
+		'nl_BE'          => 'nl_NL',
+		'nl_NL_formal'   => 'nl_NL',
+		'pt_AO'          => 'pt_PT',
+		'pt_PT_ao90'     => 'pt_PT',
+		'th'             => 'th_TH',
+		'zh_SG'          => 'zh_SG',
+	);
+
+	/**
 	 * Flag to indicate setting has been loaded from DB.
 	 *
 	 * @var bool
@@ -356,8 +396,13 @@ class WC_Gateway_PPEC_Settings {
 			} else {
 				$locale = 'en_US';
 			}
-		} else if ( ! in_array( $locale, $this->_supported_locales ) ) {
-			$locale = 'en_US';
+		} elseif ( ! in_array( $locale, $this->_supported_locales ) ) {
+			// Mapping some WP locales to PayPal locales
+			if ( isset( $this->_locales_mapping[ $locale ] ) ) {
+				$locale = $this->_locales_mapping[ $locale ];
+			} else {
+				$locale = 'en_US';
+			}
 		}
 
 		return apply_filters( 'woocommerce_paypal_express_checkout_paypal_locale', $locale );

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -52,7 +52,6 @@ class WC_Gateway_PPEC_Settings {
 		'sk_SK',
 		'sv_SE',
 		'th_TH',
-		'tr_TR', // Not supported
 		'zh_CN',
 		'zh_HK',
 		'zh_TW',

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -22,30 +22,41 @@ class WC_Gateway_PPEC_Settings {
 	 * @var array
 	 */
 	protected $_supported_locales = array(
+		'ar_EG',
+		'cs_CZ',
 		'da_DK',
 		'de_DE',
+		'el_GR',
 		'en_AU',
+		'en_IN',
 		'en_GB',
 		'en_US',
 		'es_ES',
+		'es_XC',
+		'fi_FI',
 		'fr_CA',
 		'fr_FR',
+		'fr_XC',
 		'he_IL',
+		'hu_HU',
 		'id_ID',
 		'it_IT',
 		'ja_JP',
+		'ko_KR',
 		'nl_NL',
 		'no_NO',
 		'pl_PL',
 		'pt_BR',
 		'pt_PT',
 		'ru_RU',
+		'sk_SK',
 		'sv_SE',
 		'th_TH',
-		'tr_TR',
+		'tr_TR', // Not supported
 		'zh_CN',
 		'zh_HK',
 		'zh_TW',
+		'zh_XC',
 	);
 
 	/**

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -61,7 +61,7 @@ class WC_Gateway_PPEC_Settings {
 	/**
 	 * Mapping between WP locale codes and PayPal locale codes
 	 *
-	 * @var bool
+	 * @var array
 	 */
 	protected $_locales_mapping = array(
 		'ar'             => 'ar_EG',
@@ -95,7 +95,7 @@ class WC_Gateway_PPEC_Settings {
 		'pt_AO'          => 'pt_PT',
 		'pt_PT_ao90'     => 'pt_PT',
 		'th'             => 'th_TH',
-		'zh_SG'          => 'zh_SG',
+		'zh_SG'          => 'zh_CN',
 	);
 
 	/**


### PR DESCRIPTION
Fixes #480 

**Description**
When the WP locale does not have an exact equivalent PayPal locale, the PayPal checkout process defaults to _en_US_. While this is acceptable for certain cases, there are cases where a locales mapping can give a better choice for PayPal locale.

Firstly, there are more [supported locale codes](https://developer.paypal.com/docs/api/reference/locale-codes/#supported-locale-codes)(34) by PayPal now than in the master branch(24). I have added these. 

One of the existing locale codes, _tr_TR_ is not in the list of supported locale codes. So, I have removed it. I am not certain about this.

I have added a locales_mapping that maps WP locale codes to PayPal locale codes for some of the obvious cases.

**Steps to Test**

1. In the WordPress General Settings, change the Site Language to 'Français' and save.
2. Now, add any product to the cart and click on the PayPal button. 
3. The language in the popup is French: https://d.pr/i/gVuKDO
4. Now, change the Site Language to 'Français de Belgique' and save.
5. Now, add any product to the cart and click on the PayPal button. 
6. On master, the language in the popup is en_US English(https://d.pr/i/zA6Iae) while on this branch it is French(https://d.pr/i/sPJE6O).

In combination with the `woocommerce_paypal_express_checkout_paypal_locale` filter, any wp locale code can be mapped to an appropriate PayPal locale code with this fix.

Closes #480