### PR TITLE
Display smart buttons in product page only if product is in stock

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -269,9 +269,11 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * @since 1.4.0
 	 */
 	public function display_paypal_button_product() {
+		global $product;
+
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) ) {
+		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || ! $product->is_in_stock() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #628 

When one of the products in a product bundle is out of stock, there is an appropriate message in the product page, the "Add to cart" button is not displayed, but the PayPal Smart buttons are displayed.

I have added a check for the stock status of the product before displaying the smart buttons. Though this check is redundant for simple products, for bundled products, this solves the issue.

**Steps to Test**
1. Install the Product Bundles plugin.
1. Create a bundled product BP with component products A,B and C: https://d.pr/i/gYc12o
1. Edit one of the component products and make it out of stock. Look at the product page: https://d.pr/i/fsURy8
1. On master, the Smart buttons are displayed, while on this branch, they are not.

Closes #628