### PR TITLE
"Filter" form validity via wc_ppec_validate_product_form event.

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -43,7 +43,19 @@
 	};
 
 	var validate_form = function() {
-		fields_valid = form.get( 0 ).checkValidity();
+		
+		// Construct a custom event.
+		var validate_form_event = jQuery.Event( 'wc_ppec_validate_product_form' );
+		
+		// Set the .valid property.
+		validate_form_event.valid = form.get( 0 ).checkValidity();
+		
+		// We trigger the event to allow third parties to filter the validate_form_event.valid variable.
+		$( document ).trigger( validate_form_event, [ form ] );
+		
+		// Set status to result.
+		fields_valid = validate_form_event.valid;
+
 		update_button();
 	};
 

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -43,12 +43,8 @@
 	};
 
 	var validate_form = function() {
-			
-		// Set the .valid property.
-		fields_valid = form.get( 0 ).checkValidity();
-		
-		// We trigger the event to allow third parties to filter the fields_valid variable.
-		fields_valid = $( document ).triggerHandler( 'wc_ppec_validate_product_form', [ fields_valid, form ] );
+		// Check fields are valid and allow third parties to attach their own validation checks
+		fields_valid = form.get( 0 ).checkValidity() && $( document ).triggerHandler( 'wc_ppec_validate_product_form', [ fields_valid, form ] ) !== false;
 
 		update_button();
 	};

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -79,7 +79,10 @@
 		// Hack: IE11 uses the previous field value for the checkValidity() check if it's called in the onChange handler
 		setTimeout( validate_form, 0 );
 	} );
-	validate_form();
+
+	$( document ).ready(function() {
+		validate_form();
+	} );
 
 	var generate_cart = function( callback ) {
 		var data = {

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -43,18 +43,12 @@
 	};
 
 	var validate_form = function() {
-		
-		// Construct a custom event.
-		var validate_form_event = jQuery.Event( 'wc_ppec_validate_product_form' );
-		
+			
 		// Set the .valid property.
-		validate_form_event.valid = form.get( 0 ).checkValidity();
+		fields_valid = form.get( 0 ).checkValidity();
 		
-		// We trigger the event to allow third parties to filter the validate_form_event.valid variable.
-		$( document ).trigger( validate_form_event, [ form ] );
-		
-		// Set status to result.
-		fields_valid = validate_form_event.valid;
+		// We trigger the event to allow third parties to filter the fields_valid variable.
+		fields_valid = $( document ).triggerHandler( 'wc_ppec_validate_product_form', [ fields_valid, form ] );
 
 		update_button();
 	};


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #694 


---

### Description
Add custom `wc_ppec_validate_product_form` trigger where you can set the `.valid` property and override the result of `form.get( 0 ).checkValidity()`

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. You can check out what I'm doing here: https://wp-helgatheviking.codeanyapp.com/product/t-shirt-6-pack/
1. specifically here's my JS callback:

```
		/**
		 * PayPal Express Smart buttons compatibility.
		 */
		$( document ).on( 'wc_ppec_validate_product_form', function( validity_check, $form ) {

			var wc_mnm = $form.wc_get_mnm_script();

			if ( 'object' === typeof wc_mnm ) {
				validity_check.valid = wc_mnm.passes_validation();
			}

		})
```


### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #694 .
