### PR TITLE
Fix free subscription initial purchases using PayPal Smart Buttons

### DIFF
--- a/includes/class-wc-gateway-ppec-admin-handler.php
+++ b/includes/class-wc-gateway-ppec-admin-handler.php
@@ -171,9 +171,9 @@ class WC_Gateway_PPEC_Admin_Handler {
 				$order_total = $old_wc ? $order->order_total : $order->get_total();
 
 				$params['AUTHORIZATIONID'] = $transaction_id;
-				$params['AMT'] = floatval( $order_total );
-				$params['CURRENCYCODE'] = $old_wc ? $order->order_currency : $order->get_currency();
-				$params['COMPLETETYPE'] = 'Complete';
+				$params['AMT']             = floatval( $order_total );
+				$params['CURRENCYCODE']    = $old_wc ? $order->order_currency : $order->get_currency();
+				$params['COMPLETETYPE']    = 'Complete';
 
 				$result = wc_gateway_ppec()->client->do_express_checkout_capture( $params );
 


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #700

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

When purchasing subscription products whose initial price is $0 (free trials etc) with PayPal Smart Buttons, when you return to the store, you aren't placed on the checkout with an active PayPal Session like you would when purchasing other products. This PR fixes that.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
0. If you don't have one, create a subscription product with a free trial.
1. Go to the free trial product's single product page.
1. Click the PayPal (yellow) payment button.
1. Log in to PayPal and complete the steps.
1. When you return to the store:
    - On `master` you will be placed on the normal checkout page where you will need to fill out the checkout, select a payment gateway etc.
    - On this branch, you will be placed on the Pay for order special checkout page with only PPEC selected.

Completing the PayPal checkout completes the order and similar to the normal checkout just sends the request to create a billing agreement and then completes the order. 

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #700
