### PR TITLE
Remove Smart Payment Button setting and treat as enabled by default

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -27,6 +27,9 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$this->init_form_fields();
 		$this->init_settings();
 
+		// With 1.7.0, override the use_spb option pulled from the DB to the value set in WC_Gateway_PPEC_Settings
+		$this->settings['use_spb'] = wc_gateway_ppec()->settings->use_spb;
+
 		$this->title        = $this->method_title;
 		$this->description  = '';
 		$this->enabled      = $this->get_option( 'enabled', 'yes' );

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -18,10 +18,6 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$this->method_title       = __( 'PayPal Checkout', 'woocommerce-gateway-paypal-express-checkout' );
 		$this->method_description = __( 'Allow customers to conveniently checkout directly with PayPal.', 'woocommerce-gateway-paypal-express-checkout' );
 
-		if ( empty( $_GET['woo-paypal-return'] ) && 'yes' !== $this->get_option( 'use_spb' ) ) {
-			$this->order_button_text  = __( 'Continue to payment', 'woocommerce-gateway-paypal-express-checkout' );
-		}
-
 		wc_gateway_ppec()->ips->maybe_received_credentials();
 
 		$this->init_form_fields();
@@ -58,6 +54,10 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$this->paymentaction              = $this->get_option( 'paymentaction', 'sale' );
 		$this->subtotal_mismatch_behavior = $this->get_option( 'subtotal_mismatch_behavior', 'add' );
 		$this->use_ppc                    = false;
+
+		if ( empty( $_GET['woo-paypal-return'] ) && 'yes' !== $this->get_option( 'use_spb', 'yes' ) ) {
+			$this->order_button_text = __( 'Continue to payment', 'woocommerce-gateway-paypal-express-checkout' );
+		}
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -450,7 +450,7 @@ class WC_Gateway_PPEC_Plugin {
 	 * @deprecated 1.7.0
 	 */
 	public function show_spb_notice() {
-		_deprecated_function( __METHOD__, '1.7.0', '' );
+		_deprecated_function( __METHOD__, '1.7.0' );
 
 		// Should only show when PPEC is enabled but not in SPB mode.
 		if ( 'yes' !== $this->settings->enabled || 'yes' === $this->settings->use_spb ) {

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -220,28 +220,6 @@ class WC_Gateway_PPEC_Plugin {
 		}
 	}
 
-	public function show_spb_notice() {
-		// Should only show when PPEC is enabled but not in SPB mode.
-		if ( 'yes' !== $this->settings->enabled || 'yes' === $this->settings->use_spb ) {
-			return;
-		}
-
-		// Should only show on WooCommerce screens, the main dashboard, and on the plugins screen (as in WC_Admin_Notices).
-		$screen    = get_current_screen();
-		$screen_id = $screen ? $screen->id : '';
-		if ( ! in_array( $screen_id, wc_get_screen_ids(), true ) && 'dashboard' !== $screen_id && 'plugins' !== $screen_id ) {
-			return;
-		}
-
-		$setting_link = $this->get_admin_setting_link();
-		$message = sprintf( __( '<p>PayPal Checkout with new <strong>Smart Payment Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be removed</strong> in the <strong>next release</strong>. Please upgrade to Smart Payment Buttons on the <a href="%s">PayPal Checkout settings page</a>.</p>', 'woocommerce-gateway-paypal-express-checkout' ), esc_url( $setting_link ) );
-		?>
-		<div class="notice notice-error">
-			<?php echo wp_kses( $message, array( 'a' => array( 'href' => array() ), 'strong' => array(), 'p' => array() ) ); ?>
-		</div>
-		<?php
-	}
-
 	/**
 	 * AJAX handler for dismiss notice action.
 	 *
@@ -320,7 +298,6 @@ class WC_Gateway_PPEC_Plugin {
 	protected function _run() {
 		require_once( $this->includes_path . 'functions.php' );
 		$this->_load_handlers();
-		add_action( 'admin_notices', array( $this, 'show_spb_notice' ) );
 	}
 
 	/**
@@ -462,5 +439,37 @@ class WC_Gateway_PPEC_Plugin {
 		}
 
 		return apply_filters( 'woocommerce_cart_needs_shipping', $needs_shipping );
+	}
+
+	/* Deprecated Functions */
+
+	/**
+	 * Shows an admin notice notifying store managers that support for non-spb
+	 * on the checkout is being removed in 1.7.0
+	 *
+	 * @deprecated 1.7.0
+	 */
+	public function show_spb_notice() {
+		_deprecated_function( __METHOD__, '1.7.0', '' );
+
+		// Should only show when PPEC is enabled but not in SPB mode.
+		if ( 'yes' !== $this->settings->enabled || 'yes' === $this->settings->use_spb ) {
+			return;
+		}
+
+		// Should only show on WooCommerce screens, the main dashboard, and on the plugins screen (as in WC_Admin_Notices).
+		$screen    = get_current_screen();
+		$screen_id = $screen ? $screen->id : '';
+		if ( ! in_array( $screen_id, wc_get_screen_ids(), true ) && 'dashboard' !== $screen_id && 'plugins' !== $screen_id ) {
+			return;
+		}
+
+		$setting_link = $this->get_admin_setting_link();
+		$message = sprintf( __( '<p>PayPal Checkout with new <strong>Smart Payment Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be removed</strong> in the <strong>next release</strong>. Please upgrade to Smart Payment Buttons on the <a href="%s">PayPal Checkout settings page</a>.</p>', 'woocommerce-gateway-paypal-express-checkout' ), esc_url( $setting_link ) );
+		?>
+		<div class="notice notice-error">
+			<?php echo wp_kses( $message, array( 'a' => array( 'href' => array() ), 'strong' => array(), 'p' => array() ) ); ?>
+		</div>
+		<?php
 	}
 }

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -89,8 +89,9 @@ class WC_Gateway_PPEC_Settings {
 		if ( $this->_is_setting_loaded && ! $force_reload ) {
 			return $this;
 		}
-		$this->_settings          = (array) get_option( 'woocommerce_ppec_paypal_settings', array() );
-		$this->_is_setting_loaded = true;
+		$this->_settings            = (array) get_option( 'woocommerce_ppec_paypal_settings', array() );
+		$this->_settings['use_spb'] = ! apply_filters( 'woocommerce_paypal_express_checkout_disable_smart_payment_buttons', false, $this ) ? 'yes' : 'no';
+		$this->_is_setting_loaded   = true;
 		return $this;
 	}
 

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -59,6 +59,9 @@ wc_enqueue_js( "
 		var enable_toggle         = $( 'a.ppec-toggle-settings' ).length > 0;
 		var enable_sandbox_toggle = $( 'a.ppec-toggle-sandbox-settings' ).length > 0;
 
+		// as of v1.7.0 this option is enabled by default, but can be modified using a filter. Hiding the checkbox will let the settings page hide/show the correct settings depending on whether spb is enabled or disabled
+		$( '#woocommerce_ppec_paypal_use_spb' ).closest( 'tr' ).hide();
+
 		$( '#woocommerce_ppec_paypal_environment' ).change(function(){
 			$( ppec_sandbox_fields + ',' + ppec_live_fields ).closest( 'tr' ).hide();
 


### PR DESCRIPTION
Fixes #579

This PR removes the smart payment button (SPB) option from the PPEC settings page and treats it as enabled by default for all stores.

**changes**
- Inside [`WC_Gateway_PPEC::__construct()`](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/2c9bde786cf0ddff47a13d40a891caf15b7c8a59/includes/abstracts/abstract-wc-gateway-ppec.php#L27) and on [`WC_Gateway_PPEC_Settings::load`](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/01f18d6734f97a8930528c00573846de686a8772/includes/class-wc-gateway-ppec-settings.php#L88), manually set/override the value of `use_spb` option to be always `'yes'` (this can be filtered to continue using legacy checkout buttons)
- Hide the Smart Payment button option from the settings page
- Remove the notice from 1.6.18 notifying store admins that SPB are going to become the default.

**testing**

Use this filter to test the legacy checkout buttons:

```
add_filter( 'woocommerce_paypal_express_checkout_disable_smart_payment_buttons', '__return_true' );
```

Here's what I've checked:
- settings page with SPB enabled and disabled using the filter ✅
  - The settings page behaves exactly the same as before except the SPB option is not visible.
- Standard Checkout process (both SPB enabled and disabled with filter)
- Checkout from Cart page (both SPB enabled and disabled) ✅ 
- Checkout from the Product page (both SPB enabled and disabled) ✅
- Third-party code using `WC()->payment_gateways->get_available_payment_gateways()['ppec_paypal']->settings['use_spb']` (like in the [RN helper](https://github.com/woocommerce/robot-ninja-helper/blob/76ae3c68f8b775dab6c486dada31ea5b1ca09abf/includes/class-rn-gateway-settings.php#L265)) continue to work as expected (spb set to 'yes' by default unless filtered) ✅