### PR TITLE
Do not display smart buttons for external products and grouped products

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -273,7 +273,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || ! $product->is_in_stock() || $product->is_type( 'external' ) ) {
+		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || ! $product->is_in_stock() || $product->is_type( 'external' ) || $product->is_type( 'grouped' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -273,7 +273,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || ! $product->is_in_stock() ) {
+		if ( ! is_product() || ! isset( $gateways['ppec_paypal'] ) || ! $product->is_in_stock() || $product->is_type( 'external' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #460 and #478 

The smart buttons are displayed in the single product page of External/affiliate products and grouped product pages. Clicking on the smart button gives an error.

Along the lines of #662 I added a check for the product being of type external or grouped before the smart buttons are displayed.

**Steps to Test**
1. Create an external product EP
2. View the product page. 
3. Apart from the button that is linked to the external site, the PayPal smart buttons are also displayed on master. On this branch, the smart buttons are not displayed.
4. Repeat the above process for a grouped product.

Closes #460 and #478 