### PR TITLE
Deprecate `WC_Gateway_PPEC_Client::update_billing_agreement()`

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -997,23 +997,6 @@ class WC_Gateway_PPEC_Client {
 	}
 
 	/**
-	 * Updates or deletes a billing agreement.
-	 *
-	 * @see https://developer.paypal.com/docs/classic/api/merchant/BAUpdate_API_Operation_NVP/
-	 *
-	 * @since 1.2.0
-	 *
-	 * @param string $billing_agreement_id Billing agreement ID
-	 */
-	public function update_billing_agreement( $billing_agreement_id ) {
-		$params = array(
-			'METHOD'      => 'BillAgreementUpdate',
-			'VERSION'     => self::API_VERSION,
-			'REFERENCEID' => $billing_agreement_id,
-		);
-	}
-
-	/**
 	 * Processes a payment from a buyer's account, which is identified by a
 	 * previous transaction
 	 *
@@ -1236,6 +1219,27 @@ class WC_Gateway_PPEC_Client {
 			isset( $response['ACK'] )
 			&&
 			in_array( $response['ACK'], array( 'Success', 'SuccessWithWarning' ) )
+		);
+	}
+
+	/** Deprecated Functions */
+
+	/**
+	 * Updates or deletes a billing agreement.
+	 *
+	 * @see https://developer.paypal.com/docs/classic/api/merchant/BAUpdate_API_Operation_NVP/
+	 *
+	 * @since 1.2.0
+	 * @deprecated 1.7.0
+	 *
+	 * @param string $billing_agreement_id Billing agreement ID
+	 */
+	public function update_billing_agreement( $billing_agreement_id ) {
+		_deprecated_function( __METHOD__, '1.7.0' );
+		$params = array(
+			'METHOD'      => 'BillAgreementUpdate',
+			'VERSION'     => self::API_VERSION,
+			'REFERENCEID' => $billing_agreement_id,
 		);
 	}
 }


### PR DESCRIPTION
### Description

This function didn't do anything (it only defined an unused variable) and hasn't been used by the plugin since it was introduced.

For more details see these comments: https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/602#issuecomment-580057785 and https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/603#issuecomment-580091280

### To test

1. Add the following code to your site somewhere.
2. You should receive the following error notice.

```php
wc_gateway_ppec()->client->update_billing_agreement( 'B-12352352343' );
``` 

```
PHP Notice:  WC_Gateway_PPEC_Client::update_billing_agreement is <strong>deprecated</strong> since version 1.7.0 with no alternative available. in /app/public/wp-includes/functions.php on line 4651
```

closes #602