### PR TITLE
Save transaction data of Reference transactions in _woo_pp_txnData meta

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -386,6 +386,10 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$txn_data = $old_wc ? get_post_meta( $order_id, '_woo_pp_txnData', true ) : $order->get_meta( '_woo_pp_txnData', true );
 		$order_currency = $old_wc ? $order->order_currency : $order->get_currency();
 
+		if( ! isset($txn_data['refundable_txns'] ) ) {
+			return new WP_Error( 'paypal_refund_error', __( 'Refund Error: Sorry! This is not a refundable transaction.', 'woocommerce-gateway-paypal-express-checkout' ) );
+		}
+
 		foreach ( $txn_data['refundable_txns'] as $key => $value ) {
 			$refundable_amount = $value['amount'] - $value['refunded_amount'];
 

--- a/includes/class-wc-gateway-ppec-with-paypal-addons.php
+++ b/includes/class-wc-gateway-ppec-with-paypal-addons.php
@@ -195,44 +195,10 @@ class WC_Gateway_PPEC_With_PayPal_Addons extends WC_Gateway_PPEC_With_PayPal {
 			if ( ! $client->response_has_success_status( $response ) ) {
 				throw new Exception( __( 'PayPal API error', 'woocommerce-gateway-paypal-express-checkout' ) );
 			}
-			$settings = wc_gateway_ppec()->settings;
-			$old_wc   = version_compare( WC_VERSION, '3.0', '<' );
-			$meta     = $old_wc ? get_post_meta( $order_id, '_woo_pp_txnData', true ) : $order->get_meta( '_woo_pp_txnData', true );
 
-			if ( ! empty( $meta ) ) {
-				$txnData = $meta;
-			} else {
-				$txnData = array( 'refundable_txns' => array() );
-			}
-
-			$txn = array(
-				'txnID'           => $response['TRANSACTIONID'],
-				'amount'          => $response['AMT'],
-				'refunded_amount' => 0
-			);
+			wc_gateway_ppec_save_transaction_data( $order, $response );
 
 			$status = ! empty( $response['PAYMENTSTATUS'] ) ? $response['PAYMENTSTATUS'] : '';
-
-			if ( 'Completed' == $status ) {
-				$txn['status'] = 'Completed';
-			} else {
-				$txn['status'] = $status . '_' . $response['REASONCODE'];
-			}
-			$txnData['refundable_txns'][] = $txn;
-
-			$paymentAction = $settings->get_paymentaction();
-
-			if ( 'authorization' == $paymentAction ) {
-				$txnData['auth_status'] = 'NotCompleted';
-			}
-
-			$txnData['txn_type'] = $paymentAction;
-
-			if ( $old_wc ) {
-				update_post_meta( $order_id, '_woo_pp_txnData', $txnData );
-			} else {
-				$order->update_meta_data( '_woo_pp_txnData', $txnData );
-			}
 
 			switch ( $status ) {
 				case 'Pending':

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -165,3 +165,56 @@ function wc_gateway_ppec_is_US_based_store() {
 	$base_location = wc_get_base_location();
 	return in_array( $base_location['country'], array( 'US', 'PR', 'GU', 'VI', 'AS', 'MP' ), true );
 }
+
+/**
+ * Saves the transaction details from the transaction response into a post meta.
+ *
+ * @since 2.0
+ *
+ * @param object $order                Order for which the transaction was made
+ * @param object $transaction_response Response from a transaction, which contains the transaction details
+ * @param object $prefix               A prefix string which is empty for Reference Transactions and is 'PAYMENTINFO_0_' for Express Checkout
+ * @return void
+ */
+function wc_gateway_ppec_save_transaction_data( $order, $transaction_response, $prefix = '' ) {
+
+	$settings = wc_gateway_ppec()->settings;
+	$old_wc   = version_compare( WC_VERSION, '3.0', '<' );
+	$order_id = $old_wc ? $order->id : $order->get_id();
+	$meta     = $old_wc ? get_post_meta( $order_id, '_woo_pp_txnData', true ) : $order->get_meta( '_woo_pp_txnData', true );
+
+	if ( ! empty( $meta ) ) {
+		$txnData = $meta;
+	} else {
+		$txnData = array( 'refundable_txns' => array() );
+	}
+
+	$txn = array(
+		'txnID'           => $transaction_response[$prefix . 'TRANSACTIONID'],
+		'amount'          => $transaction_response[$prefix . 'AMT'],
+		'refunded_amount' => 0
+	);
+
+	$status = ! empty( $transaction_response[$prefix . 'PAYMENTSTATUS'] ) ? $transaction_response[$prefix . 'PAYMENTSTATUS'] : '';
+
+	if ( 'Completed' == $status ) {
+		$txn['status'] = 'Completed';
+	} else {
+		$txn['status'] = $status . '_' . $transaction_response[$prefix . 'REASONCODE'];
+	}
+	$txnData['refundable_txns'][] = $txn;
+
+	$paymentAction = $settings->get_paymentaction();
+
+	if ( 'authorization' == $paymentAction ) {
+		$txnData['auth_status'] = 'NotCompleted';
+	}
+
+	$txnData['txn_type'] = $paymentAction;
+
+	if ( $old_wc ) {
+		update_post_meta( $order_id, '_woo_pp_txnData', $txnData );
+	} else {
+		$order->update_meta_data( '_woo_pp_txnData', $txnData );
+	}
+}


### PR DESCRIPTION
**Issue**: #612

---

### Description
Whenever a Reference Transaction is done( via a renewal order of WC Subscriptions or a scheduled order of Autoship ) the transaction details are not stored in `_woo_pp_txnData` meta like it is done with Express Checkout. Because of this, the Reference Transaction orders throw errors while refund.

To fix this, the details required for refund are saved in the `_woo_pp_txnData`  meta for Reference Transactions too.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Create a subscription product and purchase it.
1. Try to refund the parent order. This should fo through without any issues.
1. Now, process a renewal order on the subscription. 
1. Try to refund the renewal order. On this branch, it will go through but on any other branch, it will throw an error.
1. Also note that the renewal order has an entry for `_woo_pp_txnData` meta in `wp_postmeta` table in the database on this branch, while there is no such entry made on other branches.


Closes #612 .
