### PR TITLE
Check if product_page shortcode is present to find if it is a product page

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -432,18 +432,15 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * Frontend scripts
 	 */
 	public function enqueue_scripts() {
-		global $post;
-
 		$settings = wc_gateway_ppec()->settings;
 		$client   = wc_gateway_ppec()->client;
 
 		wp_enqueue_style( 'wc-gateway-ppec-frontend', wc_gateway_ppec()->plugin_url . 'assets/css/wc-gateway-ppec-frontend.css' );
 
-		$is_cart               = is_cart() && ! WC()->cart->is_empty() && 'yes' === $settings->cart_checkout_enabled;
-		$has_product_shortcode = is_singular( array( 'page' ) ) && has_shortcode( $post->post_content, 'product_page' );
-		$is_product            = ( is_product() || $has_product_shortcode ) && 'yes' === $settings->checkout_on_single_product_enabled;
-		$is_checkout           = is_checkout() && 'yes' === $settings->mark_enabled && ! wc_gateway_ppec()->checkout->has_active_session();
-		$page                  = $is_cart ? 'cart' : ( $is_product ? 'product' : ( $is_checkout ? 'checkout' : null ) );
+		$is_cart     = is_cart() && ! WC()->cart->is_empty() && 'yes' === $settings->cart_checkout_enabled;
+		$is_product  = ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) && 'yes' === $settings->checkout_on_single_product_enabled;
+		$is_checkout = is_checkout() && 'yes' === $settings->mark_enabled && ! wc_gateway_ppec()->checkout->has_active_session();
+		$page        = $is_cart ? 'cart' : ( $is_product ? 'product' : ( $is_checkout ? 'checkout' : null ) );
 
 		if ( 'yes' !== $settings->use_spb && $is_cart ) {
 			wp_enqueue_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -432,15 +432,18 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * Frontend scripts
 	 */
 	public function enqueue_scripts() {
+		global $post;
+
 		$settings = wc_gateway_ppec()->settings;
 		$client   = wc_gateway_ppec()->client;
 
 		wp_enqueue_style( 'wc-gateway-ppec-frontend', wc_gateway_ppec()->plugin_url . 'assets/css/wc-gateway-ppec-frontend.css' );
 
-		$is_cart     = is_cart() && ! WC()->cart->is_empty() && 'yes' === $settings->cart_checkout_enabled;
-		$is_product  = is_product() && 'yes' === $settings->checkout_on_single_product_enabled;
-		$is_checkout = is_checkout() && 'yes' === $settings->mark_enabled && ! wc_gateway_ppec()->checkout->has_active_session();
-		$page        = $is_cart ? 'cart' : ( $is_product ? 'product' : ( $is_checkout ? 'checkout' : null ) );
+		$is_cart               = is_cart() && ! WC()->cart->is_empty() && 'yes' === $settings->cart_checkout_enabled;
+		$has_product_shortcode = is_singular( array( 'page' ) ) && has_shortcode( $post->post_content, 'product_page' );
+		$is_product            = ( is_product() || $has_product_shortcode ) && 'yes' === $settings->checkout_on_single_product_enabled;
+		$is_checkout           = is_checkout() && 'yes' === $settings->mark_enabled && ! wc_gateway_ppec()->checkout->has_active_session();
+		$page                  = $is_cart ? 'cart' : ( $is_product ? 'product' : ( $is_checkout ? 'checkout' : null ) );
 
 		if ( 'yes' !== $settings->use_spb && $is_cart ) {
 			wp_enqueue_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );


### PR DESCRIPTION
Fixes #497 

A single product page created using the 'product_page' shortcode was not showing the PayPal smart buttons. 

The scripts for showing the smart buttons are enqueued based on several conditions, one of which is whether it is a product page. The `is_product()` function is used for this purpose but this returns false for the page created using shortcode. I added an additional check `$has_product_shortcode` which looks for the `product_page` shortcode in the content of the page.

**Steps to test**
1. Create a page with a product_page shortcode in the content for a particular product id existing in your installation. For example, if you have a product with id 45, then create a page with `[product_page id=45]` as content. Publish it.
2. View this product page. On master you can see that the PayPal smart buttons are not displayed but on this branch they are.

Closes #497 