### PR TITLE
Update the deploy script and `.git*` files to ignore composer, vendor and other developer files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+.github export-ignore
 .gitattributes export-ignore
 .gitmodules export-ignore
 .gitignore export-ignore
@@ -9,3 +10,8 @@ package.json export-ignore
 package-lock.json export-ignore
 phpunit.xml export-ignore
 phpcs.xml export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+vendor export-ignore
+.editorconfig export-ignore
+wordpress_org_assets export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 sftp-config.json
 /deploy/
 /vendor/
+composer.lock
 
 # Ignore all log files except for .htaccess
 /logs/*

--- a/deploy.sh
+++ b/deploy.sh
@@ -77,6 +77,11 @@ DEVELOPER.md
 package-lock.json
 package.json
 deploy.sh
+composer.lock
+composer.json
+vendor
+.gitattributes
+.editorconfig
 .gitignore" $SVNPATH/trunk/
 
 echo "Moving assets-wp-repo"


### PR DESCRIPTION
With the introduction of using `composer install` to run `phpcs` (see #719), this PR makes sure we don't accidentally deploy or push up any composer or other developer files.

Changes:

 - adds `composer.lock` to .gitignore 
 - adds `composer.lock`, `composer.json`, `vendor`, `.gitattributes` and `.editorconfig` to the list of ignored files/directories when copying files over to the .org SVN
 - adds export-ignore flags for `composer.json`, `composer.lock`, `vendor/` and `.editorconfig` in the `.gitattributes` file