### PR TITLE
Update checkout buttons separator to be consistent

### DIFF
--- a/assets/css/wc-gateway-ppec-frontend.css
+++ b/assets/css/wc-gateway-ppec-frontend.css
@@ -8,7 +8,6 @@
 }
 .wcppec-checkout-buttons__separator {
 	display: block;
-	opacity: .5;
 	margin: 0 0 1em;
 }
 .wcppec-checkout-buttons__button {

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -352,7 +352,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 
 			<?php if ( has_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout' ) ) : ?>
 				<div class="wcppec-checkout-buttons__separator">
-					<?php _e( '&mdash; or &mdash;', 'woocommerce-gateway-paypal-express-checkout' ); ?>
+					<?php _e( '&mdash; OR &mdash;', 'woocommerce-gateway-paypal-express-checkout' ); ?>
 				</div>
 			<?php endif; ?>
 

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -351,9 +351,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		<div class="wcppec-checkout-buttons woo_pp_cart_buttons_div">
 
 			<?php if ( has_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout' ) ) : ?>
-				<div class="wcppec-checkout-buttons__separator">
-					<?php _e( '&mdash; OR &mdash;', 'woocommerce-gateway-paypal-express-checkout' ); ?>
-				</div>
+				<div class="wcppec-checkout-buttons__separator">&mdash; <?php esc_html_e( 'OR', 'woocommerce-gateway-paypal-express-checkout' ); ?> &mdash;</div>
 			<?php endif; ?>
 
 			<?php if ( 'yes' === $settings->use_spb ) :


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #747

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

This PR updates our cart checkout button separator so we're consistent. 

Before and after:

<img width="1344" alt="Screen Shot 2020-05-28 at 3 49 57 pm" src="https://user-images.githubusercontent.com/8490476/83103865-e7d53800-a0fa-11ea-9d68-5a926f8bd1c7.png">

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Checkout this branch. 
2. Enable checkout buttons on the cart page.
1. _Optional_: enable Stripe's checkout buttons. This may require more set up than it's worth. I can;'t recall how to do it exactly. I think you need a card stored in your google wallet or something 🤷‍♂️  
1. On the cart page notice the - or - has been replaced with - OR - to be consistent with other gateways. 

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #747 
