### PR TITLE
Check sku exists before adding it as a parameter

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -332,8 +332,10 @@ class WC_Gateway_PPEC_Client {
 					'L_PAYMENTREQUEST_0_DESC' . $count   => ! empty( $values['description'] ) ? substr( strip_tags( $values['description'] ), 0, 127 ) : '',
 					'L_PAYMENTREQUEST_0_QTY' . $count    => $values['quantity'],
 					'L_PAYMENTREQUEST_0_AMT' . $count    => $values['amount'],
-					'L_PAYMENTREQUEST_0_NUMBER' . $count => $values['sku'],
 				);
+				if ( isset( $values['sku'] ) ) {
+					$line_item_params['L_PAYMENTREQUEST_0_NUMBER' . $count] = $values['sku'];
+				}
 
 				$params = array_merge( $params, $line_item_params );
 				$count++;
@@ -958,8 +960,10 @@ class WC_Gateway_PPEC_Client {
 					'L_PAYMENTREQUEST_0_DESC' . $count   => ! empty( $values['description'] ) ? strip_tags( $values['description'] ) : '',
 					'L_PAYMENTREQUEST_0_QTY' . $count    => $values['quantity'],
 					'L_PAYMENTREQUEST_0_AMT' . $count    => $values['amount'],
-					'L_PAYMENTREQUEST_0_NUMBER' . $count => $values['sku'],
 				);
+				if ( isset( $values['sku'] ) ) {
+					$line_item_params['L_PAYMENTREQUEST_0_NUMBER' . $count] = $values['sku'];
+				}
 
 				$params = array_merge( $params, $line_item_params );
 				$count++;

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -328,13 +328,14 @@ class WC_Gateway_PPEC_Client {
 			$count = 0;
 			foreach ( $details['items'] as $line_item_key => $values ) {
 				$line_item_params = array(
-					'L_PAYMENTREQUEST_0_NAME' . $count   => $values['name'],
-					'L_PAYMENTREQUEST_0_DESC' . $count   => ! empty( $values['description'] ) ? substr( strip_tags( $values['description'] ), 0, 127 ) : '',
-					'L_PAYMENTREQUEST_0_QTY' . $count    => $values['quantity'],
-					'L_PAYMENTREQUEST_0_AMT' . $count    => $values['amount'],
+					'L_PAYMENTREQUEST_0_NAME' . $count => $values['name'],
+					'L_PAYMENTREQUEST_0_DESC' . $count => ! empty( $values['description'] ) ? substr( strip_tags( $values['description'] ), 0, 127 ) : '',
+					'L_PAYMENTREQUEST_0_QTY' . $count  => $values['quantity'],
+					'L_PAYMENTREQUEST_0_AMT' . $count  => $values['amount'],
 				);
+
 				if ( isset( $values['sku'] ) ) {
-					$line_item_params['L_PAYMENTREQUEST_0_NUMBER' . $count] = $values['sku'];
+					$line_item_params[ 'L_PAYMENTREQUEST_0_NUMBER' . $count ] = $values['sku'];
 				}
 
 				$params = array_merge( $params, $line_item_params );
@@ -956,13 +957,14 @@ class WC_Gateway_PPEC_Client {
 			$count = 0;
 			foreach ( $details['items'] as $line_item_key => $values ) {
 				$line_item_params = array(
-					'L_PAYMENTREQUEST_0_NAME' . $count   => $values['name'],
-					'L_PAYMENTREQUEST_0_DESC' . $count   => ! empty( $values['description'] ) ? strip_tags( $values['description'] ) : '',
-					'L_PAYMENTREQUEST_0_QTY' . $count    => $values['quantity'],
-					'L_PAYMENTREQUEST_0_AMT' . $count    => $values['amount'],
+					'L_PAYMENTREQUEST_0_NAME' . $count => $values['name'],
+					'L_PAYMENTREQUEST_0_DESC' . $count => ! empty( $values['description'] ) ? strip_tags( $values['description'] ) : '',
+					'L_PAYMENTREQUEST_0_QTY' . $count  => $values['quantity'],
+					'L_PAYMENTREQUEST_0_AMT' . $count  => $values['amount'],
 				);
+
 				if ( isset( $values['sku'] ) ) {
-					$line_item_params['L_PAYMENTREQUEST_0_NUMBER' . $count] = $values['sku'];
+					$line_item_params[ 'L_PAYMENTREQUEST_0_NUMBER' . $count ] = $values['sku'];
 				}
 
 				$params = array_merge( $params, $line_item_params );


### PR DESCRIPTION

After #664, when a coupon is added to the cart with a product having sku, this error was thrown.

        Undefined index: sku in /app/public/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/includes/class-wc-gateway-ppec-client.php on line 335

I've added a check to see if the sku is set, before adding it as a parameter.

**Steps to test**
1. On 1.7_dev branch, add a product with sku and apply a coupon. Click on the PayPal button. This error is thrown in the debug log.
2. On this branch, this error should not be seen.