### PR TITLE
Fixes "Billing State / County is a required field." error on Confirm your PayPal Order page

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -126,6 +126,11 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			return $fields;
 		}
 
+		// Regardless of shipping, PP doesn't have the county required (e.g. using Ireland without a county is acceptable)
+		if ( array_key_exists( 'state', $fields ) ) {
+			$fields['state']['required'] = false;
+		}
+
 		if ( ! apply_filters( 'woocommerce_paypal_express_checkout_address_not_required', ! WC_Gateway_PPEC_Plugin::needs_shipping() ) ) {
 			return $fields;
 		}
@@ -137,11 +142,6 @@ class WC_Gateway_PPEC_Checkout_Handler {
 					$fields[ $not_required_field ]['required'] = false;
 				}
 			}
-		}
-
-		// Regardless of shipping, PP doesn't have the county required (e.g. using Ireland without a county is acceptable)
-		if ( array_key_exists( 'state', $fields ) ) {
-			$fields['state']['required'] = false;
 		}
 
 		return $fields;


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issues**: #722 and #724

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
When you try to purchase a product with PP from the product/cart page and set your country to Cyprus, when you return from PayPal and try to place the order, you'll get a "Billing State/County is a required field" error.

To explain... when you set your country to Cyprus in PayPal checkout, the address fields don't have a state field and only requires a city to be filled in: https://d.pr/i/B0n9wX

On the WooCommerce side, we do include a State field for Cyprus and it's set as required: https://d.pr/i/FGmyzM

While digging through the code I noticed we have a line of code that makes the [State field optional while on the "confirm your Paypal order" page](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/06ae4cecdb9c3c976d3ba2dcbe7237e9b78da42f/includes/class-wc-gateway-ppec-checkout-handler.php#L143-L145), however this code doesn't run if the cart needs shipping because we exit early due to [this condition](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/06ae4cecdb9c3c976d3ba2dcbe7237e9b78da42f/includes/class-wc-gateway-ppec-checkout-handler.php#L129).

Based on the [inline comment](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/06ae4cecdb9c3c976d3ba2dcbe7237e9b78da42f/includes/class-wc-gateway-ppec-checkout-handler.php#L142) which says "regardless of shipping" and my understanding of this function, I believe the fix here is to make sure we make the `billing_state` field optional on the Confirm your PayPal Order page.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Visit a non-virtual product page
1. click on one the PayPal SPB
1. Choose Cyprus as the country when you're filling out the PP Checkout modal
1. Return to the "Confirm your PayPal Order" page and try to place the order
1. You should see an error saying "Billing State / County is a required field."

![](https://d.pr/i/oYJ72W+)

---

This doesn't close both the related issues since they've also mentioned seeing other errors when clicking the place order button on the Confirm your PayPal Order page.
