### PR TITLE
Release 2.0.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,22 @@
 *** Changelog ***
 
+= 2.0.0 - 2020-05-25 =
+* New - Upgrade to the latest PayPal Checkout Javascript SDK. PR#668
+* Add - New setting found under Button Styles for choosing a Smart Payment Button label. PR#666
+* Add - Support for more locales. PR#658
+* Fix - Display Smart Payment Buttons on Product pages built from a shortcode. PR#665
+* Fix - Send the product SKU to PayPal so it's displayed in the order/transaction details and reports on PayPal. PR#664
+* Fix - Show an error when saving incomplete/missing API credentials. PR#712
+* Fix - Remove PHP warnings in later versions of PHP when a PayPal Session doesn't exist. PR#727
+* Fix - Error when processing refunds (Already Refunded. No Amount to Refund). PR#710
+* Fix - Required state field errors on the "Confirm your PayPal Order" page when returning from PayPal. PR#725
+* Fix - Display WC Add To Cart validation errors on the product page when clicking the PayPal Smart Payment Buttons. PR#707
+* Update - Smart Payment Buttons are enabled by default and settings to toggle these on/off have been removed and replaced with a filter. PR#660
+* Update - Deprecate unused/incomplete function `WC_Gateway_PPEC_Client::update_billing_agreement()`. PR#602
+* Update - Move inline javascript found in `settings-ppec.php` to `ppec-settings.js`. PR#676
+* Update - Move Support and Documentation links from the plugin actions to plugin meta section on the Plugin activation/deactivation page. PR#735
+* Update - WooCommerce 4.1 and WordPress 5.4 compatibility. PR#732
+
 = 1.6.21 - 2020-04-14 =
 * Fix - Ensure Puerto Rico and supported Locales are eligible for PayPal Credit. PR#693
 * Fix - Support purchasing subscriptions with $0 initial payment - free trials, synced etc. PR#698

--- a/languages/woocommerce-gateway-paypal-express-checkout.pot
+++ b/languages/woocommerce-gateway-paypal-express-checkout.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the WooCommerce PayPal Checkout Gateway plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce PayPal Checkout Gateway 1.6.21\n"
+"Project-Id-Version: WooCommerce PayPal Checkout Gateway 2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-gateway-paypal-express-checkout\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-04-14T16:21:37+10:00\n"
+"POT-Creation-Date: 2020-05-25T14:58:35+10:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: woocommerce-gateway-paypal-express-checkout\n"
@@ -36,6 +36,8 @@ msgstr ""
 
 #: includes/abstracts/abstract-wc-gateway-ppec.php:18
 #: includes/class-wc-gateway-ppec-privacy.php:12
+#: includes/settings/settings-ppec.php:358
+#: includes/settings/settings-ppec.php:404
 msgid "PayPal Checkout"
 msgstr ""
 
@@ -43,108 +45,119 @@ msgstr ""
 msgid "Allow customers to conveniently checkout directly with PayPal."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:22
+#: includes/abstracts/abstract-wc-gateway-ppec.php:59
 msgid "Continue to payment"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:166
+#: includes/abstracts/abstract-wc-gateway-ppec.php:169
 msgid "Sorry, an error occurred while trying to process your payment. Please try again."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:199
+#: includes/abstracts/abstract-wc-gateway-ppec.php:202
 msgid "No API certificate on file."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:208
+#: includes/abstracts/abstract-wc-gateway-ppec.php:211
 msgid "expires on %s (%s)"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:212
+#: includes/abstracts/abstract-wc-gateway-ppec.php:215
 msgid "expired on %s (%s)"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:222
+#: includes/abstracts/abstract-wc-gateway-ppec.php:225
 msgid "Certificate belongs to API username %1$s; %2$s."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:224
+#: includes/abstracts/abstract-wc-gateway-ppec.php:227
 msgid "The certificate on file is not valid."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:284
+#: includes/abstracts/abstract-wc-gateway-ppec.php:292
+msgid "Error: You must enter API username."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:296
 msgid "Error: You must enter API password."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:295
-#: includes/abstracts/abstract-wc-gateway-ppec.php:329
-msgid "Error: The API credentials you provided are not valid.  Please double-check that you entered them correctly and try again."
-msgstr ""
-
 #: includes/abstracts/abstract-wc-gateway-ppec.php:300
-#: includes/abstracts/abstract-wc-gateway-ppec.php:333
-msgid "An error occurred while trying to validate your API credentials.  Unable to verify that your API credentials are correct."
-msgstr ""
-
-#: includes/abstracts/abstract-wc-gateway-ppec.php:307
-msgid "Error: The API certificate is not valid."
-msgstr ""
-
-#: includes/abstracts/abstract-wc-gateway-ppec.php:315
-msgid "Error: The API certificate has expired."
-msgstr ""
-
-#: includes/abstracts/abstract-wc-gateway-ppec.php:320
-msgid "Error: The API username does not match the name in the API certificate.  Make sure that you have the correct API certificate."
-msgstr ""
-
-#: includes/abstracts/abstract-wc-gateway-ppec.php:338
 msgid "Error: You must provide API signature or certificate."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:356
+#: includes/abstracts/abstract-wc-gateway-ppec.php:310
+#: includes/abstracts/abstract-wc-gateway-ppec.php:337
+msgid "Error: The API credentials you provided are not valid.  Please double-check that you entered them correctly and try again."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:314
+msgid "An error occurred while trying to validate your API credentials. Unable to verify that your API credentials are correct."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:321
+msgid "Error: The API certificate is not valid."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:328
+msgid "Error: The API certificate has expired."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:330
+msgid "Error: The API username does not match the name in the API certificate. Make sure that you have the correct API certificate."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:340
+msgid "An error occurred while trying to validate your API credentials.  Unable to verify that your API credentials are correct."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:359
 msgid "The \"require billing address\" option is not enabled by your account and has been disabled."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:375
+#: includes/abstracts/abstract-wc-gateway-ppec.php:384
 msgid "Refund Error: You need to specify a refund amount."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:395
-#: includes/abstracts/abstract-wc-gateway-ppec.php:418
-#: includes/abstracts/abstract-wc-gateway-ppec.php:468
+#: includes/abstracts/abstract-wc-gateway-ppec.php:396
+msgid "Refund Error: Sorry! This is not a refundable transaction."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-gateway-ppec.php:408
+#: includes/abstracts/abstract-wc-gateway-ppec.php:431
+#: includes/abstracts/abstract-wc-gateway-ppec.php:481
 msgid "PayPal refund completed; transaction ID = %s"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:442
+#: includes/abstracts/abstract-wc-gateway-ppec.php:455
 msgid "Refund Error: All transactions have been fully refunded. There is no amount left to refund"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:444
+#: includes/abstracts/abstract-wc-gateway-ppec.php:457
 msgid "Refund Error: The requested refund amount is too large. The refund amount must be less than or equal to %s."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:559
+#: includes/abstracts/abstract-wc-gateway-ppec.php:572
 msgid "Already using URL as image: %s"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:567
+#: includes/abstracts/abstract-wc-gateway-ppec.php:580
 msgid "Select a image to upload"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:568
+#: includes/abstracts/abstract-wc-gateway-ppec.php:581
 msgid "Use this image"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:569
-#: includes/abstracts/abstract-wc-gateway-ppec.php:572
+#: includes/abstracts/abstract-wc-gateway-ppec.php:582
+#: includes/abstracts/abstract-wc-gateway-ppec.php:585
 msgid "Add image"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:580
+#: includes/abstracts/abstract-wc-gateway-ppec.php:593
 msgid "Remove image"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-gateway-ppec.php:619
+#: includes/abstracts/abstract-wc-gateway-ppec.php:632
 msgid "Remove"
 msgstr ""
 
@@ -285,24 +298,28 @@ msgstr ""
 msgid "An error (%s) occurred while processing your PayPal payment.  Please contact the store owner for assistance."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:65
-#: includes/class-wc-gateway-ppec-cart-handler.php:135
-#: includes/class-wc-gateway-ppec-cart-handler.php:156
+#: includes/class-wc-gateway-ppec-cart-handler.php:70
+#: includes/class-wc-gateway-ppec-cart-handler.php:140
+#: includes/class-wc-gateway-ppec-cart-handler.php:161
 msgid "Cheatin&#8217; huh?"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:314
-#: includes/class-wc-gateway-ppec-cart-handler.php:359
-#: includes/class-wc-gateway-ppec-cart-handler.php:394
+#: includes/class-wc-gateway-ppec-cart-handler.php:319
+#: includes/class-wc-gateway-ppec-cart-handler.php:364
+#: includes/class-wc-gateway-ppec-cart-handler.php:399
 msgid "Check out with PayPal"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:349
+#: includes/class-wc-gateway-ppec-cart-handler.php:354
 msgid "&mdash; or &mdash;"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:364
+#: includes/class-wc-gateway-ppec-cart-handler.php:369
 msgid "Pay with PayPal Credit"
+msgstr ""
+
+#: includes/class-wc-gateway-ppec-cart-handler.php:509
+msgid "An error occurred while processing your PayPal payment. Please contact the store owner for assistance."
 msgstr ""
 
 #: includes/class-wc-gateway-ppec-checkout-handler.php:77
@@ -343,7 +360,7 @@ msgstr ""
 
 #: includes/class-wc-gateway-ppec-checkout-handler.php:444
 #: includes/class-wc-gateway-ppec-checkout-handler.php:498
-#: includes/class-wc-gateway-ppec-checkout-handler.php:1156
+#: includes/class-wc-gateway-ppec-checkout-handler.php:1124
 msgid "Your PayPal checkout session has expired. Please check out again."
 msgstr ""
 
@@ -359,29 +376,29 @@ msgstr ""
 msgid "You have cancelled Checkout with PayPal. Please try to process your order again."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-checkout-handler.php:983
+#: includes/class-wc-gateway-ppec-checkout-handler.php:951
 #: includes/class-wc-gateway-ppec-ipn-handler.php:190
 msgid "Payment authorized. Change payment status to processing or complete to capture funds."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-checkout-handler.php:985
+#: includes/class-wc-gateway-ppec-checkout-handler.php:953
 #: includes/class-wc-gateway-ppec-ipn-handler.php:192
 msgid "Payment pending (%s)."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-checkout-handler.php:1167
+#: includes/class-wc-gateway-ppec-checkout-handler.php:1135
 msgid "The payment method was updated for this subscription."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-checkout-handler.php:1172
+#: includes/class-wc-gateway-ppec-checkout-handler.php:1140
 msgid "The payment method was updated for all your current subscriptions."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-checkout-handler.php:1181
+#: includes/class-wc-gateway-ppec-checkout-handler.php:1149
 msgid "There was a problem updating your payment method. Please try again later or use a different payment method."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-checkout-handler.php:1204
+#: includes/class-wc-gateway-ppec-checkout-handler.php:1172
 msgid "You have cancelled Checkout with PayPal. The payment method was not updated."
 msgstr ""
 
@@ -501,40 +518,52 @@ msgstr ""
 msgid "Success!  Your PayPal account has been set up successfully."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:157
+#: includes/class-wc-gateway-ppec-plugin.php:158
 msgid "%s in WooCommerce Gateway PayPal Checkout plugin can only be called once"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:243
-msgid "<p>PayPal Checkout with new <strong>Smart Payment Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be removed</strong> in the <strong>next release</strong>. Please upgrade to Smart Payment Buttons on the <a href=\"%s\">PayPal Checkout settings page</a>.</p>"
-msgstr ""
-
-#: includes/class-wc-gateway-ppec-plugin.php:281
+#: includes/class-wc-gateway-ppec-plugin.php:260
 msgid "WooCommerce Gateway PayPal Checkout requires WooCommerce to be activated"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:285
+#: includes/class-wc-gateway-ppec-plugin.php:264
 msgid "WooCommerce Gateway PayPal Checkout requires WooCommerce version 2.5 or greater"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:289
+#: includes/class-wc-gateway-ppec-plugin.php:268
 msgid "WooCommerce Gateway PayPal Checkout requires cURL to be installed on your server"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:292
+#: includes/class-wc-gateway-ppec-plugin.php:271
 msgid "WooCommerce Gateway PayPal Checkout requires OpenSSL >= 1.0.1 to be installed on your server"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:319
+#: includes/class-wc-gateway-ppec-plugin.php:298
 msgid "PayPal Checkout is almost ready. To get started, <a href=\"%s\">connect your PayPal account</a>."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:450
+#: includes/class-wc-gateway-ppec-plugin.php:428
 msgid "Settings"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-plugin.php:453
+#: includes/class-wc-gateway-ppec-plugin.php:447
+msgid "View Documentation"
+msgstr ""
+
+#: includes/class-wc-gateway-ppec-plugin.php:447
 msgid "Docs"
+msgstr ""
+
+#: includes/class-wc-gateway-ppec-plugin.php:448
+msgid "Open a support request at WooCommerce.com"
+msgstr ""
+
+#: includes/class-wc-gateway-ppec-plugin.php:448
+msgid "Support"
+msgstr ""
+
+#: includes/class-wc-gateway-ppec-plugin.php:503
+msgid "<p>PayPal Checkout with new <strong>Smart Payment Buttons™</strong> gives your customers the power to pay the way they want without leaving your site.</p><p>The <strong>existing buttons will be removed</strong> in the <strong>next release</strong>. Please upgrade to Smart Payment Buttons on the <a href=\"%s\">PayPal Checkout settings page</a>.</p>"
 msgstr ""
 
 #: includes/class-wc-gateway-ppec-privacy.php:14
@@ -584,20 +613,20 @@ msgid "PayPal API error"
 msgstr ""
 
 #. translators: placeholder is pending reason from PayPal API.
-#: includes/class-wc-gateway-ppec-with-paypal-addons.php:204
+#: includes/class-wc-gateway-ppec-with-paypal-addons.php:206
 msgid "PayPal transaction held: %s"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-with-paypal-addons.php:215
+#: includes/class-wc-gateway-ppec-with-paypal-addons.php:217
 msgid "PayPal payment approved (ID: %s)"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-with-paypal-addons.php:219
+#: includes/class-wc-gateway-ppec-with-paypal-addons.php:221
 msgid "PayPal payment declined"
 msgstr ""
 
 #: includes/class-wc-gateway-ppec-with-paypal-credit.php:15
-#: includes/settings/settings-ppec.php:586
+#: includes/settings/settings-ppec.php:417
 msgid "PayPal Credit"
 msgstr ""
 
@@ -615,512 +644,573 @@ msgstr ""
 msgid "The buyer's session information could not be found."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:15
+#: includes/settings/settings-ppec.php:17
 msgid "Setup or link an existing PayPal account"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:16
+#: includes/settings/settings-ppec.php:18
 msgid "%s or <a href=\"#\" class=\"ppec-toggle-settings\">click here to toggle manual API credential input</a>."
 msgstr ""
 
 #. Translators: Placeholders are opening an closing link HTML tags.
-#: includes/settings/settings-ppec.php:29
+#: includes/settings/settings-ppec.php:31
 msgid "To reset current credentials and use another account %1$sclick here%2$s. %3$sLearn more about your API Credentials%2$s."
 msgstr ""
 
 #. Translators: Placeholders are opening an closing link HTML tags.
 #. Translators: Placeholders are opening and closing link HTML tags.
-#: includes/settings/settings-ppec.php:30
-#: includes/settings/settings-ppec.php:52
+#: includes/settings/settings-ppec.php:32
+#: includes/settings/settings-ppec.php:54
 msgid "Reset current credentials"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:32
-#: includes/settings/settings-ppec.php:54
+#: includes/settings/settings-ppec.php:34
+#: includes/settings/settings-ppec.php:56
 msgid "Learn more"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:37
+#: includes/settings/settings-ppec.php:39
 msgid "Setup or link an existing PayPal Sandbox account"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:38
+#: includes/settings/settings-ppec.php:40
 msgid "%s or <a href=\"#\" class=\"ppec-toggle-sandbox-settings\">click here to toggle manual API credential input</a>."
 msgstr ""
 
 #. Translators: Placeholders are opening and closing link HTML tags.
-#: includes/settings/settings-ppec.php:51
+#: includes/settings/settings-ppec.php:53
 msgid "Your account setting is set to sandbox, no real charging takes place. To accept live payments, switch your environment to live and connect your PayPal account. To reset current credentials and use other sandbox account %1$sclick here%2$s. %3$sLearn more about your API Credentials%2$s."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:58
-#: includes/settings/settings-ppec.php:592
-msgid "Enable PayPal Credit"
+#: includes/settings/settings-ppec.php:60
+#: includes/settings/settings-ppec.php:432
+msgid "Enable PayPal Credit to eligible customers"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:60
+#: includes/settings/settings-ppec.php:62
 msgid "This option is disabled. Currently PayPal Credit only available for U.S. merchants using USD currency."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:63
+#: includes/settings/settings-ppec.php:65
 msgid "This enables PayPal Credit, which displays a PayPal Credit button next to the primary PayPal Checkout button. PayPal Checkout lets you give customers access to financing through PayPal Credit® - at no additional cost to you. You get paid up front, even though customers have more time to pay. A pre-integrated payment button shows up next to the PayPal Button, and lets customers pay quickly with PayPal Credit®. (Should be unchecked for stores involved in Real Money Gaming.)"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:267
+#: includes/settings/settings-ppec.php:72
 msgid "Enable/Disable"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:269
+#: includes/settings/settings-ppec.php:74
 msgid "Enable PayPal Checkout"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:270
+#: includes/settings/settings-ppec.php:75
 msgid "This enables PayPal Checkout which allows customers to checkout directly via PayPal from your cart page."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:276
+#: includes/settings/settings-ppec.php:81
 msgid "Title"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:278
+#: includes/settings/settings-ppec.php:83
 msgid "This controls the title which the user sees during checkout."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:279
+#: includes/settings/settings-ppec.php:84
+#: includes/settings/settings-ppec.php:357
+#: includes/settings/settings-ppec.php:403
 msgid "PayPal"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:283
+#: includes/settings/settings-ppec.php:88
 msgid "Description"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:286
+#: includes/settings/settings-ppec.php:91
 msgid "This controls the description which the user sees during checkout."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:287
+#: includes/settings/settings-ppec.php:92
 msgid "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:291
+#: includes/settings/settings-ppec.php:96
 msgid "Account Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:296
+#: includes/settings/settings-ppec.php:101
 msgid "Environment"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:299
+#: includes/settings/settings-ppec.php:104
 msgid "This setting specifies whether you will process live transactions, or whether you will process simulated transactions using the PayPal Sandbox."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:303
+#: includes/settings/settings-ppec.php:108
 msgid "Live"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:304
+#: includes/settings/settings-ppec.php:109
 msgid "Sandbox"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:309
+#: includes/settings/settings-ppec.php:114
 msgid "API Credentials"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:314
+#: includes/settings/settings-ppec.php:119
 msgid "Live API Username"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:316
-#: includes/settings/settings-ppec.php:323
-#: includes/settings/settings-ppec.php:330
-#: includes/settings/settings-ppec.php:358
-#: includes/settings/settings-ppec.php:365
-#: includes/settings/settings-ppec.php:372
+#: includes/settings/settings-ppec.php:121
+#: includes/settings/settings-ppec.php:128
+#: includes/settings/settings-ppec.php:135
+#: includes/settings/settings-ppec.php:162
+#: includes/settings/settings-ppec.php:169
+#: includes/settings/settings-ppec.php:176
 msgid "Get your API credentials from PayPal."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:321
+#: includes/settings/settings-ppec.php:126
 msgid "Live API Password"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:328
+#: includes/settings/settings-ppec.php:133
 msgid "Live API Signature"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:333
-#: includes/settings/settings-ppec.php:375
+#: includes/settings/settings-ppec.php:138
+#: includes/settings/settings-ppec.php:179
 msgid "Optional if you provide a certificate below"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:336
+#: includes/settings/settings-ppec.php:141
 msgid "Live API Certificate"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:342
+#: includes/settings/settings-ppec.php:147
 msgid "Live API Subject"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:344
-#: includes/settings/settings-ppec.php:386
+#: includes/settings/settings-ppec.php:149
+#: includes/settings/settings-ppec.php:190
 msgid "If you're processing transactions on behalf of someone else's PayPal account, enter their email address or Secure Merchant Account ID (also known as a Payer ID) here. Generally, you must have API permissions in place with the other account in order to process anything other than \"sale\" transactions for them."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:347
-#: includes/settings/settings-ppec.php:389
-#: includes/settings/settings-ppec.php:410
-#: includes/settings/settings-ppec.php:418
-#: includes/settings/settings-ppec.php:426
+#: includes/settings/settings-ppec.php:152
+#: includes/settings/settings-ppec.php:193
+#: includes/settings/settings-ppec.php:213
+#: includes/settings/settings-ppec.php:221
+#: includes/settings/settings-ppec.php:229
 msgid "Optional"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:351
+#: includes/settings/settings-ppec.php:155
 msgid "Sandbox API Credentials"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:356
+#: includes/settings/settings-ppec.php:160
 msgid "Sandbox API Username"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:363
+#: includes/settings/settings-ppec.php:167
 msgid "Sandbox API Password"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:370
+#: includes/settings/settings-ppec.php:174
 msgid "Sandbox API Signature"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:378
+#: includes/settings/settings-ppec.php:182
 msgid "Sandbox API Certificate"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:384
+#: includes/settings/settings-ppec.php:188
 msgid "Sandbox API Subject"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:393
+#: includes/settings/settings-ppec.php:196
 msgid "PayPal-hosted Checkout Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:395
+#: includes/settings/settings-ppec.php:198
 msgid "Customize the appearance of PayPal Checkout on the PayPal side."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:398
+#: includes/settings/settings-ppec.php:201
 msgid "Brand Name"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:400
+#: includes/settings/settings-ppec.php:203
 msgid "A label that overrides the business name in the PayPal account on the PayPal hosted checkout pages."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:405
+#: includes/settings/settings-ppec.php:208
 msgid "Logo Image (190×60)"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:407
+#: includes/settings/settings-ppec.php:210
 msgid "If you want PayPal to co-brand the checkout page with your logo, enter the URL of your logo image here.<br/>The image must be no larger than 190x60, GIF, PNG, or JPG format, and should be served over HTTPS."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:413
+#: includes/settings/settings-ppec.php:216
 msgid "Header Image (750×90)"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:415
+#: includes/settings/settings-ppec.php:218
 msgid "If you want PayPal to co-brand the checkout page with your header, enter the URL of your header image here.<br/>The image must be no larger than 750x90, GIF, PNG, or JPG format, and should be served over HTTPS."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:421
+#: includes/settings/settings-ppec.php:224
 msgid "Page Style"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:423
+#: includes/settings/settings-ppec.php:226
 msgid "Optionally enter the name of the page style you wish to use. These are defined within your PayPal account."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:429
+#: includes/settings/settings-ppec.php:232
 msgid "Landing Page"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:432
+#: includes/settings/settings-ppec.php:235
 msgid "Type of PayPal page to display."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:436
+#: includes/settings/settings-ppec.php:239
 msgctxt "Type of PayPal page"
 msgid "Billing (Non-PayPal account)"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:437
+#: includes/settings/settings-ppec.php:240
 msgctxt "Type of PayPal page"
 msgid "Login (PayPal account login)"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:442
+#: includes/settings/settings-ppec.php:245
 msgid "Advanced Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:447
+#: includes/settings/settings-ppec.php:250
 msgid "Debug Log"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:449
+#: includes/settings/settings-ppec.php:252
 msgid "Enable Logging"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:452
+#: includes/settings/settings-ppec.php:255
 msgid "Log PayPal events, such as IPN requests."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:455
+#: includes/settings/settings-ppec.php:258
 msgid "Invoice Prefix"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:457
+#: includes/settings/settings-ppec.php:260
 msgid "Please enter a prefix for your invoice numbers. If you use your PayPal account for multiple stores ensure this prefix is unique as PayPal will not allow orders with the same invoice number."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:462
+#: includes/settings/settings-ppec.php:265
 msgid "Billing Addresses"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:464
+#: includes/settings/settings-ppec.php:267
 msgid "Require Billing Address"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:466
+#: includes/settings/settings-ppec.php:269
 msgid "PayPal only returns a shipping address back to the website. To make sure billing address is returned as well, please enable this functionality on your PayPal account by calling %1$sPayPal Technical Support%2$s."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:469
-#: includes/settings/settings-ppec.php:471
+#: includes/settings/settings-ppec.php:272
+#: includes/settings/settings-ppec.php:274
 msgid "Require Phone Number"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:473
+#: includes/settings/settings-ppec.php:276
 msgid "Require buyer to enter their telephone number during checkout if none is provided by PayPal"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:476
+#: includes/settings/settings-ppec.php:279
 msgid "Payment Action"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:479
+#: includes/settings/settings-ppec.php:282
 msgid "Choose whether you wish to capture funds immediately or authorize payment only."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:483
+#: includes/settings/settings-ppec.php:286
 msgid "Sale"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:484
+#: includes/settings/settings-ppec.php:287
 msgid "Authorize"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:488
+#: includes/settings/settings-ppec.php:291
 msgid "Instant Payments"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:490
+#: includes/settings/settings-ppec.php:293
 msgid "Require Instant Payment"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:493
+#: includes/settings/settings-ppec.php:296
 msgid "If you enable this setting, PayPal will be instructed not to allow the buyer to use funding sources that take additional time to complete (for example, eChecks). Instead, the buyer will be required to use an instant funding source, such as an instant transfer, a credit/debit card, or PayPal Credit."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:496
+#: includes/settings/settings-ppec.php:299
 msgid "Subtotal Mismatch Behavior"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:499
+#: includes/settings/settings-ppec.php:302
 msgid "Internally, WC calculates line item prices and taxes out to four decimal places; however, PayPal can only handle amounts out to two decimal places (or, depending on the currency, no decimal places at all). Occasionally, this can cause discrepancies between the way WooCommerce calculates prices versus the way PayPal calculates them. If a mismatch occurs, this option controls how the order is dealt with so payment can still be taken."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:503
+#: includes/settings/settings-ppec.php:306
 msgid "Add another line item"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:504
+#: includes/settings/settings-ppec.php:307
 msgid "Do not send line items to PayPal"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:509
+#: includes/settings/settings-ppec.php:312
 msgid "Button Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:511
+#: includes/settings/settings-ppec.php:314
 msgid "Customize the appearance of PayPal Checkout on your site."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:514
+#: includes/settings/settings-ppec.php:317
 msgid "Smart Payment Buttons"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:517
+#: includes/settings/settings-ppec.php:320
 msgid "Use Smart Payment Buttons"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:518
+#: includes/settings/settings-ppec.php:321
 msgid "PayPal Checkout's Smart Payment Buttons provide a variety of button customization options, such as color, language, shape, and multiple button layout. <a href=\"%s\">Learn more about Smart Payment Buttons</a>."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:521
+#: includes/settings/settings-ppec.php:324
 msgid "Button Color"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:526
+#: includes/settings/settings-ppec.php:329
 msgid "Controls the background color of the primary button. Use \"Gold\" to leverage PayPal's recognition and preference, or change it to match your site design or aesthetic."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:528
+#: includes/settings/settings-ppec.php:331
 msgid "Gold (Recommended)"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:529
+#: includes/settings/settings-ppec.php:332
 msgid "Blue"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:530
+#: includes/settings/settings-ppec.php:333
 msgid "Silver"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:531
+#: includes/settings/settings-ppec.php:334
 msgid "Black"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:535
+#: includes/settings/settings-ppec.php:338
 msgid "Button Shape"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:540
+#: includes/settings/settings-ppec.php:343
 msgid "The pill-shaped button's unique and powerful shape signifies PayPal in people's minds. Use the rectangular button as an alternative when pill-shaped buttons might pose design challenges."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:542
+#: includes/settings/settings-ppec.php:345
 msgid "Pill"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:543
+#: includes/settings/settings-ppec.php:346
 msgid "Rectangle"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:553
+#: includes/settings/settings-ppec.php:350
+#: includes/settings/settings-ppec.php:396
+msgid "Button Label"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:355
+msgid "This controls the label on the primary button."
+msgstr ""
+
+#: includes/settings/settings-ppec.php:359
+#: includes/settings/settings-ppec.php:405
+msgid "PayPal Buy Now"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:360
+#: includes/settings/settings-ppec.php:406
+msgid "Pay with PayPal"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:370
 msgid "Button Layout"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:558
+#: includes/settings/settings-ppec.php:375
 msgid "If additional funding sources are available to the buyer through PayPal, such as Venmo, then multiple buttons are displayed in the space provided. Choose \"vertical\" for a dynamic list of alternative and local payment options, or \"horizontal\" when space is limited."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:560
+#: includes/settings/settings-ppec.php:377
 msgid "Vertical"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:561
+#: includes/settings/settings-ppec.php:378
 msgid "Horizontal"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:565
+#: includes/settings/settings-ppec.php:382
 msgid "Button Size"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:570
+#: includes/settings/settings-ppec.php:387
 msgid "PayPal offers different sizes of the \"PayPal Checkout\" buttons, allowing you to select a size that best fits your site's theme. This setting will allow you to choose which size button(s) appear on your cart page. (The \"Responsive\" option adjusts to container size, and is available and recommended for Smart Payment Buttons.)"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:572
+#: includes/settings/settings-ppec.php:389
 msgid "Responsive"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:573
+#: includes/settings/settings-ppec.php:390
 msgid "Small"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:574
+#: includes/settings/settings-ppec.php:391
 msgid "Medium"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:575
+#: includes/settings/settings-ppec.php:392
 msgid "Large"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:584
+#: includes/settings/settings-ppec.php:401
+msgid "PayPal offers different labels on the \"PayPal Checkout\" buttons, allowing you to select a suitable label.)"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:415
 msgid "Hides the specified funding methods."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:587
+#: includes/settings/settings-ppec.php:418
 msgid "ELV"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:588
-msgid "Credit Card"
+#: includes/settings/settings-ppec.php:419
+msgid "Credit or debit cards"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:611
+#: includes/settings/settings-ppec.php:420
+msgid "Venmo"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:421
+msgid "SEPA-Lastschrift"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:422
+msgid "Bancontact"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:423
+msgid "eps"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:424
+msgid "giropay"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:425
+msgid "iDEAL"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:426
+msgid "MyBank"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:427
+msgid "Przelewy24"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:428
+msgid "Sofort"
+msgstr ""
+
+#: includes/settings/settings-ppec.php:451
 msgid "Checkout on cart page"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:614
+#: includes/settings/settings-ppec.php:454
 msgid "Enable PayPal Checkout on the cart page"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:615
+#: includes/settings/settings-ppec.php:455
 msgid "This shows or hides the PayPal Checkout button on the cart page."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:624
+#: includes/settings/settings-ppec.php:464
 msgid "Mini-cart Button Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:629
-#: includes/settings/settings-ppec.php:660
-#: includes/settings/settings-ppec.php:692
+#: includes/settings/settings-ppec.php:469
+#: includes/settings/settings-ppec.php:500
+#: includes/settings/settings-ppec.php:532
 msgid "Configure Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:630
+#: includes/settings/settings-ppec.php:470
 msgid "Configure settings specific to mini-cart"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:635
-#: includes/settings/settings-ppec.php:666
-#: includes/settings/settings-ppec.php:698
+#: includes/settings/settings-ppec.php:475
+#: includes/settings/settings-ppec.php:506
+#: includes/settings/settings-ppec.php:538
 msgid "Optionally override global button settings above and configure buttons for this context."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:646
+#: includes/settings/settings-ppec.php:486
 msgid "Single Product Button Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:651
-#: includes/settings/settings-ppec.php:654
+#: includes/settings/settings-ppec.php:491
+#: includes/settings/settings-ppec.php:494
 msgid "Checkout on Single Product"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:657
+#: includes/settings/settings-ppec.php:497
 msgid "Enable PayPal Checkout on Single Product view."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:661
+#: includes/settings/settings-ppec.php:501
 msgid "Configure settings specific to Single Product view"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:678
+#: includes/settings/settings-ppec.php:518
 msgid "Regular Checkout Button Settings"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:683
+#: includes/settings/settings-ppec.php:523
 msgid "PayPal Mark"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:686
+#: includes/settings/settings-ppec.php:526
 msgid "Enable the PayPal Mark on regular checkout"
 msgstr ""
 
-#: includes/settings/settings-ppec.php:687
+#: includes/settings/settings-ppec.php:527
 msgid "This enables the PayPal mark, which can be shown on regular WooCommerce checkout to use PayPal Checkout like a regular WooCommerce gateway."
 msgstr ""
 
-#: includes/settings/settings-ppec.php:693
+#: includes/settings/settings-ppec.php:533
 msgid "Configure settings specific to regular checkout"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, store, sa
 Requires at least: 4.4
 Tested up to: 5.4
 Requires PHP: 5.5
-Stable tag: 1.6.21
+Stable tag: 2.0.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -101,6 +101,23 @@ Please use this to inform us about bugs, or make contributions via PRs.
 9. Initiate checkout from mini-cart.
 
 == Changelog ==
+
+= 2.0.0 - 2020-05-25 =
+* New - Upgrade to the latest PayPal Checkout Javascript SDK. PR#668
+* Add - New setting found under Button Styles for choosing a Smart Payment Button label. PR#666
+* Add - Support for more locales. PR#658
+* Fix - Display Smart Payment Buttons on Product pages built from a shortcode. PR#665
+* Fix - Send the product SKU to PayPal so it's displayed in the order/transaction details and reports on PayPal. PR#664
+* Fix - Show an error when saving incomplete/missing API credentials. PR#712
+* Fix - Remove PHP warnings in later versions of PHP when a PayPal Session doesn't exist. PR#727
+* Fix - Error when processing refunds (Already Refunded. No Amount to Refund). PR#710
+* Fix - Required state field errors on the "Confirm your PayPal Order" page when returning from PayPal. PR#725
+* Fix - Display WC Add To Cart validation errors on the product page when clicking the PayPal Smart Payment Buttons. PR#707
+* Update - Smart Payment Buttons are enabled by default and settings to toggle these on/off have been removed and replaced with a filter. PR#660
+* Update - Deprecate unused/incomplete function `WC_Gateway_PPEC_Client::update_billing_agreement()`. PR#602
+* Update - Move inline javascript found in `settings-ppec.php` to `ppec-settings.js`. PR#676
+* Update - Move Support and Documentation links from the plugin actions to plugin meta section on the Plugin activation/deactivation page. PR#735
+* Update - WooCommerce 4.1 and WordPress 5.4 compatibility. PR#732
 
 = 1.6.21 - 2020-04-14 =
 * Fix - Ensure Puerto Rico and supported Locales are eligible for PayPal Credit. PR#693

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Checkout Gateway
  * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: Accept all major credit and debit cards, plus Venmo and PayPal Credit in the US, presenting options in a customizable stack of payment buttons. Fast, seamless, and flexible.
- * Version: 1.6.21
+ * Version: 2.0.0
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Copyright: © 2019 WooCommerce / PayPal.
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'WC_GATEWAY_PPEC_VERSION', '1.6.21' );
+define( 'WC_GATEWAY_PPEC_VERSION', '2.0.0' );
 
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.


### PR DESCRIPTION
```
= 2.0.0 - 2020-05-25 =
* New - Upgrade to the latest PayPal Checkout Javascript SDK. PR#668
* Add - New setting found under Button Styles for choosing a Smart Payment Button label. PR#666
* Add - Support for more locales. PR#658
* Fix - Display Smart Payment Buttons on Product pages built from a shortcode. PR#665
* Fix - Send the product SKU to PayPal so it's displayed in the order/transaction details and reports on PayPal. PR#664
* Fix - Show an error when saving incomplete/missing API credentials. PR#712
* Fix - Remove PHP warnings in later versions of PHP when a PayPal Session doesn't exist. PR#727
* Fix - Error when processing refunds (Already Refunded. No Amount to Refund). PR#710
* Fix - Required state field errors on the "Confirm your PayPal Order" page when returning from PayPal. PR#725
* Fix - Display WC Add To Cart validation errors on the product page when clicking the PayPal Smart Payment Buttons. PR#707
* Update - Smart Payment Buttons are enabled by default and settings to toggle these on/off have been removed and replaced with a filter. PR#660
* Update - Deprecate unused/incomplete function `WC_Gateway_PPEC_Client::update_billing_agreement()`. PR#602
* Update - Move inline javascript found in `settings-ppec.php` to `ppec-settings.js`. PR#676
* Update - Move Support and Documentation links from the plugin actions to plugin meta section on the Plugin activation/deactivation page. PR#735
* Update - WooCommerce 4.1 and WordPress 5.4 compatibility. PR#732
```