### PR TITLE
Hide debit/credit card SPBs for subscription purchases

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -498,7 +498,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				'generic_error_msg'    => wp_kses( __( 'An error occurred while processing your PayPal payment. Please contact the store owner for assistance.', 'woocommerce-gateway-paypal-express-checkout' ), array() ),
 			);
 
-			if ( ! is_null(  $page ) ) {
+			if ( ! is_null( $page ) ) {
 				if ( 'product' === $page && 'yes' === $settings->single_product_settings_toggle ) {
 					$button_settings = $this->get_button_settings( $settings, 'single_product' );
 				} elseif ( 'checkout' === $page && 'yes' === $settings->mark_settings_toggle ) {
@@ -512,10 +512,12 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 			$settings_toggle = 'yes' === $settings->mini_cart_settings_toggle;
 			$mini_cart_data  = $this->get_button_settings( $settings, $settings_toggle ? 'mini_cart' : '' );
+
 			foreach( $mini_cart_data as $key => $value ) {
 				unset( $mini_cart_data[ $key ] );
 				$mini_cart_data[ 'mini_cart_' . $key ] = $value;
 			}
+
 			$data = array_merge( $data, $mini_cart_data );
 
 			if ( ! $settings->use_legacy_checkout_js() ) {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -519,6 +519,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 			}
 
 			$data = array_merge( $data, $mini_cart_data );
+			$data = apply_filters( 'woocommerce_paypal_express_checkout_payment_button_data', $data, $page );
 
 			if ( ! $settings->use_legacy_checkout_js() ) {
 				$script_args = array(

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -38,6 +38,11 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 		add_action( 'wc_ajax_wc_ppec_update_shipping_costs', array( $this, 'wc_ajax_update_shipping_costs' ) );
 		add_action( 'wc_ajax_wc_ppec_start_checkout', array( $this, 'wc_ajax_start_checkout' ) );
+
+		// Load callbacks specific to Subscriptions integration.
+		if ( class_exists( 'WC_Subscriptions_Order' ) ) {
+			add_filter( 'woocommerce_paypal_express_checkout_payment_button_data', array( $this, 'hide_card_payment_buttons_for_subscriptions' ), 10, 2 );
+		}
 	}
 
 	/**
@@ -572,6 +577,51 @@ class WC_Gateway_PPEC_Cart_Handler {
 		if ( ! empty( WC()->session ) && ! WC()->session->has_session() ) {
 			WC()->session->set_customer_session_cookie( true );
 		}
+	}
+
+
+	/**
+	 * Removes card payment method buttons from carts or pages which require a billing agreement.
+	 *
+	 * When the payment requires a billing agreement, we need a PayPal account and so require the customer to login. This means
+	 * card payment buttons cannot be used to make these purchases.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array       $payment_button_data PayPal Smart Payment Button settings.
+	 * @param string|null $page The specific page the customer is viewing. Can be 'product', 'cart' or 'checkout'. Otherwise null.
+	 * @return array      $payment_button_data
+	 */
+	public function hide_card_payment_buttons_for_subscriptions( $payment_button_data, $page ) {
+		if ( ! class_exists( 'WC_Subscriptions_Product' ) ) {
+			return $payment_button_data;
+		}
+
+		$needs_billing_agreement = wc_gateway_ppec()->checkout->needs_billing_agreement_creation( array() );
+
+		// Mini-cart handling. By default an empty string is passed if no methods are disallowed, therefore we need to check for non array formats too.
+		if ( $needs_billing_agreement && ( ! is_array( $payment_button_data['mini_cart_disallowed_methods'] ) || ! in_array( 'card', $payment_button_data['mini_cart_disallowed_methods'] ) ) ) {
+			$payment_button_data['mini_cart_disallowed_methods']   = ! is_array( $payment_button_data['mini_cart_disallowed_methods'] ) ? array() : $payment_button_data['mini_cart_disallowed_methods'];
+			$payment_button_data['mini_cart_disallowed_methods'][] = 'card';
+		}
+
+		// Specific Page handling.
+		if ( ! $page ) {
+			return $payment_button_data;
+		}
+
+		// Add special handling for the product page where we need to use the product to test eligibility.
+		if ( 'product' === $page ) {
+			$needs_billing_agreement = WC_Subscriptions_Product::is_subscription( $GLOBALS['post']->ID );
+		}
+
+		// By default an empty string is passed if no methods are disallowed, therefore we need to check for non array formats too.
+		if ( $needs_billing_agreement && ( ! is_array( $payment_button_data['disallowed_methods'] ) || ! in_array( 'card', $payment_button_data['disallowed_methods'] ) ) ) {
+			$payment_button_data['disallowed_methods']   = ! is_array( $payment_button_data['disallowed_methods'] ) ? array() : $payment_button_data['disallowed_methods'];
+			$payment_button_data['disallowed_methods'][] = 'card';
+		}
+
+		return $payment_button_data;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->

GitHub comment: https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/668#issuecomment-604242940

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

When purchasing a subscription, you cannot use debit or credit card smart payment buttons because we need to create a billing agreement and therefore need a PayPal account. This PR hides credit and debit card fields when viewing a subscription product page or if the cart contains a subscription.

Unfortunately, the changes needed here were more than I would have liked. This is because of the way the `get_button_settings()` function sometimes gets an empty string or an array of hidden methods and so we needed to work around that. 

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Set up your [PayPal Checkout settings](https://user-images.githubusercontent.com/8490476/77714957-0dc05c80-7026-11ea-8d86-a06b9b51a6a8.png) so all payment options are visible.
1. On `master` go to a subscription product's page and try to purchase the product using [one of the credit card options](https://user-images.githubusercontent.com/8490476/77715284-ecac3b80-7026-11ea-92cd-531384b9a9c4.png). You should see an [error](https://user-images.githubusercontent.com/8490476/77715910-96d89300-7028-11ea-81c8-ab558add6dc0.png). 
1. Switch to this branch. The credit card fields will be hidden.
1. You can also test using the old JS Smart payment buttons by removing the REST API Client ID credential.

@jorgeatorres what are your thoughts on this approach? I tried heaps of possible fixes, I tried using a filter but couldn't find a good place to add a callback because this runs before all classes with Subscriptions integration. The current set of changes include some duplicate code, before the SDK code overrides the hidden methods generated by `get_button_settings()`. 

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

**Note:** 
When using the new JS SDK, if you're viewing a subscription's single product page, you won't be able to see/use the credit card fields in the mini-cart because there's no longer any context-specific hidden methods. 

For example: 
On Subscription page:
<img width="390" alt="Screen Shot 2020-03-27 at 3 28 36 pm" src="https://user-images.githubusercontent.com/8490476/77724931-dfe81180-703f-11ea-8205-9ac135d33975.png">

On simple product page:
<img width="390" alt="Screen Shot 2020-03-27 at 3 30 47 pm" src="https://user-images.githubusercontent.com/8490476/77724969-f68e6880-703f-11ea-8ee2-0f34ace530d1.png">



