### PR TITLE
#735: Update plugin links

### DIFF
--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -443,8 +443,8 @@ class WC_Gateway_PPEC_Plugin {
 
 		if ( false !== strpos( $file, plugin_basename( dirname( __DIR__ ) ) ) ) {
 			$row_meta = array(
-				'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_docs_url', 'https://docs.woocommerce.com/document/paypal-express-checkout/' ) ) . '" title="' . esc_attr( __( 'View Documentation', 'woocommerce-gateway-paypal-express-checkout' ) ) . '">' . __( 'Docs', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
-				'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_support_url', 'https://woocommerce.com/my-account/create-a-ticket?select=woocommerce-gateway-paypal-checkout' ) ) . '" title="' . esc_attr( __( 'Open a support request at WooCommerce.com', 'woocommerce-gateway-paypal-express-checkout' ) ) . '">' . __( 'Support', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
+				'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_docs_url', 'https://docs.woocommerce.com/document/paypal-express-checkout/' ) ) . '" title="' . esc_attr__( 'View Documentation', 'woocommerce-gateway-paypal-express-checkout' ) . '">' . esc_html__( 'Docs', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
+				'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_support_url', 'https://woocommerce.com/my-account/create-a-ticket?select=woocommerce-gateway-paypal-checkout' ) ) . '" title="' . esc_attr__( 'Open a support request at WooCommerce.com', 'woocommerce-gateway-paypal-express-checkout' ) . '">' . esc_html__( 'Support', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
 			);
 			return array_merge( $links, $row_meta );
 		}

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -148,6 +148,7 @@ class WC_Gateway_PPEC_Plugin {
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->file ), array( $this, 'plugin_action_links' ) );
+		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_ajax_ppec_dismiss_notice_message', array( $this, 'ajax_dismiss_notice' ) );
 	}
 
@@ -427,9 +428,27 @@ class WC_Gateway_PPEC_Plugin {
 			$plugin_links[] = '<a href="' . esc_url( $setting_url ) . '">' . esc_html__( 'Settings', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>';
 		}
 
-		$plugin_links[] = '<a href="https://docs.woocommerce.com/document/paypal-express-checkout/">' . esc_html__( 'Docs', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>';
-
 		return array_merge( $plugin_links, $links );
+	}
+
+	/**
+	 * Plugin page links to support and documentation
+	 *
+	 * @since 1.6.22
+	 * @param  array  $links List of plugin links.
+	 * @param  string $file Current file.
+	 * @return array
+	 */
+	public function plugin_row_meta( $links, $file ) {
+
+		if ( false !== strpos( $file, plugin_basename( dirname( __DIR__ ) ) ) ) {
+			$row_meta = array(
+				'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_docs_url', 'https://docs.woocommerce.com/document/paypal-express-checkout/' ) ) . '" title="' . esc_attr( __( 'View Documentation', 'woocommerce-gateway-paypal-express-checkout' ) ) . '">' . __( 'Docs', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
+				'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_support_url', 'https://woocommerce.com/my-account/create-a-ticket?select=woocommerce-gateway-paypal-checkout' ) ) . '" title="' . esc_attr( __( 'Open a support request at WooCommerce.com', 'woocommerce-gateway-paypal-express-checkout' ) ) . '">' . __( 'Support', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
+			);
+			return array_merge( $links, $row_meta );
+		}
+		return (array) $links;
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -434,21 +434,22 @@ class WC_Gateway_PPEC_Plugin {
 	/**
 	 * Plugin page links to support and documentation
 	 *
-	 * @since 1.6.22
+	 * @since 2.0
 	 * @param  array  $links List of plugin links.
 	 * @param  string $file Current file.
 	 * @return array
 	 */
 	public function plugin_row_meta( $links, $file ) {
+		$row_meta = array();
 
 		if ( false !== strpos( $file, plugin_basename( dirname( __DIR__ ) ) ) ) {
 			$row_meta = array(
-				'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_docs_url', 'https://docs.woocommerce.com/document/paypal-express-checkout/' ) ) . '" title="' . esc_attr__( 'View Documentation', 'woocommerce-gateway-paypal-express-checkout' ) . '">' . esc_html__( 'Docs', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
-				'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_paypal_express_checkout_support_url', 'https://woocommerce.com/my-account/create-a-ticket?select=woocommerce-gateway-paypal-checkout' ) ) . '" title="' . esc_attr__( 'Open a support request at WooCommerce.com', 'woocommerce-gateway-paypal-express-checkout' ) . '">' . esc_html__( 'Support', 'woocommerce-gateway-paypal-express-checkout' ) . '</a>',
+				'docs'    => sprintf( '<a href="%s" title="%s">%s</a>', esc_url( 'https://docs.woocommerce.com/document/paypal-express-checkout/' ), esc_attr__( 'View Documentation', 'woocommerce-gateway-paypal-express-checkout' ), esc_html__( 'Docs', 'woocommerce-gateway-paypal-express-checkout' ) ),
+				'support' => sprintf( '<a href="%s" title="%s">%s</a>', esc_url( 'https://woocommerce.com/my-account/create-a-ticket?select=woocommerce-gateway-paypal-checkout' ), esc_attr__( 'Open a support request at WooCommerce.com', 'woocommerce-gateway-paypal-express-checkout' ), esc_html__( 'Support', 'woocommerce-gateway-paypal-express-checkout' ) ),
 			);
-			return array_merge( $links, $row_meta );
 		}
-		return (array) $links;
+
+		return array_merge( $links, $row_meta );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Move `Docs` link from action section to meta section and add `Support` link to the meta section.

Closes #735.

### How to test the changes in this Pull Request:

1. Check out featured branch 
2. Add plugin to testing site
3. Activate plugin
4. Look up links on plugin page

**Before:**

![#735-before](https://user-images.githubusercontent.com/3323310/82634994-60368780-9c29-11ea-812c-fe9970d05a7f.png)

**After:**

![#735-after](https://user-images.githubusercontent.com/3323310/82634991-5e6cc400-9c29-11ea-8ede-948eb3f64eb7.png)

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Update - Move `Docs` link from action section to meta section and add `Support` link to the meta section.



