### PR TITLE
Add filter for SDK script arguements

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -553,6 +553,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 					'currency'    => get_woocommerce_currency(),
 				);
 
+				$script_args = apply_filters( 'woocommerce_paypal_express_checkout_script_args', $script_args );
+
 				wp_register_script( 'paypal-checkout-sdk', add_query_arg( $script_args, 'https://www.paypal.com/sdk/js' ), array(), null, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 				$spb_script_dependencies[] = 'paypal-checkout-sdk';
 


### PR DESCRIPTION
### Description
I added a filter that allows users to change the query parameters sent to the PayPal SDK. This allows changing the 'commit' key to a value of 'true' and enable bypassing of the review process during the checkout flow, which depending on store needs can create an improved customer experience. 

### Steps to test:
Doesn't alter any functionality. Used as normal and no change. Implemented filter in my website and works perfectly for bypassing review process.

### Documentation
Possibly. This would be useful for store owners wishing to bypass the review process and complete checkout with PayPal.

Closes # .
