### PR TITLE
Release 2.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 2.0.1 - 2020-05-26 =
+* Fix - PayPal buttons not loading on the page, accompanied with the javascript/console error: "paypal.getFundingSources (or paypal.Buttons) is not a function". PR#740
+
 = 2.0.0 - 2020-05-25 =
 * New - Upgrade to the latest PayPal Checkout Javascript SDK. PR#668
 * Add - New setting found under Button Styles for choosing a Smart Payment Button label. PR#666

--- a/languages/woocommerce-gateway-paypal-express-checkout.pot
+++ b/languages/woocommerce-gateway-paypal-express-checkout.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the WooCommerce PayPal Checkout Gateway plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce PayPal Checkout Gateway 2.0\n"
+"Project-Id-Version: WooCommerce PayPal Checkout Gateway 2.0.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-gateway-paypal-express-checkout\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-05-25T14:58:35+10:00\n"
+"POT-Creation-Date: 2020-05-26T08:06:44+10:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: woocommerce-gateway-paypal-express-checkout\n"
@@ -298,27 +298,27 @@ msgstr ""
 msgid "An error (%s) occurred while processing your PayPal payment.  Please contact the store owner for assistance."
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:70
-#: includes/class-wc-gateway-ppec-cart-handler.php:140
-#: includes/class-wc-gateway-ppec-cart-handler.php:161
+#: includes/class-wc-gateway-ppec-cart-handler.php:71
+#: includes/class-wc-gateway-ppec-cart-handler.php:141
+#: includes/class-wc-gateway-ppec-cart-handler.php:162
 msgid "Cheatin&#8217; huh?"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:319
-#: includes/class-wc-gateway-ppec-cart-handler.php:364
-#: includes/class-wc-gateway-ppec-cart-handler.php:399
+#: includes/class-wc-gateway-ppec-cart-handler.php:320
+#: includes/class-wc-gateway-ppec-cart-handler.php:365
+#: includes/class-wc-gateway-ppec-cart-handler.php:400
 msgid "Check out with PayPal"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:354
+#: includes/class-wc-gateway-ppec-cart-handler.php:355
 msgid "&mdash; or &mdash;"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:369
+#: includes/class-wc-gateway-ppec-cart-handler.php:370
 msgid "Pay with PayPal Credit"
 msgstr ""
 
-#: includes/class-wc-gateway-ppec-cart-handler.php:509
+#: includes/class-wc-gateway-ppec-cart-handler.php:510
 msgid "An error occurred while processing your PayPal payment. Please contact the store owner for assistance."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, store, sa
 Requires at least: 4.4
 Tested up to: 5.4
 Requires PHP: 5.5
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -101,6 +101,9 @@ Please use this to inform us about bugs, or make contributions via PRs.
 9. Initiate checkout from mini-cart.
 
 == Changelog ==
+
+= 2.0.1 - 2020-05-26 =
+* Fix - PayPal buttons not loading on the page, accompanied with the javascript/console error: "paypal.getFundingSources (or paypal.Buttons) is not a function". PR#740
 
 = 2.0.0 - 2020-05-25 =
 * New - Upgrade to the latest PayPal Checkout Javascript SDK. PR#668

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Checkout Gateway
  * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: Accept all major credit and debit cards, plus Venmo and PayPal Credit in the US, presenting options in a customizable stack of payment buttons. Fast, seamless, and flexible.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Copyright: © 2019 WooCommerce / PayPal.
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'WC_GATEWAY_PPEC_VERSION', '2.0.0' );
+define( 'WC_GATEWAY_PPEC_VERSION', '2.0.1' );
 
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.


### PR DESCRIPTION
```
* Fix - PayPal buttons not loading on the page, accompanied with the javascript/console error: "paypal.getFundingSources (or paypal.Buttons) is not a function". PR#740
```