### PR TITLE
Add en_CA to the list of PayPal supported locales

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -31,6 +31,7 @@ class WC_Gateway_PPEC_Settings {
 		'en_IN',
 		'en_GB',
 		'en_US',
+		'en_CA',
 		'es_ES',
 		'es_XC',
 		'fi_FI',


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #733


---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

PayPal's [locale docs](https://developer.paypal.com/docs/api/reference/locale-codes/#supported-locale-codes) list `en_US` as the code to use for Canadian English, however, this means when customers choose to pay with a credit card, the default address is US. After some testing, it appears the docs are incorrect and using `en_CA` works.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. In your sites, general settings set the language to English Canada (https://cloudup.com/cVrqnwcOGmF)
1. Add a product to the cart and proceed to checkout. 
1. Click the credit card Smart Payment Button.
      1. On `master` you'll notice US is the default address. https://cloudup.com/cejsTyhAPwC
      2. On this branch the address is Canada by default. https://cloudup.com/cpMNOlYRfeO
1. I also tested using the legacy JS and it works there too. 
     1. On `master` `en_US` is passed to the modal and the address is US by default. https://cloudup.com/iZKdPBo3mOk
     2. On this branch, the modal is passed `en_CA` and Canada is the default. https://cloudup.com/iUi7XWUvneF. *

\* For some reason the URL when you click the credit card button in the PayPal modal changes to something like this: https://www.sandbox.paypal.com/.../...?locale.x=en_US...&country.x=CA&locale.x=en_CA&country.x=CA. You'll notice there is a `locale.x=en_US` and a `locale.x=en_CA`. This URL is generated by PayPal but just wanted to note it in case you see the `en_US` and wondering what's up with that. 

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #733
