### PR TITLE
Add PHP version requirement and update WP and WC tested up to versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,8 @@
 Contributors: automattic, woothemes, akeda, dwainm, royho, allendav, slash1andy, woosteve, spraveenitpro, mikedmoore, fernashes, shellbeezy, danieldudzic, mikaey, fullysupportedphil, dsmithweb, corsonr, bor0, zandyring, pauldechov, robobot3000
 Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, store, sales, sell, shop, shopping, cart, checkout, configurable, paypal
 Requires at least: 4.4
-Tested up to: 5.3
+Tested up to: 5.4
+Requires PHP: 5.5
 Stable tag: 1.6.21
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -11,7 +11,7 @@
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: woocommerce-gateway-paypal-express-checkout
  * Domain Path: /languages
- * WC tested up to: 4.0
+ * WC tested up to: 4.1
  * WC requires at least: 2.6
  */
 /**


### PR DESCRIPTION
Adds a `Requires PHP` flag and updates the WC and WP tested up to versions.

Closes #701, closes #715, closes #608 
