### PR TITLE
Support subscription initial payments for $0 - free trials, synced etc.

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -140,8 +140,12 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 					$checkout->create_billing_agreement( $order, $checkout_details );
 				}
 
-				// Complete the payment now.
-				$checkout->do_payment( $order, $session->token, $session->payer_id );
+				// Complete the payment now if there's an amount to process.
+				if ( $order->get_total() > 0 ) {
+					$checkout->do_payment( $order, $session->token, $session->payer_id );
+				} else {
+					$order->payment_complete();
+				}
 
 				// Clear Cart
 				WC()->cart->empty_cart();

--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -563,7 +563,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		// If the cart total is zero (e.g. because of a coupon), don't allow this gateway.
 		// We do this only if we're on the checkout page (is_checkout), but not on the order-pay page (is_checkout_pay_page)
 		if ( is_cart() || ( is_checkout() && ! is_checkout_pay_page() ) ) {
-			if ( isset( $gateways['ppec_paypal'] ) && ( 0 >= WC()->cart->total ) ) {
+			if ( isset( $gateways['ppec_paypal'] ) && ! WC()->cart->needs_payment() ) {
 				unset( $gateways['ppec_paypal'] );
 			}
 		}


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #367 

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
As is described on the issue, PPEC would remove itself from the list of available payment gateways if the cart total is $0.

This is because it couldn't previously process $0 orders. This PR also fixes that. 

Like WC Subscriptions Reference Transaction implementation, the order of operations is something like this:

1. Generate an EC token.
2. Redirect the customer off to PayPal.
3. When they complete the process at PayPal, they will be redirected back to the store.
4. We then send a request to PayPal to get the billing agreement token.

It's at this point that PPEC would error as it would then try to process a $0 payment using that billing agreement. 

This PR fixes that by doing something similar to Subscriptions. Once we have the billing agreement, we just need to complete the order if there's no payment amount required.

This happens in WC Subscriptions [here](https://github.com/woocommerce/woocommerce-subscriptions/blob/3.0.2/includes/gateways/paypal/class-wcs-paypal.php#L261-L267).

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Create a subscription product with a free trial.
1. Add that product to the cart.
1. Go to the checkout page.
     1. On `master` PPEC won't appear as an available payment method.
     2. On this branch it will be available. 
1. To test 23623fb, you can reverse that change locally and try to complete the checkout. 
     1. Without 23623fb the customer is redirected to PayPal. Once they return to the store, we attempt to request payment for $0 and they get an error. 
     2. With 23623fb, when the customer returns to the store, the order is automatically completed.

You can check the PayPal EC debug logs to see that it's getting the Billing Agreement (BA) and then trying to process a payment using the BA when it's not needed.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #367 
