### PR TITLE
Use base64_decode on API certificate while creating Credential object

### DIFF
--- a/assets/js/wc-gateway-ppec-settings.js
+++ b/assets/js/wc-gateway-ppec-settings.js
@@ -9,6 +9,9 @@
 
 			$( 'button.image_remove' )
 				.on( 'click', this.removeProductImage );
+
+			$( '.wc_ppec_remove_certificate' )
+				.on( 'click', this.removeCertificate );
 		},
 
 		onClickUploadButton: function( event ) {
@@ -76,6 +79,15 @@
 			$button.hide();
 			$field.siblings( 'button.image_upload' ).show();
 		},
+
+		removeCertificate: function( event ) {
+			event.preventDefault();
+			var environment = $( event.target ).data( 'environment' );
+
+			// Add a hidden element that will trigger the cert to be deleted on save.
+			$( event.target ).parent( '.description' ).append( '<input name="woocommerce_ppec_delete_' + environment + '_api_certificate" type="hidden" value="true">' );
+			$( event.target ).parent( '.description' ).fadeOut();
+		}
 	};
 
 	function getAttachmentUrl( attachment ) {

--- a/assets/js/wc-gateway-ppec-settings.js
+++ b/assets/js/wc-gateway-ppec-settings.js
@@ -123,6 +123,11 @@
 
 		handleSignatureDisplayFor: function( event, environment ) {
 			var certificate_upload_input = environment === 'sandbox' ? $( '#woocommerce_ppec_paypal_sandbox_api_certificate' )[0] : $( '#woocommerce_ppec_paypal_api_certificate' )[0];
+
+			if ( ! certificate_upload_input ) {
+				return;
+			}
+
 			var uploaded_new_cert        = certificate_upload_input.files.length > 0;
 			var delete_cert_element_name = 'woocommerce_ppec_delete_' + environment + '_api_certificate';
 			var cert_removed             = $( '.description > input[name="' + delete_cert_element_name + '"]' ).length > 0;

--- a/assets/js/wc-gateway-ppec-settings.js
+++ b/assets/js/wc-gateway-ppec-settings.js
@@ -12,6 +12,20 @@
 
 			$( '.wc_ppec_remove_certificate' )
 				.on( 'click', this.removeCertificate );
+
+			$( '#woocommerce_ppec_paypal_sandbox_api_signature, #woocommerce_ppec_paypal_api_signature' )
+				.on( 'change', this.handleCertificateDisplay );
+
+			$( '#woocommerce_ppec_paypal_sandbox_api_certificate, #woocommerce_ppec_paypal_api_certificate' )
+				.on( 'change', this.handleSignatureDisplay );
+
+			$( 'body' ).on( 'wc_ppec_cert_changed', this.handleSignatureDisplayFor );
+
+			// Trigger the signature and cert display handlers on init.
+			$( 'body' ).trigger( 'wc_ppec_cert_changed', [ 'sandbox' ] );
+			$( 'body' ).trigger( 'wc_ppec_cert_changed', [ 'live' ] );
+			$( '#woocommerce_ppec_paypal_sandbox_api_signature' ).trigger( 'change' );
+			$( '#woocommerce_ppec_paypal_api_signature' ).trigger( 'change' );
 		},
 
 		onClickUploadButton: function( event ) {
@@ -87,6 +101,40 @@
 			// Add a hidden element that will trigger the cert to be deleted on save.
 			$( event.target ).parent( '.description' ).append( '<input name="woocommerce_ppec_delete_' + environment + '_api_certificate" type="hidden" value="true">' );
 			$( event.target ).parent( '.description' ).fadeOut();
+			$( 'body' ).trigger( 'wc_ppec_cert_changed', [ environment ] );
+		},
+
+		handleCertificateDisplay: function( event ) {
+			var is_sandbox    = $( event.target ).attr( 'id' ).search( 'sandbox' ) !== -1;
+			var signature     = $( event.target ).val();
+			var cert_selector = is_sandbox ? '#woocommerce_ppec_paypal_sandbox_api_certificate' : '#woocommerce_ppec_paypal_api_certificate';
+
+			if ( signature ) {
+				$( cert_selector ).closest( 'tr' ).fadeOut();
+			} else {
+				$( cert_selector ).closest( 'tr' ).fadeIn();
+			}
+		},
+
+		handleSignatureDisplay: function( event ) {
+			var is_sandbox = $( event.target ).attr( 'id' ).search( 'sandbox' ) !== -1;
+			$( 'body' ).trigger( 'wc_ppec_cert_changed', [ is_sandbox ? 'sandbox' : 'live' ] );
+		},
+
+		handleSignatureDisplayFor: function( event, environment ) {
+			var certificate_upload_input = environment === 'sandbox' ? $( '#woocommerce_ppec_paypal_sandbox_api_certificate' )[0] : $( '#woocommerce_ppec_paypal_api_certificate' )[0];
+			var uploaded_new_cert        = certificate_upload_input.files.length > 0;
+			var delete_cert_element_name = 'woocommerce_ppec_delete_' + environment + '_api_certificate';
+			var cert_removed             = $( '.description > input[name="' + delete_cert_element_name + '"]' ).length > 0;
+			var has_existing_cert        = $( certificate_upload_input ).clone().prop( {type:'text'} ).val() !== ''; // We need to clone the file input, turn it into a text field to retrieve the stored value.
+			var signature_selector       = environment === 'sandbox' ? '#woocommerce_ppec_paypal_sandbox_api_signature' : '#woocommerce_ppec_paypal_api_signature';
+
+			// If we have an existing cert which hasn't been removed or the user has uploaded a new cert, hide the signature.
+			if ( ( has_existing_cert && ! cert_removed ) || uploaded_new_cert ) {
+				$( signature_selector ).closest( 'tr' ).fadeOut();
+			} else {
+				$( signature_selector ).closest( 'tr' ).fadeIn();
+			}
 		}
 	};
 

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -190,32 +190,31 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 			return __( 'No API certificate on file.', 'woocommerce-gateway-paypal-express-checkout' );
 		}
 
-		$cert = @openssl_x509_read( $cert_string ); // @codingStandardsIgnoreLine
-		$out  = '';
+		$cert      = @openssl_x509_read( $cert_string ); // @codingStandardsIgnoreLine
+		$cert_info = $cert ? openssl_x509_parse( $cert ) : null;
+		$output    = '';
 
-		if ( false !== $cert ) {
-			$certinfo = openssl_x509_parse( $cert );
-			if ( false !== $certinfo ) {
-				$valid_until = $certinfo['validTo_time_t'];
-				if ( $valid_until < time() ) {
-					// Display in red if the cert is already expired
-					$expires = '<span style="color: red;">' . __( 'expired on %s', 'woocommerce-gateway-paypal-express-checkout' ) . '</span>';
-				} elseif ( $valid_until < ( time() - 2592000 ) ) {
-					// Also display in red if the cert is going to expire in the next 30 days
-					$expires = '<span style="color: red;">' . __( 'expires on %s', 'woocommerce-gateway-paypal-express-checkout' ) . '</span>';
-				} else {
-					// Otherwise just display a normal message
-					$expires = __( 'expires on %s', 'woocommerce-gateway-paypal-express-checkout' );
-				}
+		if ( $cert_info ) {
+			$valid_until = $cert_info['validTo_time_t'];
 
-				$expires = sprintf( $expires, date_i18n( get_option( 'date_format' ), $valid_until ) );
-				$out = sprintf( __( 'Certificate belongs to API username %1$s; %2$s.', 'woocommerce-gateway-paypal-express-checkout' ), $certinfo['subject']['CN'], $expires );
+			if ( $valid_until < time() ) {
+				// Display in red if the cert is already expired
+				$expires = '<span style="color: red;">' . __( 'expired on %s', 'woocommerce-gateway-paypal-express-checkout' ) . '</span>';
+			} elseif ( $valid_until < ( time() - 2592000 ) ) {
+				// Also display in red if the cert is going to expire in the next 30 days
+				$expires = '<span style="color: red;">' . __( 'expires on %s', 'woocommerce-gateway-paypal-express-checkout' ) . '</span>';
 			} else {
-				$out = __( 'The certificate on file is not valid.', 'woocommerce-gateway-paypal-express-checkout' );
+				// Otherwise just display a normal message
+				$expires = __( 'expires on %s', 'woocommerce-gateway-paypal-express-checkout' );
 			}
+
+			$expires = sprintf( $expires, date_i18n( get_option( 'date_format' ), $valid_until ) );
+			$output = sprintf( __( 'Certificate belongs to API username %1$s; %2$s.', 'woocommerce-gateway-paypal-express-checkout' ), $cert_info['subject']['CN'], $expires );
+		} else {
+			$output = __( 'The certificate on file is not valid.', 'woocommerce-gateway-paypal-express-checkout' );
 		}
 
-		return $out;
+		return $output;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -576,4 +576,32 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 
 		return ob_get_clean();
 	}
+
+	/**
+	 * Gets the description for an environment's certificate setting.
+	 *
+	 * Includes information about the certificate on file and remove link.
+	 *
+	 * @param string $environment The environment. Optional. Can be 'live' or 'sandbox'. Default is 'live'.
+	 * @return string The HTML string for an environment's certificate including a remove link if one is on file.
+	 */
+	private function get_certificate_setting_description( $environment = 'live' ) {
+		if ( 'live' === $environment ) {
+			$credentials = wc_gateway_ppec()->settings->get_live_api_credentials();
+		} else {
+			$credentials = wc_gateway_ppec()->settings->get_sandbox_api_credentials();
+		}
+
+		// If we don't have a certificate credential return the empty certificate info.
+		if ( ! is_callable( array( $credentials, 'get_certificate' ) ) ) {
+			return $this->get_certificate_info( '' );
+		}
+
+		return sprintf(
+			'%1$s <a href="#" class="wc_ppec_remove_certificate" data-environment="%2$s">%3$s</a>',
+			$this->get_certificate_info( $credentials->get_certificate() ),
+			esc_attr( $environment ),
+			__( 'Remove', 'woocommerce-gateway-paypal-express-checkout' )
+		);
+	}
 }

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -95,7 +95,12 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		// Image upload.
 		wp_enqueue_media();
 
-		wp_enqueue_script( 'wc-gateway-ppec-settings', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-settings.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
+		$screen = get_current_screen();
+
+		// Only enqueue the setting scripts on the PayPal Checkout settings screen.
+		if ( $screen && 'woocommerce_page_wc-settings' === $screen->id && isset( $_GET['tab'], $_GET['section'] ) && 'checkout' === $_GET['tab'] && 'ppec_paypal' === $_GET['section'] ) {
+			wp_enqueue_script( 'wc-gateway-ppec-settings', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-settings.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
+		}
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -209,7 +209,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 				}
 
 				$expires = sprintf( $expires, date_i18n( get_option( 'date_format' ), $valid_until ) );
-				$out = sprintf( __( 'Certificate belongs to API username %1$s; %2$s', 'woocommerce-gateway-paypal-express-checkout' ), $certinfo['subject']['CN'], $expires );
+				$out = sprintf( __( 'Certificate belongs to API username %1$s; %2$s.', 'woocommerce-gateway-paypal-express-checkout' ), $certinfo['subject']['CN'], $expires );
 			} else {
 				$out = __( 'The certificate on file is not valid.', 'woocommerce-gateway-paypal-express-checkout' );
 			}

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -231,6 +231,9 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 			$_POST['woocommerce_ppec_paypal_api_certificate'] = base64_encode( file_get_contents( $_FILES['woocommerce_ppec_paypal_api_certificate']['tmp_name'] ) );
 			unlink( $_FILES['woocommerce_ppec_paypal_api_certificate']['tmp_name'] );
 			unset( $_FILES['woocommerce_ppec_paypal_api_certificate'] );
+		} elseif ( isset( $_POST['woocommerce_ppec_delete_live_api_certificate'] ) ) {
+			$_POST['woocommerce_ppec_paypal_api_certificate'] = '';
+			unset( $_POST['woocommerce_ppec_delete_live_api_certificate'] );
 		} else {
 			$_POST['woocommerce_ppec_paypal_api_certificate'] = $this->get_option( 'api_certificate' );
 		}
@@ -243,6 +246,9 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 			$_POST['woocommerce_ppec_paypal_sandbox_api_certificate'] = base64_encode( file_get_contents( $_FILES['woocommerce_ppec_paypal_sandbox_api_certificate']['tmp_name'] ) );
 			unlink( $_FILES['woocommerce_ppec_paypal_sandbox_api_certificate']['tmp_name'] );
 			unset( $_FILES['woocommerce_ppec_paypal_sandbox_api_certificate'] );
+		} elseif ( isset( $_POST['woocommerce_ppec_delete_sandbox_api_certificate'] ) ) {
+			$_POST['woocommerce_ppec_paypal_sandbox_api_certificate'] = '';
+			unset( $_POST['woocommerce_ppec_delete_sandbox_api_certificate'] );
 		} else {
 			$_POST['woocommerce_ppec_paypal_sandbox_api_certificate'] = $this->get_option( 'sandbox_api_certificate' );
 		}

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -196,20 +196,21 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 
 		if ( $cert_info ) {
 			$valid_until = $cert_info['validTo_time_t'];
+			$expires     = __( 'expires on %s (%s)', 'woocommerce-gateway-paypal-express-checkout' );
 
 			if ( $valid_until < time() ) {
 				// Display in red if the cert is already expired
-				$expires = '<span style="color: red;">' . __( 'expired on %s', 'woocommerce-gateway-paypal-express-checkout' ) . '</span>';
-			} elseif ( $valid_until < ( time() - 2592000 ) ) {
+				$expires = '<span style="color: red;">' . __( 'expired on %s (%s)', 'woocommerce-gateway-paypal-express-checkout' ) . '</span>';
+			} elseif ( $valid_until < ( time() - ( 30 * DAY_IN_SECONDS ) ) ) {
 				// Also display in red if the cert is going to expire in the next 30 days
-				$expires = '<span style="color: red;">' . __( 'expires on %s', 'woocommerce-gateway-paypal-express-checkout' ) . '</span>';
-			} else {
-				// Otherwise just display a normal message
-				$expires = __( 'expires on %s', 'woocommerce-gateway-paypal-express-checkout' );
+				$expires = '<span style="color: red;">' . $expires . '</span>';
 			}
 
-			$expires = sprintf( $expires, date_i18n( get_option( 'date_format' ), $valid_until ) );
-			$output = sprintf( __( 'Certificate belongs to API username %1$s; %2$s.', 'woocommerce-gateway-paypal-express-checkout' ), $cert_info['subject']['CN'], $expires );
+			$expiry_date = new WC_DateTime( "@{$valid_until}", new DateTimeZone( 'UTC' ) );
+			$expiry_date->setTimezone( wp_timezone() );
+
+			$expires = sprintf( $expires, date_i18n( get_option( 'date_format' ), $expiry_date->getTimestamp() + $expiry_date->getOffset() ), $expiry_date->format( 'T' ) );
+			$output  = sprintf( __( 'Certificate belongs to API username %1$s; %2$s.', 'woocommerce-gateway-paypal-express-checkout' ), $cert_info['subject']['CN'], $expires );
 		} else {
 			$output = __( 'The certificate on file is not valid.', 'woocommerce-gateway-paypal-express-checkout' );
 		}

--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -120,7 +120,7 @@ class WC_Gateway_PPEC_Settings {
 	 */
 	public function get_live_api_credentials() {
 		if ( $this->api_certificate ) {
-			return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->api_username, $this->api_password, $this->api_certificate, $this->api_subject );
+			return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->api_username, $this->api_password, base64_decode( $this->api_certificate ), $this->api_subject );
 		}
 
 		return new WC_Gateway_PPEC_Client_Credential_Signature( $this->api_username, $this->api_password, $this->api_signature, $this->api_subject );
@@ -133,7 +133,7 @@ class WC_Gateway_PPEC_Settings {
 	 */
 	public function get_sandbox_api_credentials() {
 		if ( $this->sandbox_api_certificate ) {
-			return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->sandbox_api_username, $this->sandbox_api_password, $this->sandbox_api_certificate, $this->sandbox_api_subject );
+			return new WC_Gateway_PPEC_Client_Credential_Certificate( $this->sandbox_api_username, $this->sandbox_api_password, base64_decode( $this->sandbox_api_certificate ), $this->sandbox_api_subject );
 		}
 
 		return new WC_Gateway_PPEC_Client_Credential_Signature( $this->sandbox_api_username, $this->sandbox_api_password, $this->sandbox_api_signature, $this->sandbox_api_subject );

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -323,7 +323,7 @@ $settings = array(
 	'api_certificate' => array(
 		'title'       => __( 'Live API Certificate', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'        => 'file',
-		'description' => $this->get_certificate_info( $this->get_option( 'api_certificate' ) ),
+		'description' => $this->get_certificate_setting_description(),
 		'default'     => '',
 	),
 	'api_subject' => array(
@@ -364,9 +364,8 @@ $settings = array(
 	'sandbox_api_certificate' => array(
 		'title'       => __( 'Sandbox API Certificate', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'        => 'file',
-		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce-gateway-paypal-express-checkout' ),
+		'description' => $this->get_certificate_setting_description( 'sandbox' ),
 		'default'     => '',
-		'desc_tip'    => true,
 	),
 	'sandbox_api_subject' => array(
 		'title'       => __( 'Sandbox API Subject', 'woocommerce-gateway-paypal-express-checkout' ),

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -26,9 +26,10 @@ if ( $enable_ips && $needs_creds ) {
 
 	$api_creds_text = sprintf(
 		// Translators: Placeholders are opening an closing link HTML tags.
-		__( 'To reset current credentials and use another account %1$sclick here%2$s.', 'woocommerce-gateway-paypal-express-checkout' ),
+		__( 'To reset current credentials and use another account %1$sclick here%2$s. %3$sLearn more about your API Credentials%2$s.', 'woocommerce-gateway-paypal-express-checkout' ),
 		'<a href="' . $reset_link . '" title="' . __( 'Reset current credentials', 'woocommerce-gateway-paypal-express-checkout' ) . '">',
-		'</a>'
+		'</a>',
+		'<a href="https://docs.woocommerce.com/document/paypal-express-checkout/#section-4" title="' . __( 'Learn more', 'woocommerce-gateway-paypal-express-checkout' ) . '">'
 	);
 }
 
@@ -47,9 +48,10 @@ if ( $enable_ips && $needs_sandbox_creds ) {
 
 	$sandbox_api_creds_text = sprintf(
 		// Translators: Placeholders are opening and closing link HTML tags.
-		__( 'Your account setting is set to sandbox, no real charging takes place. To accept live payments, switch your environment to live and connect your PayPal account. To reset current credentials and use other sandbox account %1$sclick here%2$s.', 'woocommerce-gateway-paypal-express-checkout' ),
+		__( 'Your account setting is set to sandbox, no real charging takes place. To accept live payments, switch your environment to live and connect your PayPal account. To reset current credentials and use other sandbox account %1$sclick here%2$s. %3$sLearn more about your API Credentials%2$s.', 'woocommerce-gateway-paypal-express-checkout' ),
 		'<a href="' . $reset_link . '" title="' . __( 'Reset current credentials', 'woocommerce-gateway-paypal-express-checkout' ) . '">',
-		'</a>'
+		'</a>',
+		'<a href="https://docs.woocommerce.com/document/paypal-express-checkout/#section-4" title="' . __( 'Learn more', 'woocommerce-gateway-paypal-express-checkout' ) . '">'
 	);
 }
 
@@ -370,6 +372,7 @@ $settings = array(
 		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce-gateway-paypal-express-checkout' ),
 		'default'     => '',
 		'desc_tip'    => true,
+		'placeholder' => __( 'Optional if you provide a certificate below', 'woocommerce-gateway-paypal-express-checkout' ),
 	),
 	'sandbox_api_certificate' => array(
 		'title'       => __( 'Sandbox API Certificate', 'woocommerce-gateway-paypal-express-checkout' ),

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -24,7 +24,12 @@ if ( $enable_ips && $needs_creds ) {
 		wc_gateway_ppec()->get_admin_setting_link()
 	);
 
-	$api_creds_text = sprintf( __( 'To reset current credentials and use other account <a href="%1$s" title="%2$s">click here</a>.', 'woocommerce-gateway-paypal-express-checkout' ), $reset_link, __( 'Reset current credentials', 'woocommerce-gateway-paypal-express-checkout' ) );
+	$api_creds_text = sprintf(
+		// Translators: Placeholders are opening an closing link HTML tags.
+		__( 'To reset current credentials and use another account %1$sclick here%2$s.', 'woocommerce-gateway-paypal-express-checkout' ),
+		'<a href="' . $reset_link . '" title="' . __( 'Reset current credentials', 'woocommerce-gateway-paypal-express-checkout' ) . '">',
+		'</a>'
+	);
 }
 
 if ( $enable_ips && $needs_sandbox_creds ) {
@@ -40,7 +45,12 @@ if ( $enable_ips && $needs_sandbox_creds ) {
 		wc_gateway_ppec()->get_admin_setting_link()
 	);
 
-	$sandbox_api_creds_text = sprintf( __( 'Your account setting is set to sandbox, no real charging takes place. To accept live payments, switch your environment to live and connect your PayPal account. To reset current credentials and use other sandbox account <a href="%1$s" title="%2$s">click here</a>.', 'woocommerce-gateway-paypal-express-checkout' ), $reset_link, __( 'Reset current sandbox credentials', 'woocommerce-gateway-paypal-express-checkout' ) );
+	$sandbox_api_creds_text = sprintf(
+		// Translators: Placeholders are opening and closing link HTML tags.
+		__( 'Your account setting is set to sandbox, no real charging takes place. To accept live payments, switch your environment to live and connect your PayPal account. To reset current credentials and use other sandbox account %1$sclick here%2$s.', 'woocommerce-gateway-paypal-express-checkout' ),
+		'<a href="' . $reset_link . '" title="' . __( 'Reset current credentials', 'woocommerce-gateway-paypal-express-checkout' ) . '">',
+		'</a>'
+	);
 }
 
 $credit_enabled_label = __( 'Enable PayPal Credit', 'woocommerce-gateway-paypal-express-checkout' );

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -60,21 +60,21 @@ wc_enqueue_js( "
 		var enable_sandbox_toggle = $( 'a.ppec-toggle-sandbox-settings' ).length > 0;
 
 		$( '#woocommerce_ppec_paypal_environment' ).change(function(){
-			$( ppec_sandbox_fields + ',' + ppec_live_fields ).closest( 'tr' ).hide();
+			$( '#woocommerce_ppec_paypal_api_credentials + p + table, #woocommerce_ppec_paypal_sandbox_api_credentials + p + table' ).hide();
 
 			if ( 'live' === $( this ).val() ) {
 				$( '#woocommerce_ppec_paypal_api_credentials, #woocommerce_ppec_paypal_api_credentials + p' ).show();
 				$( '#woocommerce_ppec_paypal_sandbox_api_credentials, #woocommerce_ppec_paypal_sandbox_api_credentials + p' ).hide();
 
 				if ( ! enable_toggle ) {
-					$( ppec_live_fields ).closest( 'tr' ).show();
+					$( '#woocommerce_ppec_paypal_api_credentials + p + table' ).show();
 				}
 			} else {
 				$( '#woocommerce_ppec_paypal_api_credentials, #woocommerce_ppec_paypal_api_credentials + p' ).hide();
 				$( '#woocommerce_ppec_paypal_sandbox_api_credentials, #woocommerce_ppec_paypal_sandbox_api_credentials + p' ).show();
 
 				if ( ! enable_sandbox_toggle ) {
-					$( ppec_sandbox_fields ).closest( 'tr' ).show();
+					$( '#woocommerce_ppec_paypal_sandbox_api_credentials + p + table' ).show();
 				}
 			}
 		}).change();
@@ -98,14 +98,14 @@ wc_enqueue_js( "
 		if ( enable_toggle ) {
 			$( document ).off( 'click', '.ppec-toggle-settings' );
 			$( document ).on( 'click', '.ppec-toggle-settings', function( e ) {
-				$( ppec_live_fields ).closest( 'tr' ).toggle( 'fast' );
+				$( '#woocommerce_ppec_paypal_api_credentials + p + table' ).toggle( 'fast' );
 				e.preventDefault();
 			} );
 		}
 		if ( enable_sandbox_toggle ) {
 			$( document ).off( 'click', '.ppec-toggle-sandbox-settings' );
 			$( document ).on( 'click', '.ppec-toggle-sandbox-settings', function( e ) {
-				$( ppec_sandbox_fields ).closest( 'tr' ).toggle( 'fast' );
+				$( '#woocommerce_ppec_paypal_sandbox_api_credentials + p + table' ).toggle( 'fast' );
 				e.preventDefault();
 			} );
 		}


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #584 


---
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

While storing an API Certificate file, it is base64 encoded, but while retrieving it for use, it is not base64 decoded and so there are errors while using API certificate. 


### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Log into the Sandbox seller account at sandbox.paypal.com
1. Click on the gear icon on the top right and click on Account Settings.
1. Click on Update against API Access
1. Click on Manage API credentials under NVP/SOAP API integration (Classic)
1. If you already have API Signature here, remove it and request for an API Certificate. 
1. Download the API certificate, username and password. 
1. Go to the PPEC settings page from WooCommerce settings.
1. Use the API username and password just obtained. Choose the API Certificate file and then save.
1. On master, you should get "API Certificate not valid" error but on this branch it is saved with a success message.
1. Go a step further and try to purchase a product using this set of credentials. On this branch, an order is successfully placed.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->
I want note here that the documentation specifies [here](https://docs.woocommerce.com/document/paypal-express-checkout/#section-4) against point 5 that API Signature 'and' Certificate are required. Probably needs 'or' to be used. In addition, combining it with Live API Subject being optional makes the it sound as though the Signature and Certificate are also optional. Probably requires a rewrite.

Closes #584
Closes #565 