### PR TITLE
Make checkout fields optional for virtual products only with PPEC

### DIFF
--- a/assets/js/wc-gateway-ppec-checkout-handler.js
+++ b/assets/js/wc-gateway-ppec-checkout-handler.js
@@ -1,0 +1,50 @@
+/* global wc_ppec_checkout_handler_context */
+;( function ( $, window, document ) {
+	'use strict';
+
+	// If the fields are optional, such as for a virtual product
+	if ( true == wc_ppec_checkout_handler_context.do_not_require_fields ) {
+
+		// Trigger for pre-selected gateway
+		$( '.woocommerce-checkout input[name="payment_method"]:checked' ).trigger( 'click' );
+
+		// When PPEC is selected
+		$( 'form.checkout' ).on( 'click', 'input[name="payment_method"]', function() {
+			var $not_required_fields = wc_ppec_checkout_handler_context.not_required_fields;
+			if ( 'payment_method_ppec_paypal' == $( '.woocommerce-checkout input[name="payment_method"]:checked' ).attr( 'id' ) ) {
+				// For each field not required
+				$.each( $not_required_fields, function( key, value ) {
+					var $field = $( 'form.checkout' ).find( 'label[for="' + value + '"]' );
+					if ( $field ) {
+						make_address_field_optional( $field );
+					}
+				} );
+			} else {
+				$.each( $not_required_fields, function( key, value ) {
+					var $field = $( 'form.checkout' ).find( 'label[for="' + value + '"]' );
+					if ( $field ) {
+						make_address_field_required( $field );
+					}
+				} );
+			}
+		} );
+
+		// When shipping is not needed, do not require address fields
+		var make_address_field_optional = function( field ) {
+			field.parent().removeClass( 'validate-required woocommerce-invalid woocommerce-invalid-required-field' );
+			field.find( 'abbr.required' ).remove();
+			if ( field.find( 'span.optional' ).length === 0 ) {
+				field.append( '<span class="optional">(optional)</span>' );
+			}
+		}
+
+		// When a different gateway selected, do not make fields optional (aka revert them)
+		var make_address_field_required = function( field ) {
+			field.find( 'span.optional' ).remove();
+			field.parent().addClass( 'validate-required' );
+			if (field.find( 'abbr.required' ).length === 0 ) {
+				field.append( '<abbr class="required" title="required">*</abbr>' );
+			}
+		}
+	}
+} ) ( jQuery, window, document );

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -153,15 +153,16 @@ class WC_Gateway_PPEC_Checkout_Handler {
 
 			$not_required_fields = array( 'billing_first_name', 'billing_last_name', 'billing_company', 'billing_address_1', 'billing_address_2', 'billing_city', 'billing_postcode', 'billing_country' );
 
+			// Only unset if not required and empty
 			foreach ( $not_required_fields as $not_required_field ) {
-				if ( array_key_exists( $not_required_field, $fields ) ) {
+				if ( array_key_exists( $not_required_field, $fields ) && ! empty( $fields[ $not_required_field ] ) ) {
 					unset( $fields[ $not_required_field ] );
 				}
 			}
 		}
 
 		// Regardless of shipping, PP doesn't have the county required (e.g. using Ireland without a county is acceptable)
-		if ( array_key_exists( 'billing_state', $fields ) ) {
+		if ( array_key_exists( 'billing_state', $fields ) && ! empty( $fields['billing_state'] ) ) {
 			unset( $fields['billing_state'] );
 		}
 

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -155,14 +155,14 @@ class WC_Gateway_PPEC_Checkout_Handler {
 
 			// Only unset if not required and empty
 			foreach ( $not_required_fields as $not_required_field ) {
-				if ( array_key_exists( $not_required_field, $fields ) && ! empty( $fields[ $not_required_field ] ) ) {
+				if ( array_key_exists( $not_required_field, $fields ) && empty( $fields[ $not_required_field ] ) ) {
 					unset( $fields[ $not_required_field ] );
 				}
 			}
 		}
 
 		// Regardless of shipping, PP doesn't have the county required (e.g. using Ireland without a county is acceptable)
-		if ( array_key_exists( 'billing_state', $fields ) && ! empty( $fields['billing_state'] ) ) {
+		if ( array_key_exists( 'billing_state', $fields ) && empty( $fields['billing_state'] ) ) {
 			unset( $fields['billing_state'] );
 		}
 


### PR DESCRIPTION
Issues #426, #456, #625  

### The Problem
When checking out with PPEC with a virtual product, all fields in checkout except email are optional. However, the issue was that the checkout fields would remain optional for other gateways.

This was occurring because the checkout fields were being filtered to be optional when loading the checkout, but this was not undone when other gateways were selected because the filtering had already occurred and there were no JS hooks to reload this.

### The Approach
This PR seeks to fix this issue with a couple parts.

**Front end**
The new JS should make it so that the address fields appear as either optional or required depending on which payment gateway is selected. It should also only make checkout fields optional for PPEC if no shipping is needed.

**Back end**
The back end changes how the checkout fields are filtered. Instead of using `woocommerce_default_address_fields` I have used `woocommerce_checkout_posted_data`. What is essentially happening is that the JS is taking care of how the fields appear, and this filter takes care of when that data is actually processed.

### Testing
- Try a few different versions of checkout - with virtual and physical and mixed products, logged in and guest, logged in to PayPal and not.
- When checking out, toggle the different payment gateway fields - have a couple available. Make sure that required fields appear as required when they should. Make sure that optional fields are only optional when they should be, notably all except email on PPEC.
- Make sure when checking out that required fields throw an error if they are not filled in and optional fields do not.
- Bonus: the filter `'woocommerce_paypal_express_checkout_address_not_required'` should be able to be used to always require billing fields.

### Questions
- Is this a good place to enqueue the scripts?
- Any hesitations about using `unset()`?
- Any hesitations about overall strategy?