### PR TITLE
Allow WC to perform validation when missing fields

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -27,7 +27,7 @@
 		.on( 'disable', function() {
 			$( '#woo_pp_ec_button_product' )
 				.css( {
-					'cursor': ( variation_valid ? 'pointer' : 'not-allowed' ),
+					'cursor': 'not-allowed',
 					'-webkit-filter': 'grayscale( 100% )', // Safari 6.0 - 9.0
 					'filter': 'grayscale( 100% )',
 				} )

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -14,20 +14,29 @@
 
 	$( '#woo_pp_ec_button_product' )
 		.on( 'enable', function() {
-			$( '#woo_pp_ec_button_product' ).css( {
-				'cursor': '',
-				'-webkit-filter': '', // Safari 6.0 - 9.0
-				'filter': '',
-			} );
-			$( '#woo_pp_ec_button_product > *' ).css( 'pointer-events', '' );
+			$( '#woo_pp_ec_button_product' )
+				.css( {
+					'cursor': '',
+					'-webkit-filter': '', // Safari 6.0 - 9.0
+					'filter': '',
+				} )
+				.off( 'mouseup' )
+				.find( '> *' )
+				.css( 'pointer-events', '' );
 		} )
 		.on( 'disable', function() {
-			$( '#woo_pp_ec_button_product' ).css( {
-				'cursor': 'not-allowed',
-				'-webkit-filter': 'grayscale( 100% )', // Safari 6.0 - 9.0
-				'filter': 'grayscale( 100% )',
-			} );
-			$( '#woo_pp_ec_button_product > *' ).css( 'pointer-events', 'none' );
+			$( '#woo_pp_ec_button_product' )
+				.css( {
+					'cursor': ( variation_valid ? 'pointer' : 'not-allowed' ),
+					'-webkit-filter': 'grayscale( 100% )', // Safari 6.0 - 9.0
+					'filter': 'grayscale( 100% )',
+				} )
+				.on( 'mouseup', function( event ) {
+					event.stopImmediatePropagation();
+					form.find( ':submit' ).click();
+				} )
+				.find( '> *' )
+				.css( 'pointer-events', 'none' );
 		} );
 
 	// True if the product is simple or the user selected a valid variation. False on variable product without a valid variation selected


### PR DESCRIPTION
Per #515, when attempting to pay with PayPal from product page where products are missing required or variable fields, the PPEC buttons don't trigger the same behaviors as the default WC Add To Cart button. This leads to some disconnect between the two, and a somewhat awkward experience for the user.

### Steps to reproduce:

1. Create a new required field (Multiple Choice/Radio Buttons) for all products with WooCommerce Product Add-ons extension
2. From the front-end, visit a simple product page and select either of the PayPal buttons. Nothing will happen
3. Select the Add to cart button. You should see an HTML form validation popup
4. Visit a variable product page, and select either PP button (without modifying the product form). Again, nothing will happen
5. Select the Add to cart button. You should see some sort of warning about selecting product options
6. Select product options, leaving the required field empty, and select a PP button again. Nothing should happen.
7. Select Add to cart. You should see another validation warning

### Description

This adds an event listener to the PPEC button container when it is disabled (not all required/variable fields are complete) which triggers the Add To Cart button to click when a PP button is selected. This, in turn, enforces the default WC behavior, displaying the same alerts and popups.

Closes #515 