### PR TITLE
If cart total is 0 do not show PP buttons in mini cart

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -351,7 +351,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		$settings = wc_gateway_ppec()->settings;
 
 		// billing details on checkout page to calculate shipping costs
-		if ( ! isset( $gateways['ppec_paypal'] ) || 'no' === $settings->cart_checkout_enabled || 0 === WC()->cart->get_cart_contents_count() ) {
+		if ( ! isset( $gateways['ppec_paypal'] ) || 'no' === $settings->cart_checkout_enabled || 0 === WC()->cart->get_cart_contents_count() || '0.00' === WC()->cart->get_total( 'edit' ) ) {
 			return;
 		}
 		?>

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -351,7 +351,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		$settings = wc_gateway_ppec()->settings;
 
 		// billing details on checkout page to calculate shipping costs
-		if ( ! isset( $gateways['ppec_paypal'] ) || 'no' === $settings->cart_checkout_enabled || 0 === WC()->cart->get_cart_contents_count() || '0.00' === WC()->cart->get_total( 'edit' ) ) {
+		if ( ! isset( $gateways['ppec_paypal'] ) || 'no' === $settings->cart_checkout_enabled || 0 === WC()->cart->get_cart_contents_count() || ! WC()->cart->needs_payment() ) {
 			return;
 		}
 		?>


### PR DESCRIPTION
Fixes #635 

When a free product with free shipping is in the cart, the smart payment buttons are displayed in the mini cart. PayPal does not allow for zero payment and so these buttons should not be displayed.

I added an additional check for the cart total value not being 0 for displaying the PP buttons in the mini cart.

**Steps to test**
1. Create a product Z that has price set to 0.
2. Create two shipping methods for your region - free shipping and flat rate.
3. Enable Free shipping and disable flat rate shipping.
4. Add a product P that has a price > 0. Check the mini cart. The Smart Payment buttons are displayed.
5. Add Z to the cart. Remove P. Check the mini cart. On master, the Smart Payment buttons are displayed while on this branch, they are not displayed.
6. Disable Free shipping and enable Flat rate shipping.
7. Add a product P that has a price > 0. Check the mini cart. The Smart Payment buttons are displayed.
8. Add Z to the cart. Remove P. Check the mini cart. On both master and this branch, the Smart Payment buttons are displayed because there is a shipping cost involved.

Closes #635.