### PR TITLE
Validate incomplete API credentials fields

### DIFF
--- a/assets/js/wc-gateway-ppec-settings.js
+++ b/assets/js/wc-gateway-ppec-settings.js
@@ -26,6 +26,9 @@
 			$( 'body' ).trigger( 'wc_ppec_cert_changed', [ 'live' ] );
 			$( '#woocommerce_ppec_paypal_sandbox_api_signature' ).trigger( 'change' );
 			$( '#woocommerce_ppec_paypal_api_signature' ).trigger( 'change' );
+
+			$( 'input[type=text]' ).on( 'keypress', this.maybeSubmitSettings );
+			$( 'input[type=password]' ).on( 'keypress', this.maybeSubmitSettings );
 		},
 
 		onClickUploadButton: function( event ) {
@@ -140,7 +143,22 @@
 			} else {
 				$( signature_selector ).closest( 'tr' ).fadeIn();
 			}
-		}
+		},
+
+		/**
+		 * Saves the PayPal Checkout settings when the enter key is pressed inside a text field.
+		 *
+		 * This is the default WC behaviour, however, the image upload buttons were being 'clicked' instead.
+		 *
+		 * @param event
+		 */
+		maybeSubmitSettings: function( event ) {
+			// If the enter key is pressed.
+			if ( 13 === event.which ) {
+				event.preventDefault();
+				$( ".woocommerce-save-button[name='save']" ).click();
+			}
+		},
 	};
 
 	function getAttachmentUrl( attachment ) {

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -275,70 +275,68 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		$settings = wc_gateway_ppec()->settings->load( true );
 		$creds    = $settings->get_active_api_credentials();
 
-		$username = $creds->get_username();
-		$password = $creds->get_password();
+		$has_username   = (bool) $creds->get_username();
+		$has_password   = (bool) $creds->get_password();
+		$has_credential = is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Signature' ) ? (bool) $creds->get_signature() : (bool) $creds->get_certificate();
+		$errors         = array();
 
-		if ( empty( $username ) ) {
+		// Attempt to validate the credentials if any one of them has been set.
+		if ( ! $has_username && ! $has_password && ! $has_credential ) {
 			return;
 		}
 
-		if ( empty( $password ) ) {
-			WC_Admin_Settings::add_error( __( 'Error: You must enter API password.', 'woocommerce-gateway-paypal-express-checkout' ) );
-			return false;
+		if ( ! $has_username ) {
+			$errors[] = __( 'Error: You must enter API username.', 'woocommerce-gateway-paypal-express-checkout' );
 		}
 
-		if ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Signature' ) && $creds->get_signature() ) {
+		if ( ! $has_password ) {
+			$errors[] = __( 'Error: You must enter API password.', 'woocommerce-gateway-paypal-express-checkout' );
+		}
 
-			try {
+		if ( ! $has_credential ) {
+			$errors[] = __( 'Error: You must provide API signature or certificate.', 'woocommerce-gateway-paypal-express-checkout' );
+		}
 
-				$payer_id = wc_gateway_ppec()->client->test_api_credentials( $creds, $settings->get_environment() );
+		// Only attempt to validate the credential (signature or cert), if all fields are set.
+		if ( $has_username && $has_password && $has_credential ) {
+			if ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Signature' ) ) {
+				try {
+					$payer_id = wc_gateway_ppec()->client->test_api_credentials( $creds, $settings->get_environment() );
 
-				if ( ! $payer_id ) {
-					WC_Admin_Settings::add_error( __( 'Error: The API credentials you provided are not valid.  Please double-check that you entered them correctly and try again.', 'woocommerce-gateway-paypal-express-checkout' ) );
-					return false;
+					if ( ! $payer_id ) {
+						$errors[] = __( 'Error: The API credentials you provided are not valid.  Please double-check that you entered them correctly and try again.', 'woocommerce-gateway-paypal-express-checkout' );
+					}
+				} catch ( PayPal_API_Exception $ex ) {
+
+					$errors[] = __( 'An error occurred while trying to validate your API credentials. Unable to verify that your API credentials are correct.', 'woocommerce-gateway-paypal-express-checkout' );
 				}
-			} catch ( PayPal_API_Exception $ex ) {
+			} elseif ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Certificate' ) ) {
 
-				WC_Admin_Settings::add_error( __( 'An error occurred while trying to validate your API credentials.  Unable to verify that your API credentials are correct.', 'woocommerce-gateway-paypal-express-checkout' ) );
-			}
-		} elseif ( is_a( $creds, 'WC_Gateway_PPEC_Client_Credential_Certificate' ) && $creds->get_certificate() ) {
+				$cert = @openssl_x509_read( $creds->get_certificate() ); // @codingStandardsIgnoreLine
 
-			$cert = @openssl_x509_read( $creds->get_certificate() ); // @codingStandardsIgnoreLine
-
-			if ( false === $cert ) {
-				WC_Admin_Settings::add_error( __( 'Error: The API certificate is not valid.', 'woocommerce-gateway-paypal-express-checkout' ) );
-				return false;
-			}
-
-			$cert_info   = openssl_x509_parse( $cert );
-			$valid_until = $cert_info['validTo_time_t'];
-
-			if ( $valid_until < time() ) {
-				WC_Admin_Settings::add_error( __( 'Error: The API certificate has expired.', 'woocommerce-gateway-paypal-express-checkout' ) );
-				return false;
-			}
-
-			if ( $cert_info['subject']['CN'] != $creds->get_username() ) {
-				WC_Admin_Settings::add_error( __( 'Error: The API username does not match the name in the API certificate.  Make sure that you have the correct API certificate.', 'woocommerce-gateway-paypal-express-checkout' ) );
-				return false;
-			}
-
-			try {
-
-				$payer_id = wc_gateway_ppec()->client->test_api_credentials( $creds, $settings->get_environment() );
-
-				if ( ! $payer_id ) {
-					WC_Admin_Settings::add_error( __( 'Error: The API credentials you provided are not valid.  Please double-check that you entered them correctly and try again.', 'woocommerce-gateway-paypal-express-checkout' ) );
-					return false;
+				if ( false === $cert ) {
+					$errors[] = __( 'Error: The API certificate is not valid.', 'woocommerce-gateway-paypal-express-checkout' );
 				}
-			} catch ( PayPal_API_Exception $ex ) {
-				WC_Admin_Settings::add_error( __( 'An error occurred while trying to validate your API credentials.  Unable to verify that your API credentials are correct.', 'woocommerce-gateway-paypal-express-checkout' ) );
+
+				$cert_info   = openssl_x509_parse( $cert );
+				$valid_until = $cert_info['validTo_time_t'];
+
+				if ( $valid_until < time() ) {
+					$errors[] = __( 'Error: The API certificate has expired.', 'woocommerce-gateway-paypal-express-checkout' );
+				} elseif ( $cert_info['subject']['CN'] !== $creds->get_username() ) {
+					$errors[] = __( 'Error: The API username does not match the name in the API certificate. Make sure that you have the correct API certificate.', 'woocommerce-gateway-paypal-express-checkout' );
+				}
+
+				try {
+					$payer_id = wc_gateway_ppec()->client->test_api_credentials( $creds, $settings->get_environment() );
+
+					if ( ! $payer_id ) {
+						$errors[] = __( 'Error: The API credentials you provided are not valid.  Please double-check that you entered them correctly and try again.', 'woocommerce-gateway-paypal-express-checkout' );
+					}
+				} catch ( PayPal_API_Exception $ex ) {
+					$errors[] = __( 'An error occurred while trying to validate your API credentials.  Unable to verify that your API credentials are correct.', 'woocommerce-gateway-paypal-express-checkout' );
+				}
 			}
-
-		} else {
-
-			WC_Admin_Settings::add_error( __( 'Error: You must provide API signature or certificate.', 'woocommerce-gateway-paypal-express-checkout' ) );
-			return false;
 		}
 
 		$settings_array = (array) get_option( 'woocommerce_ppec_paypal_settings', array() );
@@ -355,8 +353,15 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 			if ( ! $is_account_enabled_for_billing_address ) {
 				$settings_array['require_billing'] = 'no';
 				update_option( 'woocommerce_ppec_paypal_settings', $settings_array );
-				WC_Admin_Settings::add_error( __( 'The "require billing address" option is not enabled by your account and has been disabled.', 'woocommerce-gateway-paypal-express-checkout' ) );
+				$errors[] = __( 'The "require billing address" option is not enabled by your account and has been disabled.', 'woocommerce-gateway-paypal-express-checkout' );
 			}
+		}
+
+		if ( ! empty( $errors ) ) {
+			foreach ( $errors as $message ) {
+				WC_Admin_Settings::add_error( $message );
+			}
+			return false;
 		}
 	}
 

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -4,11 +4,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$api_username         = $this->get_option( 'api_username' );
-$sandbox_api_username = $this->get_option( 'sandbox_api_username' );
+$live_credentials       = wc_gateway_ppec()->settings->get_live_api_credentials();
+$sandbox_credentials    = wc_gateway_ppec()->settings->get_sandbox_api_credentials();
+$has_live_credential    = is_a( $live_credentials, 'WC_Gateway_PPEC_Client_Credential_Signature' ) ? (bool) $live_credentials->get_signature() : (bool) $live_credentials->get_certificate();
+$has_sandbox_credential = is_a( $sandbox_credentials, 'WC_Gateway_PPEC_Client_Credential_Signature' ) ? (bool) $sandbox_credentials->get_signature() : (bool) $sandbox_credentials->get_certificate();
 
-$needs_creds         = empty( $api_username );
-$needs_sandbox_creds = empty( $sandbox_api_username );
+$needs_creds         = ! $has_live_credential && ! (bool) $live_credentials->get_username() && ! (bool) $live_credentials->get_password();
+$needs_sandbox_creds = ! $has_sandbox_credential && ! (bool) $sandbox_credentials->get_username() && ! (bool) $sandbox_credentials->get_password();
 $enable_ips          = wc_gateway_ppec()->ips->is_supported();
 
 if ( $enable_ips && $needs_creds ) {


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #706 

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

API Credential validation was pretty confusing and imo not complete. It only started validating if you entered a username. This meant if you added just a signature, it would save without any error being displayed. 

With this PR, the idea is that validation starts if any API credential is added. 

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Go to **WooCommerce > Settings > Payments > PayPal Checkout**
1. Make a note of your existing credentials. 
1. Remove all credentials except for your signature and **Save**.
     1. On `master` you'll notice two things:
                - You don't get any error message. Just a notice saying your [settings were saved](https://user-images.githubusercontent.com/8490476/78846699-f20a7c80-7a4f-11ea-9d3f-4bcf2674953b.png).
                 - If you scroll down to the credentials, you'll also notice that the [fields are hidden](https://user-images.githubusercontent.com/8490476/78846763-34cc5480-7a50-11ea-9fb9-4aed909ddb8d.png) and need to be expanded to see the credentials you have added.
     2.  On this branch you will [receive error messages for all missing or invalid credentials](https://user-images.githubusercontent.com/8490476/78846881-92f93780-7a50-11ea-9237-e403c40a6d70.png). The [fields are also shown](https://user-images.githubusercontent.com/8490476/78846925-b328f680-7a50-11ea-8fc0-57a772da88b2.png) if any credential has been set.
1. Beyond those basic steps, test various combinations of missing and set credentials and test that the error messages are intuitive and informative. 

@menakas pinging you given you raised this issue in #696. Let me know what you think of this.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #706 
