### PR TITLE
Add en_NZ to the list of PayPal supported locales

### DIFF
--- a/includes/class-wc-gateway-ppec-settings.php
+++ b/includes/class-wc-gateway-ppec-settings.php
@@ -32,6 +32,7 @@ class WC_Gateway_PPEC_Settings {
 		'en_GB',
 		'en_US',
 		'en_CA',
+		'en_NZ',
 		'es_ES',
 		'es_XC',
 		'fi_FI',


### PR DESCRIPTION
Similar to #734.

In #536, the customer specifically requests adding support for New Zealand locale code but this was not added in #658.

As @menakas mentions in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/734#issuecomment-633331430, there are still some new locales we can add support for now that we're using the latest SDK, but let's not hold off releasing 2.0 because of this.

We can do a v2.1 in the next few weeks to add the rest :)