### PR TITLE
Display a WooCommerce pre 3.0 admin notice warning

### DIFF
--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -31,6 +31,7 @@ class WC_Gateway_PPEC_Admin_Handler {
 		add_action( 'load-woocommerce_page_wc-settings', array( $this, 'maybe_reset_api_credentials' ) );
 
 		add_action( 'woocommerce_admin_order_totals_after_total', array( $this, 'display_order_fee_and_payout' ) );
+		add_action( 'admin_notices', array( $this, 'show_wc_version_warning' ) );
 	}
 
 	public function add_capture_charge_order_action( $actions ) {
@@ -352,4 +353,42 @@ class WC_Gateway_PPEC_Admin_Handler {
 
 		<?php
 	}
+<<<<<<< HEAD
+=======
+
+	/**
+	 * Displays an admin notice for sites running a WC version pre 3.0.
+	 * The WC minimum supported version will be increased to WC 3.0 in Q1 2020.
+	 *
+	 * @since 1.6.19
+	 */
+	public static function show_wc_version_warning() {
+
+		if ( 'true' !== get_option( 'wc_ppec_display_wc_3_0_warning' ) ) {
+			return;
+		}
+
+		// Check if the notice needs to be dismissed.
+		$wc_updated = version_compare( WC_VERSION, '3.0', '>=' );
+		$dismissed  = isset( $_GET['wc_ppec_hide_3_0_notice'], $_GET['_wc_ppec_notice_nonce'] ) && wp_verify_nonce( $_GET['_wc_ppec_notice_nonce'], 'wc_ppec_hide_wc_notice_nonce' );
+
+		if ( $wc_updated || $dismissed ) {
+			delete_option( 'wc_ppec_display_wc_3_0_warning' );
+			return;
+		}
+		?>
+		<div class="error">
+			<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc_ppec_hide_3_0_notice', 'true' ), 'wc_ppec_hide_wc_notice_nonce', '_wc_ppec_notice_nonce' ) ); ?>" class="woocommerce-message-close notice-dismiss" style="position:relative;float:right;padding:9px 0px 9px 9px 9px;text-decoration:none;"></a>
+			<p>
+			<?php printf( __(
+				'%1$sWarning!%2$s PayPal Checkout will drop support for WooCommerce %3$s in a soon to be released update. To continue using PayPal Checkout please %4$supdate to %1$sWooCommerce 3.0%2$s or greater%5$s.', 'woocommerce-gateway-paypal-express-checkout' ),
+				'<strong>', '</strong>',
+				WC_VERSION,
+				'<a href="' . admin_url( 'plugins.php' ) . '">', '</a>'
+			); ?>
+			</p>
+		</div>
+		<?php
+	}
+>>>>>>> 9845c0b... fixup! Adds a do_action when the plugin is updated
 }

--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -353,8 +353,6 @@ class WC_Gateway_PPEC_Admin_Handler {
 
 		<?php
 	}
-<<<<<<< HEAD
-=======
 
 	/**
 	 * Displays an admin notice for sites running a WC version pre 3.0.
@@ -390,5 +388,4 @@ class WC_Gateway_PPEC_Admin_Handler {
 		</div>
 		<?php
 	}
->>>>>>> 9845c0b... fixup! Adds a do_action when the plugin is updated
 }

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -133,6 +133,12 @@ class WC_Gateway_PPEC_Plugin {
 			delete_option( 'pp_woo_enabled' );
 		}
 
+		// Check the the WC version on plugin update to determine if we need to display a warning.
+		// The option was added in 1.6.19 so we only need to check stores updating from before that version. Updating from 1.6.19 or greater would already have it set.
+		if ( version_compare( get_option( 'wc_ppec_version' ), '1.6.19', '<' ) && version_compare( WC_VERSION, '3.0', '<' ) ) {
+			update_option( 'wc_ppec_display_wc_3_0_warning', 'true' );
+		}
+
 		update_option( 'wc_ppec_version', $new_version );
 	}
 


### PR DESCRIPTION
## Description

This PR adds an admin notice for sites running a WC version pre 3.0, after they update to 1.6.19 (the next release).

![Screen Shot 2020-01-31 at 5 20 44 pm](https://user-images.githubusercontent.com/8490476/73519920-0d547c80-444e-11ea-96ff-70d0496a54f0.png)

The steps I took to test this are a little complicated since it requires `WC_Version` 2.6.x and you to fake a PPEC plugin update.

## To test I:

1. Created a new site (you could do this on a local dev site but I didn't want to mess anything up).
2. On the site I installed WC 2.6.14 ([download from here](https://github.com/woocommerce/woocommerce/releases/tag/2.6.14))
3. Cloned the PPEC repo into the plugins directory and checked out out this branch.
4. I manually faked the 1.6.19 update by changing the version constant in the main plugin file [here](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/display_wc_pre_30_warning/woocommerce-gateway-paypal-express-checkout.php#L30).
5. Refreshed an admin screen. Voila! Admin notice displayed.

The admin notice can be dismissed in two ways: 

1. Clicking the x on the right hand side of the notice, or
2. Updating to 3.0 will automatically hide the notice.

You could do this in a less complicated way by updating the PPEC plugin version and replacing the WC_Version constant with hardcoded '2.6.14' or lower.

The way this is written is to set the option and then delete it on dismissal so there's no option that lives forever recording that the notice was dismissed.

As always, feedback on the content of the notice is welcome 🙂 


