### PR TITLE
Only make the billing fields optional during an open PPEC session

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -37,8 +37,6 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		add_action( 'init', array( $this, 'init' ) );
 		add_filter( 'the_title', array( $this, 'endpoint_page_titles' ) );
 		add_action( 'woocommerce_checkout_init', array( $this, 'checkout_init' ) );
-		add_filter( 'woocommerce_default_address_fields', array( $this, 'filter_default_address_fields' ) );
-		add_filter( 'woocommerce_billing_fields', array( $this, 'filter_billing_fields' ) );
 		add_action( 'woocommerce_checkout_process', array( $this, 'copy_checkout_details_to_post' ) );
 
 		add_action( 'wp', array( $this, 'maybe_return_from_paypal' ) );
@@ -101,11 +99,15 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		remove_action( 'woocommerce_checkout_billing', array( $checkout, 'checkout_form_billing' ) );
 		remove_action( 'woocommerce_checkout_shipping', array( $checkout, 'checkout_form_shipping' ) );
 
-		// Lastly, let's add back in 1) displaying customer details from PayPal, 2) allow for
+		// Secondly, let's add back in 1) displaying customer details from PayPal, 2) allow for
 		// account registration and 3) shipping details from PayPal
 		add_action( 'woocommerce_checkout_billing', array( $this, 'paypal_billing_details' ) );
 		add_action( 'woocommerce_checkout_billing', array( $this, 'account_registration' ) );
 		add_action( 'woocommerce_checkout_shipping', array( $this, 'paypal_shipping_details' ) );
+
+		// Lastly make address fields optional depending on PayPal settings.
+		add_filter( 'woocommerce_default_address_fields', array( $this, 'filter_default_address_fields' ) );
+		add_filter( 'woocommerce_billing_fields', array( $this, 'filter_billing_fields' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #426 

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

This PR implements the changes discussed in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/669#issuecomment-585549636 and in the comments on pb0GrA-oX.

<details><summary>Expand to see the history</summary>
<p>
I suspect that the original bug was that when the customer clicked on the PayPal buttons on the cart or product pages, while purchasing virtual goods, and returned to the store, if the customer didn't have the require billing address setting enabled on their PayPal Account, the customer would return with no data. No shipping (virtual), and no billing (not enabled). In that situation, the checkout fields would be essentially empty. 

<img width="1104" alt="Screen Shot 2020-03-16 at 2 20 13 pm" src="https://user-images.githubusercontent.com/8490476/76722914-4db75200-6791-11ea-8587-7bb606fc237f.png">

If the customer tried to complete that purchase, the checkout would error because, by default, billing fields are required. To fix that, previous developers made the billing fields optional but under all checkout scenarios ([including other gateways](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/406#pullrequestreview-110694063)). Not just those situations when it's expected that the customer entered their address at PayPal.
</p>
</details>

This PR makes the billing fields optional only if:

1. The cart contains virtual products only, and
2. there's an active PayPal Express Checkout session active. That's to say, the customer has returned to the store after clicking a PayPal button on the cart, or product pages.

If the customer goes to the normal checkout flow, billing fields will be required.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

[PPEC settings](https://user-images.githubusercontent.com/8490476/76724520-f0be9a80-6796-11ea-8797-f37c54bd56a4.png).

1. Create a virtual product.
1. Add that virtual product to the cart.
1. Go to the checkout page. 
    1. On `master` the checkout billing fields will be optional.
    2. On this branch the billing fields will be required.

-----------

1. Go to the virtual product's single product page. 
1. Click the PayPal button. 
1. Complete the PayPal form.
1. When you return to the store, you should only have a Name and Email address filled in ([screenshot](https://user-images.githubusercontent.com/8490476/76722914-4db75200-6791-11ea-8587-7bb606fc237f.png)).
1. Complete the checkout. 
1. On both `master` and this branch, you should be able to complete with no errors. 

Unfortunately, I'm not aware of a way to test the require billing address setting since it requires that flag to be set on your PayPal account. In that case, the billing fields should be returned from PayPal and be required when you get back to the store in the second set of testing instructions. 

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

As we discussed at the meetup, we should document the require billing phone and billing address settings and add link next to the setting so users have more information about what the intended use of these settings are.

Closes #426
