### PR TITLE
Fixes `paypal.getFundingSources is not a function` console errors

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -2,6 +2,9 @@
 ;( function ( $, window, document ) {
 	'use strict';
 
+	// Use global 'paypal' object or namespaced 'paypal_sdk' as PayPal API (depends on legacy/SDK mode).
+	var paypal = wc_ppec_context.use_checkout_js ? window.paypal : window.paypal_sdk;
+
 	// Show error notice at top of checkout form, or else within button container
 	var showError = function( errorMessage, selector ) {
 		var $container = $( '.woocommerce-notices-wrapper, form.checkout' );
@@ -43,7 +46,7 @@
 
 		var paypal_funding_methods = [];
 		for ( var i = 0; i < methods.length; i++ ) {
-			var method = ( wc_ppec_context.use_checkout_js ? paypal : paypal_sdk ).FUNDING[ methods[ i ].toUpperCase() ];
+			var method = paypal.FUNDING[ methods[ i ].toUpperCase() ];
 			if ( method ) {
 				paypal_funding_methods.push( method );
 			}
@@ -202,10 +205,10 @@
 
 			var disabledFundingSources = getFundingMethods( disallowed );
 			if ( 'undefined' === typeof( disabledFundingSources ) || ! disabledFundingSources || 0 === disabledFundingSources.length ) {
-				paypal_sdk.Buttons( button_args ).render( selector );
+				paypal.Buttons( button_args ).render( selector );
 			} else {
 				// Render context specific buttons.
-				paypal_sdk.getFundingSources().forEach( function( fundingSource ) {
+				paypal.getFundingSources().forEach( function( fundingSource ) {
 					if ( -1 !== disabledFundingSources.indexOf( fundingSource ) ) {
 						return;
 					}
@@ -216,10 +219,10 @@
 						onError:       button_args.onError,
 						onCancel:      button_args.onCancel,
 						fundingSource: fundingSource,
-						style:         ( paypal_sdk.FUNDING.PAYPAL === fundingSource ) ? button_args.style : {}
+						style:         ( paypal.FUNDING.PAYPAL === fundingSource ) ? button_args.style : {}
 					};
 
-					var button = paypal_sdk.Buttons( buttonSettings );
+					var button = paypal.Buttons( buttonSettings );
 
 					if ( button.isEligible() ) {
 						button.render( selector );

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -43,7 +43,7 @@
 
 		var paypal_funding_methods = [];
 		for ( var i = 0; i < methods.length; i++ ) {
-			var method = paypal.FUNDING[ methods[ i ].toUpperCase() ];
+			var method = ( wc_ppec_context.use_checkout_js ? paypal : paypal_sdk ).FUNDING[ methods[ i ].toUpperCase() ];
 			if ( method ) {
 				paypal_funding_methods.push( method );
 			}
@@ -202,10 +202,10 @@
 
 			var disabledFundingSources = getFundingMethods( disallowed );
 			if ( 'undefined' === typeof( disabledFundingSources ) || ! disabledFundingSources || 0 === disabledFundingSources.length ) {
-				paypal.Buttons( button_args ).render( selector );
+				paypal_sdk.Buttons( button_args ).render( selector );
 			} else {
 				// Render context specific buttons.
-				paypal.getFundingSources().forEach( function( fundingSource ) {
+				paypal_sdk.getFundingSources().forEach( function( fundingSource ) {
 					if ( -1 !== disabledFundingSources.indexOf( fundingSource ) ) {
 						return;
 					}
@@ -216,10 +216,10 @@
 						onError:       button_args.onError,
 						onCancel:      button_args.onCancel,
 						fundingSource: fundingSource,
-						style:         ( paypal.FUNDING.PAYPAL === fundingSource ) ? button_args.style : {}
+						style:         ( paypal_sdk.FUNDING.PAYPAL === fundingSource ) ? button_args.style : {}
 					};
 
-					var button = paypal.Buttons( buttonSettings );
+					var button = paypal_sdk.Buttons( buttonSettings );
 
 					if ( button.isEligible() ) {
 						button.render( selector );

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -494,7 +494,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 			);
 
 		} elseif ( 'yes' === $settings->use_spb ) {
-			$spb_script_dependencies = array( 'jquery', 'paypal-checkout-js' );
+			$spb_script_dependencies = array( 'jquery' );
 			$data                    = array(
 				'use_checkout_js'      => $settings->use_legacy_checkout_js(),
 				'environment'          => 'sandbox' === $settings->get_environment() ? 'sandbox' : 'production',
@@ -543,7 +543,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 					'currency'    => get_woocommerce_currency(),
 				);
 
-				wp_register_script( 'paypal-checkout-js', add_query_arg( $script_args, 'https://www.paypal.com/sdk/js' ), array(), null, true );
+				wp_register_script( 'paypal-checkout-sdk', add_query_arg( $script_args, 'https://www.paypal.com/sdk/js' ), array(), null, true );
+				$spb_script_dependencies[] = 'paypal-checkout-sdk';
 
 				// register the fetch/promise polyfills files so the new PayPal Checkout SDK works with IE
 				if ( $is_IE ) {
@@ -554,6 +555,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				}
 			} else {
 				wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
+				$spb_script_dependencies[] = 'paypal-checkout-js';
 			}
 
 			wp_register_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', $spb_script_dependencies, wc_gateway_ppec()->version, true );
@@ -564,7 +566,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 	/**
 	 * Adds the data-namespace attribute when enqueuing the PayPal SDK script
 	 *
-	 * @since 2.0
+	 * @since 2.0.1
 	 * @param string  $tag
 	 * @param string  $handle
 	 * @return string

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -22,6 +22,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		add_action( 'woocommerce_before_cart_totals', array( $this, 'before_cart_totals' ) );
 		add_action( 'woocommerce_proceed_to_checkout', array( $this, 'display_paypal_button' ), 20 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_filter( 'script_loader_tag', array( $this, 'add_paypal_sdk_namespace_attribute' ), 10, 2 );
 
 		if ( 'yes' === wc_gateway_ppec()->settings->use_spb ) {
 			add_action( 'woocommerce_after_mini_cart', array( $this, 'display_mini_paypal_button' ), 20 );
@@ -558,6 +559,18 @@ class WC_Gateway_PPEC_Cart_Handler {
 			wp_register_script( 'wc-gateway-ppec-smart-payment-buttons', wc_gateway_ppec()->plugin_url . 'assets/js/wc-gateway-ppec-smart-payment-buttons.js', $spb_script_dependencies, wc_gateway_ppec()->version, true );
 			wp_localize_script( 'wc-gateway-ppec-smart-payment-buttons', 'wc_ppec_context', $data );
 		}
+	}
+
+	/**
+	 * Adds the data-namespace attribute when enqueuing the PayPal SDK script
+	 *
+	 * @since 2.0
+	 * @param string  $tag
+	 * @param string  $handle
+	 * @return string
+	 */
+	public function add_paypal_sdk_namespace_attribute( $tag, $handle ) {
+		return ( 'paypal-checkout-sdk' === $handle ) ? str_replace( ' src', ' data-namespace="paypal_sdk" src', $tag ) : $tag;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #739 
**Ticket**: https://wordpress.org/support/topic/latest-version-has-js-critical-error/

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

Customers have reported that after upgrading to 2.0.0 their PayPal buttons aren't loading and they're seeing the following console/javascript errors:

```
Uncaught TypeError: paypal.getFundingSources is not a function
    at render (wc-gateway-ppec-smart-payment-buttons.js:208)
    at HTMLBodyElement.dispatch (jquery.js:3)
    at HTMLBodyElement.r.handle (jquery.js:3)
    at Object.trigger (jquery.js:3)
    at Object.a.event.trigger (jquery-migrate.min.js:2)
    at HTMLBodyElement.<anonymous> (jquery.js:3)
    at Function.each (jquery.js:2)
    at a.fn.init.each (jquery.js:2)
    at a.fn.init.trigger (jquery.js:3)
    at Object.success (checkout.min.js:1)
```

I discovered that this issue is being caused by the old `https://www.paypalobjects.com/api/checkout.js` script being loaded even though we have set `wc_ppec_context.use_checkout_js` to `false` (meaning we're using sdk functions on the `paypal` variable).

At first I thought this was a caching issue, but after some investigation, I found that there are other PayPal extensions which are likely loading file. Just doing a search on my local dev site I found [the following plugins](https://d.pr/i/qRT1vB) that still use/load this incompatible `checkout.js` file
 - Jetpack Simple Payments
 - CartFlows Pro
 - PayPal powered by Braintree
 - PayPal Checkout (only when using legacy filter)

In order to have the new Javascript SDK and Checkout.js work on the same page, PayPal recommends the following:

> To load this sdk alongside the existing version (checkout.js), please specify a different namespace in the script tag, e.g. <script src="https://www.paypal.com/sdk/js?client-id=CLIENT_ID" data-namespace="paypal_sdk"></script>, then use the paypal_sdk namespace in place of paypal in your code.

This PR fixes the issues by using the `paypal_sdk` namespace approach as suggested.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Activate PayPal Powered by Braintree gateway and set it up in sandbox mode
2. Enable smart payment buttons on the checkout page
3. Set Hide payment methods setting to have 1 or more payment options disabled: https://d.pr/i/xuUmyk
4. Load the checkout page

**On master**
![](https://d.pr/i/RVLVxf+)

**On `isssue_739`**
![](https://d.pr/i/hapYC0+)

Closes #739.
