### PR TITLE
Exit early from js scripts before targeting nonexistent elements

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -2,14 +2,6 @@
 ;(function( $, window, document ) {
 	'use strict';
 
-	var form = $( 'form.cart' );
-
-	// Return early in cases where no form is present
-	// i.e. out of stock product
-	if ( ! form.length ) {
-		return;
-	}
-
 	// This button state is only applicable to non-SPB click handler below.
 	var button_enabled = true;
 	$( '#woo_pp_ec_button_product' )
@@ -44,6 +36,7 @@
 	// True if all the fields of the product form are valid (such as required fields configured by Product Add-Ons). False otherwise
 	var fields_valid = true;
 
+	var form = $( 'form.cart' );
 
 	var update_button = function() {
 		$( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -2,6 +2,14 @@
 ;(function( $, window, document ) {
 	'use strict';
 
+	var form = $( 'form.cart' );
+
+	// Return early in cases where no form is present
+	// i.e. out of stock product
+	if ( ! form.length ) {
+		return;
+	}
+
 	// This button state is only applicable to non-SPB click handler below.
 	var button_enabled = true;
 	$( '#woo_pp_ec_button_product' )
@@ -36,7 +44,6 @@
 	// True if all the fields of the product form are valid (such as required fields configured by Product Add-Ons). False otherwise
 	var fields_valid = true;
 
-	var form = $( 'form.cart' );
 
 	var update_button = function() {
 		$( '#woo_pp_ec_button_product' ).trigger( ( variation_valid && fields_valid ) ? 'enable' : 'disable' );

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -152,6 +152,11 @@
 
 	// Render cart, single product, or checkout buttons.
 	if ( wc_ppec_context.page ) {
+		// Return early in cases where no form is present in product page
+		// i.e. out of stock product
+		if ( 'product' === wc_ppec_context.page && ! $( 'form.cart' ).length ) {
+			return;
+		}
 		if ( 'checkout' !== wc_ppec_context.page ) {
 			render();
 		}

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -150,6 +150,16 @@
 		}, selector );
 	};
 
+	// Render buttons in mini-cart if present.
+	$( document.body ).on( 'wc_fragments_loaded wc_fragments_refreshed', function() {
+		var $button = $( '.widget_shopping_cart #woo_pp_ec_button_mini_cart' );
+		if ( $button.length ) {
+			// Clear any existing button in container, and render.
+			$button.empty();
+			render( true );
+		}
+	} );
+
 	// Render cart, single product, or checkout buttons.
 	if ( wc_ppec_context.page ) {
 		// Return early in cases where no form is present in product page
@@ -162,15 +172,4 @@
 		}
 		$( document.body ).on( 'updated_cart_totals updated_checkout', render.bind( this, false ) );
 	}
-
-	// Render buttons in mini-cart if present.
-	$( document.body ).on( 'wc_fragments_loaded wc_fragments_refreshed', function() {
-		var $button = $( '.widget_shopping_cart #woo_pp_ec_button_mini_cart' );
-		if ( $button.length ) {
-			// Clear any existing button in container, and render.
-			$button.empty();
-			render( true );
-		}
-	} );
-
 } )( jQuery, window, document );

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -62,8 +62,8 @@
 		var selector     = isMiniCart ? '#woo_pp_ec_button_mini_cart' : '#woo_pp_ec_button_' + wc_ppec_context.page;
 		var fromCheckout = 'checkout' === wc_ppec_context.page && ! isMiniCart;
 
-		// Don't render if already rendered in DOM.
-		if ( $( selector ).children().length ) {
+		// Don't render if selector doesn't exist or is already rendered in DOM.
+		if ( ! $( selector ).length || $( selector ).children().length ) {
 			return;
 		}
 
@@ -150,6 +150,14 @@
 		}, selector );
 	};
 
+	// Render cart, single product, or checkout buttons.
+	if ( wc_ppec_context.page ) {
+		if ( 'checkout' !== wc_ppec_context.page ) {
+			render();
+		}
+		$( document.body ).on( 'updated_cart_totals updated_checkout', render.bind( this, false ) );
+	}
+
 	// Render buttons in mini-cart if present.
 	$( document.body ).on( 'wc_fragments_loaded wc_fragments_refreshed', function() {
 		var $button = $( '.widget_shopping_cart #woo_pp_ec_button_mini_cart' );
@@ -159,17 +167,4 @@
 			render( true );
 		}
 	} );
-
-	// Render cart, single product, or checkout buttons.
-	if ( wc_ppec_context.page ) {
-		// Return early in cases where no form is present in product page
-		// i.e. out of stock product
-		if ( 'product' === wc_ppec_context.page && ! $( 'form.cart' ).length ) {
-			return;
-		}
-		if ( 'checkout' !== wc_ppec_context.page ) {
-			render();
-		}
-		$( document.body ).on( 'updated_cart_totals updated_checkout', render.bind( this, false ) );
-	}
 } )( jQuery, window, document );

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -316,6 +316,14 @@ class WC_Gateway_PPEC_Cart_Handler {
 			<?php endif; ?>
 		</div>
 		<?php
+
+		wp_enqueue_script( 'wc-gateway-ppec-generate-cart', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-generate-cart.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
+		wp_localize_script( 'wc-gateway-ppec-generate-cart', 'wc_ppec_generate_cart_context',
+			array(
+				'generate_cart_nonce' => wp_create_nonce( '_wc_ppec_generate_cart_nonce' ),
+				'ajaxurl'             => WC_AJAX::get_endpoint( 'wc_ppec_generate_cart' ),
+			)
+		);
 	}
 
 	/**
@@ -512,16 +520,6 @@ class WC_Gateway_PPEC_Cart_Handler {
 			$data = array_merge( $data, $mini_cart_data );
 
 			wp_localize_script( 'wc-gateway-ppec-smart-payment-buttons', 'wc_ppec_context', $data );
-		}
-
-		if ( $is_product ) {
-			wp_enqueue_script( 'wc-gateway-ppec-generate-cart', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-generate-cart.js', array( 'jquery' ), wc_gateway_ppec()->version, true );
-			wp_localize_script( 'wc-gateway-ppec-generate-cart', 'wc_ppec_generate_cart_context',
-				array(
-					'generate_cart_nonce' => wp_create_nonce( '_wc_ppec_generate_cart_nonce' ),
-					'ajaxurl'             => WC_AJAX::get_endpoint( 'wc_ppec_generate_cart' ),
-				)
-			);
 		}
 	}
 


### PR DESCRIPTION
Per issue #558, when on a single product page containing an item that is out of
stock, both `wc-gateway-ppec-smart-payment-buttons.js` and
`wc-gateway-ppec-generate-cart.js` scripts throw exceptions as both
scripts are trying to target elements which don't exist when the product is out of stock:

From `wc-gateway-ppec-generate-cart.js`:
```
TypeError: Cannot read property 'checkValidity' of undefined
```

From `wc-gateway-ppec-smart-payment-buttons.js`:
```
Error: Document is ready and element #woo_pp_ec_button_product does not exist
```

### Steps to reproduce

From `master`:

1. Create an out-of-stock product.
2. Visit its single product page.
3. Check the browser console/source tabs

### Description

This PR adds a check for the relevant form element in each script and returns early if it is not present in the single product view. Doing so stops the scripts before they target invalid elements and resolves above exceptions.


Fixes #558
