### PR TITLE
Check for response error message before assigning

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -122,11 +122,16 @@
 						body: data,
 					} ).then( function( response ) {
 						if ( ! response.success ) {
-							var messageItems = response.data.messages.map( function( message ) {
-								return '<li>' + message + '</li>';
-							} ).join( '' );
-
-							showError( '<ul class="woocommerce-error" role="alert">' + messageItems + '</ul>', selector );
+							// Error messages may be preformatted in which case response structure will differ
+							var messages = response.data ? response.data.messages : response.messages;
+							if ( 'string' === typeof messages ) {
+								showError( messages );
+							} else {
+								var messageItems = messages.map( function( message ) {
+									return '<li>' + message + '</li>';
+								} ).join( '' );
+								showError( '<ul class="woocommerce-error" role="alert">' + messageItems + '</ul>', selector );
+							}
 							return null;
 						}
 						return response.data.token;


### PR DESCRIPTION
Per #708 when an invalid email is entered prior to selecting a PayPal button, the process fails and no error message is displayed for the user.

### Steps to Reproduce:
( From #708 )

1. Fill all the checkout fields (Name, Address, Postcode and ...) except Email
2. Fill the email field with an incorrect format like (test@test) or just (test)
3. Click on the PayPal button
4. You will see no errors appear and PayPal popup or new tab doesn't work.

### Description
After some digging, it looks like the reason for this is cases in which a non-empty invalid email is entered, [the response from our AJAX call in the spb script](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/49416711ebd4fcc3f945853d2856e71b528a4392/assets/js/wc-gateway-ppec-smart-payment-buttons.js#L123) is not structured as we expect.

What we get from WC is something like:

```
{
	result: "failure", 
	messages: "<ul class="woocommerce-error" role="alert">↵ <li>↵ Invalid billing email address </li>↵ </ul>↵", 
	...
}
```

And what we are expecting is something like:

```
{
	success: false,
	data: {
		messages: [
			_error string_
		]
	}
	...
}
```

As a result, [when attempting to map through the messages array](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/49416711ebd4fcc3f945853d2856e71b528a4392/assets/js/wc-gateway-ppec-smart-payment-buttons.js#L125) in these cases, an exception is thrown.

To get around this, I added a conditional when assigning error messages to check whether the response contains the error in `response.data.messages` or `response.messages`, finally showing the error accordingly.

This works, but in cases where there are multiple fields empty and multiple error messages should be displayed, the response still only contains the single email-related error message. 

It looks like this is because when we trigger [process_checkout()](https://github.com/woocommerce/woocommerce/blob/3bf473517d407ae46264e0081dfeafedbcce68d6/includes/class-wc-checkout.php#L1106), BEFORE getting to [validate_checkout()](https://github.com/woocommerce/woocommerce/blob/3bf473517d407ae46264e0081dfeafedbcce68d6/includes/class-wc-checkout.php#L1134) which our logic relies on, the email field is first validated in the call to [update_session()](https://github.com/woocommerce/woocommerce/blob/3bf473517d407ae46264e0081dfeafedbcce68d6/includes/class-wc-checkout.php#L1131)

I tried to see if there was a way to bypass/work around this, but it doesn't seem like there is. As it stands, this PR will display messages in all cases, but won't display multiple errors when an invalid email is entered.

@mattallan would you mind looking over this when you have time to confirm whether I've missed anything?

Thank you!

Fixes #708 
