### PR TITLE
Fix JS errors when Payment Action is set to Authorize

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -537,6 +537,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				$script_args = array(
 					'client-id'   => $settings->get_active_rest_client_id(),
 					'merchant-id' => $client->get_payer_id(),
+					'intent'      => 'authorization' === $settings->get_paymentaction() ? 'authorize' : 'capture',
 					'locale'      => $settings->get_paypal_locale(),
 					'components'  => 'buttons,funding-eligibility',
 					'commit'      => 'checkout' === $page ? 'true' : 'false',


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #750 

**Ticket**: 3007850-zen

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

The checkout is currently broken when you set the Payment Action in PPEC settings to Authorize.

With the new `sdk/js` we must set the [intent query-parameter](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#intent) when loading the payment form otherwise PayPal defaults to capture and then throws and error when trying to place the order.

From my understanding, in 1.6.21 we never had to set an intent when loading the from with `checkout.js` because we handled authorization in later API requests once we received a token from PayPal, but with the new sdk we need to.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Set the payment action settings to Authorize: https://d.pr/i/2ONQis
1. Visit checkout page
1. Try click PayPal button and notice a JS error

Closes #750
