### PR TITLE
Fixes "PHP Warning: Creating default object from empty value" when a PayPal session doesn't exist

### DIFF
--- a/includes/class-wc-gateway-ppec-with-spb-addons.php
+++ b/includes/class-wc-gateway-ppec-with-spb-addons.php
@@ -46,7 +46,7 @@ class WC_Gateway_PPEC_With_SPB_Addons extends WC_Gateway_PPEC_With_PayPal_Addons
 	 */
 	public function process_payment( $order_id ) {
 		if ( isset( $_POST['payerID'] ) && isset( $_POST['paymentToken'] ) ) {
-			$session = WC()->session->get( 'paypal' );
+			$session = WC()->session->get( 'paypal', new stdClass() );
 
 			$session->checkout_completed = true;
 			$session->payer_id           = $_POST['payerID'];

--- a/includes/class-wc-gateway-ppec-with-spb.php
+++ b/includes/class-wc-gateway-ppec-with-spb.php
@@ -46,7 +46,7 @@ class WC_Gateway_PPEC_With_SPB extends WC_Gateway_PPEC_With_PayPal {
 	 */
 	public function process_payment( $order_id ) {
 		if ( isset( $_POST['payerID'] ) && isset( $_POST['paymentToken'] ) ) {
-			$session = WC()->session->get( 'paypal' );
+			$session = WC()->session->get( 'paypal', new stdClass() );
 
 			$session->checkout_completed = true;
 			$session->payer_id           = $_POST['payerID'];


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #718

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
In PHP versions 5.4 and above, a PHP warning is thrown when you try to set `$session->{value}` when `$session` is `null`.

This PR removes these warnings by sending a default return value when calling `WC()->session->get( 'PayPal' )` when a session doesn't exist.

Closes #718 
