### PR TITLE
Upgrade the plugin on plugins loaded rather than on plugin init

### DIFF
--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -76,17 +76,12 @@ class WC_Gateway_PPEC_Plugin {
 		$this->plugin_path   = trailingslashit( plugin_dir_path( $this->file ) );
 		$this->plugin_url    = trailingslashit( plugin_dir_url( $this->file ) );
 		$this->includes_path = $this->plugin_path . trailingslashit( 'includes' );
-
-		// Updates
-		if ( version_compare( $version, get_option( 'wc_ppec_version' ), '>' ) ) {
-			$this->run_updater( $version );
-		}
 	}
 
 	/**
 	 * Handle updates.
-	 * @param  [type] $new_version [description]
-	 * @return [type]              [description]
+	 *
+	 * @param string $new_version The plugin's new version.
 	 */
 	private function run_updater( $new_version ) {
 		// Map old settings to settings API
@@ -163,6 +158,11 @@ class WC_Gateway_PPEC_Plugin {
 			}
 
 			$this->_check_dependencies();
+
+			if ( $this->needs_update() ) {
+				$this->run_updater( $this->version );
+			}
+
 			$this->_run();
 			$this->_check_credentials();
 
@@ -384,6 +384,15 @@ class WC_Gateway_PPEC_Plugin {
 		require_once( $this->includes_path . 'class-wc-gateway-ppec-client-credential-certificate.php' );
 		require_once( $this->includes_path . 'class-wc-gateway-ppec-client-credential-signature.php' );
 		require_once( $this->includes_path . 'class-wc-gateway-ppec-client.php' );
+	}
+
+	/**
+	 * Checks if the plugin needs to record an update.
+	 *
+	 * @return bool Whether the plugin needs to be updated.
+	 */
+	protected function needs_update() {
+		return version_compare( $this->version, get_option( 'wc_ppec_version' ), '>' );
 	}
 
 	/**


### PR DESCRIPTION
### Description

This PR moves the upgrade process from plugin init (when WP loads the plugin files) to the `plugins_loaded` hook.

This is to ensure we have access to WC core functions. It also means the plugin is updated at a consistent time, not when WP loads the plugin which can change, and when the dependencies are met. eg WC is active.

This change means: 

1. The plugin version won't update until `plugins_loaded`.
2. The plugin version won't update if the plugin dependencies aren't met. 

### To test

1. Disable the WooCommerce plugin.
2. Go into the database and change the `wc_ppec_version` option to 1.6.18. _We need to trick it into running an update. This is fine since the PPEC upgrade script is very minor._
3. Reload an Admin page.
     1. On `master` you will get the following error. Note that the plugin version is still updated to 1.6.19.
     2. On this branch, the plugin will load correctly, without error. The version also won't be updated until the dependencies are met. 

```
PHP Warning:  Use of undefined constant WC_VERSION - assumed 'WC_VERSION' (this will throw an Error in a future version of PHP) in /app/public/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/includes/class-wc-gateway-ppec-plugin.php on line 138
PHP Stack trace:
PHP   1. {main}() /app/public/wp-admin/plugins.php:0
PHP   2. require_once() /app/public/wp-admin/plugins.php:10
PHP   3. require_once() /app/public/wp-admin/admin.php:34
PHP   4. require_once() /app/public/wp-load.php:37
PHP   5. require_once() /app/public/wp-config.php:91
PHP   6. include_once() /app/public/wp-settings.php:360
PHP   7. wc_gateway_ppec() /app/public/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php:49
PHP   8. WC_Gateway_PPEC_Plugin->__construct() /app/public/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php:43
PHP   9. WC_Gateway_PPEC_Plugin->run_updater() /app/public/wp-content/plugins/woocommerce-gateway-paypal-express-checkout/includes/class-wc-gateway-ppec-plugin.php:82
```




