### PR TITLE
Ensure Puerto Rico and supported Locales are eligible for PayPal Credit

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -303,9 +303,21 @@ class WC_Gateway_PPEC_Settings {
 	 */
 	public function get_paypal_locale() {
 		$locale = get_locale();
-		if ( ! in_array( $locale, $this->_supported_locales ) ) {
+
+		// For stores based in the US, we need to do some special mapping so PayPal Credit is allowed.
+		if ( wc_gateway_ppec_is_US_based_store() ) {
+			// PayPal has support for French, Spanish and Chinese languages based in the US. See https://developer.paypal.com/docs/archive/checkout/reference/supported-locales/
+			preg_match('/^(fr|es|zh)_/', $locale, $language_code );
+
+			if ( ! empty( $language_code ) ) {
+				$locale = $language_code[0] . 'US';
+			} else {
+				$locale = 'en_US';
+			}
+		} else if ( ! in_array( $locale, $this->_supported_locales ) ) {
 			$locale = 'en_US';
 		}
+
 		return apply_filters( 'woocommerce_paypal_express_checkout_paypal_locale', $locale );
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -76,8 +76,7 @@ function wc_gateway_ppec_log( $message ) {
  * @return bool Returns true if PayPal credit is supported
  */
 function wc_gateway_ppec_is_credit_supported() {
-	$base = wc_get_base_location();
-	return 'US' === $base['country'] && 'USD' === get_woocommerce_currency();
+	return wc_gateway_ppec_is_US_based_store() && 'USD' === get_woocommerce_currency();
 }
 
 /**
@@ -153,4 +152,16 @@ function wc_gateway_ppec_get_transaction_fee( $order ) {
 	}
 
 	return $fee;
+}
+
+/**
+ * Checks whether the store is based in the US.
+ *
+ * Stores with a base location in the US or Puerto Rico are considered US based stores.
+ *
+ * @return bool True if the store is located in the US or Puerto Rico, otherwise false.
+ */
+function wc_gateway_ppec_is_US_based_store() {
+	$base_location = wc_get_base_location();
+	return in_array( $base_location['country'], array( 'US', 'PR' ), true );
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -157,11 +157,11 @@ function wc_gateway_ppec_get_transaction_fee( $order ) {
 /**
  * Checks whether the store is based in the US.
  *
- * Stores with a base location in the US or Puerto Rico are considered US based stores.
+ * Stores with a base location in the US, Puerto Rico, Guam, US Virgin Islands, American Samoa, or Northern Mariana Islands are considered US based stores.
  *
- * @return bool True if the store is located in the US or Puerto Rico, otherwise false.
+ * @return bool True if the store is located in the US or US Territory, otherwise false.
  */
 function wc_gateway_ppec_is_US_based_store() {
 	$base_location = wc_get_base_location();
-	return in_array( $base_location['country'], array( 'US', 'PR' ), true );
+	return in_array( $base_location['country'], array( 'US', 'PR', 'GU', 'VI', 'AS', 'MP' ), true );
 }


### PR DESCRIPTION
**Issue**: #691 

**A11n only:** See this [Slack thread](https://a8c.slack.com/archives/CJTS771PB/p1583731009099000) for additional context.

### Description

This PR ensures stores based in Puerto Rico are eligible for PayPal Credit. Secondly, stores based in the US or Puerto Rico will always map to a US-based locale. 

The locales options by WordPress don't map perfectly to PayPals supported locales (https://developer.paypal.com/docs/archive/checkout/reference/supported-locales/), so I had to do some special mapping. 

Any US-based store with a WP locale that is French, Español or Chinese will map to their PayPal US-based codes. `fr_US`, `es_US`, or `zh_US` respectively. If the store language isn't one of those but is a US-based store it will map to `en_US`.

Any store, located outside of the US or Puerto Rico will continue to map to what they did before. 

### To test

1. Under **WooCommerce > Settings** set your store's base location to [Puerto Rico](https://user-images.githubusercontent.com/8490476/76191978-57d6cf00-622c-11ea-85d5-c945948b2821.png).
1. Under the WP  **Settings**, set the site language to [Español](https://user-images.githubusercontent.com/8490476/76192046-8f457b80-622c-11ea-9c79-5618bbf6f81b.png).
1. Enable PayPal Credit. Here's a full-page screenshot of my [PPEC settings](https://user-images.githubusercontent.com/8490476/76192201-f8c58a00-622c-11ea-946a-993331ac9411.png).
1. Place a standard product in the cart.
1. Go to the checkout page. 
   1. On `master` you won't see a PayPal Credit button.
   1. On this branch, the PayPal [Credit button will be displayed](https://user-images.githubusercontent.com/8490476/76192320-404c1600-622d-11ea-9a98-c295a05d35ac.png) and clicking it will [display the modal in Español](https://user-images.githubusercontent.com/8490476/76192356-51952280-622d-11ea-8239-3bd24785a3bb.png).
1. You can follow those steps and change your site's language to another variation of Español, Chinese, or French. They should all map to their `fr_US`, `es_US`, or `zh_US` counterparts. 
1. You can also test sites based outside the US, they should continue to not display PayPal Credit.