### PR TITLE
Pass store currency to SDK SPB args

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -541,6 +541,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 					'locale'     => $settings->get_paypal_locale(),
 					'components' => 'buttons,funding-eligibility',
 					'commit'     => 'checkout' === $page ? 'true' : 'false',
+					'currency'   => get_woocommerce_currency(),
 				);
 
 				wp_register_script( 'paypal-checkout-js', add_query_arg( $script_args, 'https://www.paypal.com/sdk/js' ), array(), null, true );


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->

**Slack thread**: https://a8c.slack.com/archives/CJTS771PB/p1588918039373700

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

When the store's base currency is set to AUD (and possibly other currencies), clicking the new SPBs leads to a console log error. See below.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Set your store's base currency to AUD https://cloudup.com/cf9Z4m3JjOO
1. Go to a product page and click the new PayPal SDK SPB.
     1. On `2.0_dev` the modal will pop up and then close with the following errors in the console log. 
     2. On this branch, the modal displays correctly and payment can be taken. 

<img width="1038" alt="Screen Shot 2020-05-08 at 5 27 45 pm" src="https://user-images.githubusercontent.com/8490476/81382154-45581380-9151-11ea-91de-75a5c6eadcfa.png">

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->
