### PR TITLE
Add a button label setting for the smart payment buttons

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -55,7 +55,6 @@
 		var prefix        = isMiniCart ? 'mini_cart_' : '';
 		var button_size   = wc_ppec_context[ prefix + 'button_size' ];
 		var button_layout = wc_ppec_context[ prefix + 'button_layout' ];
-		var button_label  = wc_ppec_context[ prefix + 'button_label' ];
 		var allowed       = wc_ppec_context[ prefix + 'allowed_methods' ];
 		var disallowed    = wc_ppec_context[ prefix + 'disallowed_methods' ];
 
@@ -80,9 +79,9 @@
 			style: {
 				color: wc_ppec_context.button_color,
 				shape: wc_ppec_context.button_shape,
+				label: wc_ppec_context.button_label,
 				layout: button_layout,
 				size: button_size,
-				label: button_label,
 				branding: true,
 				tagline: false,
 			},

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -383,7 +383,6 @@ class WC_Gateway_PPEC_Cart_Handler {
 	/**
 	 * Convert from settings to values expected by PayPal Button API:
 	 *   - 'small' button size only allowed if layout is 'vertical'.
-	 *   - 'label' only allowed if layout is 'vertical'.
 	 *   - 'disallowed' funding methods if layout is 'vertical'.
 	 *   - 'allowed' funding methods if layout is 'horizontal'.
 	 *   - Only allow PayPal Credit if supported.
@@ -399,12 +398,12 @@ class WC_Gateway_PPEC_Cart_Handler {
 		$data = array(
 			'button_layout'        => $settings->{ $prefix . 'button_layout' },
 			'button_size'          => $settings->{ $prefix . 'button_size' },
+			'button_label'         => $settings->{ $prefix . 'button_label' },
 			'hide_funding_methods' => $settings->{ $prefix . 'hide_funding_methods' },
 			'credit_enabled'       => $settings->{ $prefix . 'credit_enabled' },
 		);
 
 		$button_layout        = $data['button_layout'];
-		$data['button_label'] = 'horizontal' === $button_layout ? 'buynow' : null;
 		$data['button_size']  = 'vertical' === $button_layout && 'small' === $data['button_size']
 			? 'medium'
 			: $data['button_size'];
@@ -467,6 +466,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				'page'                 => $page,
 				'button_color'         => $settings->button_color,
 				'button_shape'         => $settings->button_shape,
+				'button_label'         => $settings->button_label,
 				'start_checkout_nonce' => wp_create_nonce( '_wc_ppec_start_checkout_nonce' ),
 				'start_checkout_url'   => WC_AJAX::get_endpoint( 'wc_ppec_start_checkout' ),
 			);

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -531,6 +531,20 @@ $settings = array(
 			'rect' => __( 'Rectangle', 'woocommerce-gateway-paypal-express-checkout' ),
 		),
 	),
+	'button_label' => array(
+		'title'       => __( 'Button Label', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type'        => 'select',
+		'class'       => 'wc-enhanced-select woocommerce_ppec_paypal_spb',
+		'default'     => 'paypal',
+		'desc_tip'    => true,
+		'description' => __( 'This controls the label on the primary button.', 'woocommerce-gateway-paypal-express-checkout' ),
+		'options'     => array(
+			'paypal'   => __( 'PayPal', 'woocommerce-gateway-paypal-express-checkout' ),
+			'checkout' => __( 'PayPal Checkout', 'woocommerce-gateway-paypal-express-checkout' ),
+			'buynow'   => __( 'PayPal Buy Now', 'woocommerce-gateway-paypal-express-checkout' ),
+			'pay'      => __( 'Pay with PayPal', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+	),
 );
 
 /**
@@ -561,6 +575,20 @@ $per_context_settings = array(
 			'small'      => __( 'Small', 'woocommerce-gateway-paypal-express-checkout' ),
 			'medium'     => __( 'Medium', 'woocommerce-gateway-paypal-express-checkout' ),
 			'large'      => __( 'Large', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+	),
+	'button_label' => array(
+		'title'       => __( 'Button Label', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type'        => 'select',
+		'class'       => 'wc-enhanced-select woocommerce_ppec_paypal_spb',
+		'default'     => 'paypal',
+		'desc_tip'    => true,
+		'description' => __( 'PayPal offers different labels on the "PayPal Checkout" buttons, allowing you to select a suitable label.)', 'woocommerce-gateway-paypal-express-checkout' ),
+		'options'     => array(
+			'paypal'   => __( 'PayPal', 'woocommerce-gateway-paypal-express-checkout' ),
+			'checkout' => __( 'PayPal Checkout', 'woocommerce-gateway-paypal-express-checkout' ),
+			'buynow'   => __( 'PayPal Buy Now', 'woocommerce-gateway-paypal-express-checkout' ),
+			'pay'      => __( 'Pay with PayPal', 'woocommerce-gateway-paypal-express-checkout' ),
 		),
 	),
 	'hide_funding_methods' => array(


### PR DESCRIPTION
Fixes #572 

The smart payment button can have a label. According to [documentation](https://developer.paypal.com/docs/archive/checkout/how-to/customize-button/?mark=label#label), there are some preset values that can be passed to get one of the available labels.
Currently, all these options are not available as a setting. In addition, the only hardcoded value is set for a horizontal layout only.

I added a button label setting with 4 of the 5 available options(I did not add the `installment` which is specific to two countries only), removed the restriction on vertical layout and passed these settings to PayPal for display on the buttons.

**Steps to Test**
1. On master, in the PPEC settings page, change the layout to Vertical and see that the corresponding PayPal button does not have the default label, whereas it is displayed for Horizontal.
2. On this branch, in the PPEC settings page, along with other style options, the button label setting is also shown as a dropdown box. Choosing on the values and saving it should show the corresponding labelled button in the frontend.

Closes #572 