### PR TITLE
Style SDK payment button widths using css

### DIFF
--- a/assets/css/wc-gateway-ppec-frontend.css
+++ b/assets/css/wc-gateway-ppec-frontend.css
@@ -56,3 +56,22 @@
 #payment .place-order .button {
 	display: block;
 }
+/**
+ * PayPal Payment buttons generated via the SDK need to be styled via CSS.
+ * To be backwards compatible, these rules are inline with the widths used by PayPal JS.
+ *
+ * @see https://developer.paypal.com/docs/archive/checkout/how-to/customize-button/#size
+ * @see https://developer.paypal.com/docs/checkout/integration-features/customize-button/#size
+ */
+.wc_ppec_small_payment_buttons {
+	width: 150px;
+	display: inline-block;
+}
+.wc_ppec_medium_payment_buttons {
+	width: 250px;
+	display: inline-block;
+}
+.wc_ppec_large_payment_buttons {
+	width: 350px;
+	display: inline-block;
+}

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -197,6 +197,9 @@
 			// 'style.size' is no longer supported in the JS SDK. See https://developer.paypal.com/docs/checkout/integration-features/customize-button/#size.
 			delete button_args['style']['size'];
 
+			// Add a class selector so the buttons can be styled via css.
+			$( selector ).addClass( 'wc_ppec_' + button_size + '_payment_buttons' );
+
 			// Drop other args no longer needed in the JS SDK.
 			var args_to_remove = [ 'env', 'locale', 'commit', 'funding', 'payment', 'onAuthorize' ];
 			args_to_remove.forEach( function( arg ) {


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #748 

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

When using JS SPBs, we could pass a size param to PayPal and they styled the buttons for us. Now with the SDK, this is no longer possible (see this [doc](https://developer.paypal.com/docs/checkout/integration-features/customize-button/#size)). In order to maintain backwards compatibility, the width of the payment buttons needs to be done via css. This PR adds that.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. In your PayPal Checkout settings set the payment buttons size to **Horizontal** and **Small**. (https://cloudup.com/cwHMv51atvb)
1. On any of the pages where the payment buttons are displayed, view the button. 
1. You'll notice on `master` that there's no difference in button size. 
1. On this branch the buttons will be small. 

<img width="1329" alt="Screen Shot 2020-05-28 at 1 42 52 pm" src="https://user-images.githubusercontent.com/8490476/83096493-2661f700-a0e9-11ea-91ca-4e627e3c6620.png">

For comparison, this is what the old PP buttons looked like using the legacy JS, https://cloudup.com/c9tO4BiMwHr.

I've also tested different sizes on different pages and they all seem to be working as expected. 

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #748 