### PR TITLE
Fix currency number format issue

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -300,12 +300,12 @@ class WC_Gateway_PPEC_Client {
 		$params = array_merge(
 			$params,
 			array(
-				'PAYMENTREQUEST_0_AMT'         => $details['order_total'],
-				'PAYMENTREQUEST_0_ITEMAMT'     => $details['total_item_amount'],
-				'PAYMENTREQUEST_0_SHIPPINGAMT' => $details['shipping'],
-				'PAYMENTREQUEST_0_TAXAMT'      => $details['order_tax'],
-				'PAYMENTREQUEST_0_SHIPDISCAMT' => $details['ship_discount_amount'],
-				'NOSHIPPING'                   => WC_Gateway_PPEC_Plugin::needs_shipping() ? 0 : 1,
+				'PAYMENTREQUEST_0_AMT'          => set_currency_format( $details['order_total'] ),
+				'PAYMENTREQUEST_0_ITEMAMT'      => set_currency_format( $details['total_item_amount'] ),
+				'PAYMENTREQUEST_0_SHIPPINGAMT'  => set_currency_format( $details['shipping'] ),
+				'PAYMENTREQUEST_0_TAXAMT'       => set_currency_format( $details['order_tax'] ),
+				'PAYMENTREQUEST_0_SHIPDISCAMT'  => set_currency_format( $details['ship_discount_amount'] ),
+				'NOSHIPPING'                    => WC_Gateway_PPEC_Plugin::needs_shipping() ? 0 : 1,
 			)
 		);
 
@@ -333,7 +333,7 @@ class WC_Gateway_PPEC_Client {
 					'L_PAYMENTREQUEST_0_NAME' . $count => $values['name'],
 					'L_PAYMENTREQUEST_0_DESC' . $count => ! empty( $values['description'] ) ? substr( strip_tags( $values['description'] ), 0, 127 ) : '', // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
 					'L_PAYMENTREQUEST_0_QTY' . $count  => $values['quantity'],
-					'L_PAYMENTREQUEST_0_AMT' . $count  => $values['amount'],
+					'L_PAYMENTREQUEST_0_AMT' . $count  => set_currency_format( $values['amount'] ),
 				);
 
 				if ( isset( $values['sku'] ) ) {
@@ -940,11 +940,11 @@ class WC_Gateway_PPEC_Client {
 		$params = array(
 			'TOKEN'                          => $args['token'],
 			'PAYERID'                        => $args['payer_id'],
-			'PAYMENTREQUEST_0_AMT'           => $details['order_total'],
-			'PAYMENTREQUEST_0_ITEMAMT'       => $details['total_item_amount'],
-			'PAYMENTREQUEST_0_SHIPPINGAMT'   => $details['shipping'],
-			'PAYMENTREQUEST_0_TAXAMT'        => $details['order_tax'],
-			'PAYMENTREQUEST_0_SHIPDISCAMT'   => $details['ship_discount_amount'],
+			'PAYMENTREQUEST_0_AMT'           => set_currency_format( $details['order_total'] ),
+			'PAYMENTREQUEST_0_ITEMAMT'       => set_currency_format( $details['total_item_amount'] ),
+			'PAYMENTREQUEST_0_SHIPPINGAMT'   => set_currency_format( $details['shipping'] ),
+			'PAYMENTREQUEST_0_TAXAMT'        => set_currency_format( $details['order_tax'] ),
+			'PAYMENTREQUEST_0_SHIPDISCAMT'   => set_currency_format( $details['ship_discount_amount'] ),
 			'PAYMENTREQUEST_0_INSURANCEAMT'  => 0,
 			'PAYMENTREQUEST_0_HANDLINGAMT'   => 0,
 			'PAYMENTREQUEST_0_CURRENCYCODE'  => get_woocommerce_currency(),
@@ -975,7 +975,7 @@ class WC_Gateway_PPEC_Client {
 					'L_PAYMENTREQUEST_0_NAME' . $count => $values['name'],
 					'L_PAYMENTREQUEST_0_DESC' . $count => ! empty( $values['description'] ) ? strip_tags( $values['description'] ) : '', // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
 					'L_PAYMENTREQUEST_0_QTY' . $count  => $values['quantity'],
-					'L_PAYMENTREQUEST_0_AMT' . $count  => $values['amount'],
+					'L_PAYMENTREQUEST_0_AMT' . $count  => set_currency_format( $values['amount'] ),
 				);
 
 				if ( isset( $values['sku'] ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -217,3 +217,10 @@ function wc_gateway_ppec_save_transaction_data( $order, $transaction_response, $
 		$order->update_meta_data( '_woo_pp_txnData', $txnData );
 	}
 }
+
+function set_currency_format ( $value ) {
+	$settings = wc_gateway_ppec()->settings;
+	$decimals = $settings->get_number_of_decimal_digits();
+	$value = number_format( $value, $decimals );
+	return $value;
+}


### PR DESCRIPTION
### Description

I changed the currency format set in the send info. We are using this plugin for 1 of our sites, but when we tried to implement it for out other site we came across the problem of the currency returning paypal errors about the currency format.
Prices ending in 0 cents got cut off (example: 90.20 -> 90.2) which returned errors due to not having 2 decimals.
Tested the changes myself on both sites. The already working site is still functioning accordingly. The site we had problems with also works after this change.

### Steps to test:
1. Use different Woocommerce settings for decimals. (0, 1 (to make sure a 0 would get cut off) and 2)
2. Use sandbox to confirm a payment.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
no
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
customers wouldn't notice any changes.

Closes # .
