### PR TITLE
Make the SDK script args filterable

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -553,6 +553,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 					'currency'    => get_woocommerce_currency(),
 				);
 
+				$script_args = apply_filters( 'woocommerce_paypal_express_checkout_sdk_script_args', $script_args, $settings, $client );
+
 				wp_register_script( 'paypal-checkout-sdk', add_query_arg( $script_args, 'https://www.paypal.com/sdk/js' ), array(), null, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 				$spb_script_dependencies[] = 'paypal-checkout-sdk';
 


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
See #762 for the original PR that was opened and then not long after, closed by the author.

I found this user has opened a ticket on WP.org as well: https://wordpress.org/support/topic/can-i-checkout-through-paypal-instead-of-redirect/

I can understand why people may want to filter the script args so they can change some of the values we set like: `locale`, `currency` and `commit`, or even set any parameters we're not using (see more details on all available script args in the PayPal docs on [Customising the PayPal JavaScript SDK Script](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#query-parameters))

This PR is similar to #762 except I've added a few extra args to the filter to include: `$client` and `$settings`.