### PR TITLE
Don't display the Debit or Credit card buttons when button layout setting is Horizontal

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -463,7 +463,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 			$data['disallowed_methods'] = $data['hide_funding_methods'];
 		} else {
 			$data['allowed_methods']    = 'yes' === $data['credit_enabled'] ? array( 'CREDIT' ) : array();
-			$data['disallowed_methods'] = 'yes' !== $data['credit_enabled'] ? array( 'CREDIT' ) : array();
+			$data['disallowed_methods'] = 'yes' !== $data['credit_enabled'] ? array( 'CARD', 'CREDIT' ) : array( 'CARD' );
 		}
 		unset( $data['hide_funding_methods'], $data['credit_enabled'] );
 


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

While hanging out in WP.org support I've been noticing some complaints about the Debit or Credit cards buttons being displayed after updating to 2.0:
 - https://wordpress.org/support/topic/remove-black-debit-or-credit-card-button-in-paypal-checkout/
 - https://wordpress.org/support/topic/paypal-checkout-2-0-1-new-button-issue/#post-12906795

After comparing 1.6.21 and 2.0.n, I noticed that we started displaying the Debit or Credit card button on the horizontal layout.

![](https://d.pr/i/3yZUCR+)

Because there's no setting for removing the debit/credit card button on horizontal view and this was an undocumented change, I think we should just restore the previous behaviour from 1.6.21 and hide the card button.

Something interesting I found is that the Paypal demo site doesn't show a Debit card button when it's set to horizontal: https://developer.paypal.com/demo/checkout/#/pattern/horizontal 🤔  
And I've confirmed we're definitely setting `layout` to `horizontal`

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Go to PayPal Checkout settings
1. Set Button Layout to "horizontal"
1. View product page
   1. 1.6.21/legacy: https://d.pr/i/mkBNQY
   1. master: https://d.pr/i/3yZUCR

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

