### PR TITLE
Do not add discounts to total item amount and cause line item amount offset

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -580,11 +580,11 @@ class WC_Gateway_PPEC_Client {
 		// the difference.
 		$diff = 0;
 
-		if ( $details['total_item_amount'] != $rounded_total ) {
+		if ( $details['total_item_amount'] + $discounts != $rounded_total ) {
 			if ( 'add' === $settings->get_subtotal_mismatch_behavior() ) {
 				// Add line item to make up different between WooCommerce
 				// calculations and PayPal calculations.
-				$diff = round( $details['total_item_amount'] - $rounded_total, $decimals );
+				$diff = round( $details['total_item_amount'] + $discounts - $rounded_total, $decimals );
 				if ( abs( $diff ) > 0.000001 && 0.0 !== (float) $diff ) {
 					$extra_line_item = $this->_get_extra_offset_line_item( $diff );
 
@@ -600,10 +600,10 @@ class WC_Gateway_PPEC_Client {
 
 		// Enter discount shenanigans. Item total cannot be 0 so make modifications
 		// accordingly.
-		if ( $details['total_item_amount'] == $discounts ) {
+		if ( $details['total_item_amount'] == 0 ) {
 			// Omit line items altogether.
 			unset( $details['items'] );
-		} else if ( $discounts > 0 && $discounts < $details['total_item_amount'] && ! empty( $details['items'] ) ) {
+		} else if ( $discounts > 0 && 0 < $details['total_item_amount'] && ! empty( $details['items'] ) ) {
 			// Else if there is discount, add them to the line-items
 			$details['items'][] = $this->_get_extra_discount_line_item($discounts);
 		}
@@ -611,10 +611,10 @@ class WC_Gateway_PPEC_Client {
 		$details['ship_discount_amount'] = 0;
 
 		// AMT
-		$details['order_total']       = round( $details['order_total'] - $discounts, $decimals );
+		$details['order_total']       = round( $details['order_total'], $decimals );
 
 		// ITEMAMT
-		$details['total_item_amount'] = round( $details['total_item_amount'] - $discounts, $decimals );
+		$details['total_item_amount'] = round( $details['total_item_amount'], $decimals );
 
 		// If the totals don't line up, adjust the tax to make it work (it's
 		// probably a tax mismatch).

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -470,7 +470,7 @@ class WC_Gateway_PPEC_Client {
 		$discounts     = WC()->cart->get_cart_discount_total();
 
 		$details = array(
-			'total_item_amount' => round( WC()->cart->cart_contents_total + $discounts + WC()->cart->fee_total, $decimals ),
+			'total_item_amount' => round( WC()->cart->cart_contents_total + WC()->cart->fee_total, $decimals ),
 			'order_tax'         => round( WC()->cart->tax_total + WC()->cart->shipping_tax_total, $decimals ),
 			'shipping'          => round( WC()->cart->shipping_total, $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_cart(),
@@ -695,7 +695,7 @@ class WC_Gateway_PPEC_Client {
 		$fees          = round( $this->_get_total_order_fees( $order ), $decimals );
 
 		$details = array(
-			'total_item_amount' => round( $order->get_subtotal() + $discounts + $fees, $decimals ),
+			'total_item_amount' => round( $order->get_subtotal() - $discounts + $fees, $decimals ),
 			'order_tax'         => round( $order->get_total_tax(), $decimals ),
 			'shipping'          => round( ( version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_total_shipping() : $order->get_shipping_total() ), $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_order( $order ),

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -856,7 +856,12 @@ class WC_Gateway_PPEC_Client {
 		$order    = wc_get_order( $order );
 
 		$rounded_total = 0;
-		foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $cart_item_key => $values ) {
+		foreach ( $order->get_items( array( 'line_item', 'fee', 'coupon' ) ) as $cart_item_key => $values ) {
+			if( 'coupon' === $values['type']) {
+				$amount = round($values['line_total'], $decimals);
+				$rounded_total -= $amount;
+				continue;
+			}
 			if( 'fee' === $values['type']) {
 				$amount = round( $values['line_total'], $decimals);
 			} else {

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -695,7 +695,7 @@ class WC_Gateway_PPEC_Client {
 		$fees          = round( $this->_get_total_order_fees( $order ), $decimals );
 
 		$details = array(
-			'total_item_amount' => round( $order->get_subtotal() - $discounts + $fees, $decimals ),
+			'total_item_amount' => round( $order->get_subtotal() + $fees, $decimals ),
 			'order_tax'         => round( $order->get_total_tax(), $decimals ),
 			'shipping'          => round( ( version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_total_shipping() : $order->get_shipping_total() ), $decimals ),
 			'items'             => $this->_get_paypal_line_items_from_order( $order ),


### PR DESCRIPTION
Fixes #485 

Description
---

Whenever a coupon is added to provide a discount, the Purchase details in the Paypal buyer account shows an extra item added "Line Item Amount Offset", equal to the discount amount and then eventually deducted as a Shipping Discount Amount: https://d.pr/i/unojiU

This extra line item amount offset was introduced to account for rounding variations between WC and PayPal, but this has been applying to all discounts, even if there is no rounding issue.

This total_item_amount includes the total of items and discounts and the difference is added as an extra line item. So, the first commit 8417ab5 does not include discounts in it (in both the cases of getting the details from the order and the cart).

The next commit a9cf763 makes appropriate modifications to the checks and conditions with the above change in mind.

The last commit 4bc0ba9 deducts the discounts via 'coupon' line item to calculate the rounded total.

Steps to Test
---
**Test A**

1. Create a product with a decimal part, say $89.99 ( from #663)
2. Create a 99% discount coupon.
3. Purchase the product via PayPal Smart button after applying the coupon.
4. On master, the purchase details show the extra line item and an extra discount. On this branch, it looks clean.

**Test B**( from #562 )
1. Set Woocommerce Options in "WooCommerce->Settings"

    - In the "General" tab set "Number of Decimals" to 4
    - In the "Tax" tab set "Prices Entered With Tax" to "Yes, I will enter prices inclusive of tax"

1. Add this code to functions.php or custom plugin:

        //Sets parameter for price display to only show 2 decimals regardless of "Number of Decimals" option
        function myslug_decimals_price_args($args)
        {
        $args['decimals'] = 2;
        return $args;
        }
       add_filter('wc_price_args', 'myslug_decimals_price_args', 10, 1);

1. Create a "Percentage discount" coupon
1. Apply the coupon
1. Checkout via the PayPal Smart Button

To further test, add more calculations like tax, shipping etc.. In all cases, there is no line item amount offset added on this branch, even if there is a discrepancy in rounding causing a Shipping discount of 0.01 applied(Why shipping discount and not rounding adjustment will be addressed in another PR): https://d.pr/i/HkITTR

Closes #485 