### PR TITLE
Notify user on single product page if cart has contents

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -31,6 +31,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		add_action( 'widget_title', array( $this, 'maybe_enqueue_checkout_js' ), 10, 3 );
 
 		if ( 'yes' === wc_gateway_ppec()->settings->checkout_on_single_product_enabled ) {
+			add_action( 'woocommerce_before_main_content', array( $this, 'display_notice_product' ) );
 			add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'display_paypal_button_product' ), 1 );
 			add_action( 'wc_ajax_wc_ppec_generate_cart', array( $this, 'wc_ajax_generate_cart' ) );
 			add_action( 'wp', array( $this, 'ensure_session' ) ); // Ensure there is a customer session so that nonce is not invalidated by new session created on AJAX POST request.
@@ -278,6 +279,17 @@ class WC_Gateway_PPEC_Cart_Handler {
 			$customer->set_billing_postcode( $billing_postcode );
 			$customer->set_billing_phone( $billing_phone );
 			$customer->set_billing_email( $billing_email );
+		}
+	}
+
+	/**
+	 * Display notice on single product page if cart contains items
+	 *
+	 * @since 2.0.0
+	 */
+	public function display_notice_product() {
+		if (WC()->cart->get_cart_contents_count() > 0) {
+			wc_add_notice( apply_filters( 'woocommerce_paypal_express_checkout__cart_not_empty_message', esc_html__('Clicking on the Smart Payment buttons will not add the cart items for purchase!', 'woocommerce-gateway-paypal-express-checkout' ) ), 'notice' );
 		}
 	}
 


### PR DESCRIPTION
**Issue**: #498

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
When there exists items in the cart, clicking the smart payment button on single product page cause the cart to be emptied without any warning and the single product is checked out.

This work adds a confirmation message asking if cart contents should be added to the purchase. Based on the user input, either the cart contents are added to the purchase or just the single product is checked out.


### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Add a product A to the cart
1. Go to another product B's page.
1. Click on the PayPal smart button.
1. On master, the product A is removed from the cart and B is checked out. On this branch, a confirmation message is asked. If user input is 'Ok' to add cart contents, both A and B are checked out. If user input is 'Cancel', only B is checked out.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #498 .
