### PR TITLE
save order-data to database

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -414,6 +414,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 						update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
 					} else {
 						$order->update_meta_data( '_woo_pp_txnData', $txn_data );
+						$order->save();
 					}
 
 					return true;
@@ -438,6 +439,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 						update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
 					} else {
 						$order->update_meta_data( '_woo_pp_txnData', $txn_data );
+						$order->save();
 					}
 
 					return true;
@@ -489,6 +491,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 							update_post_meta( $order_id, '_woo_pp_txnData', $txn_data );
 						} else {
 							$order->update_meta_data( '_woo_pp_txnData', $txn_data );
+							$order->save();
 						}
 
 						return true;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -215,5 +215,6 @@ function wc_gateway_ppec_save_transaction_data( $order, $transaction_response, $
 		update_post_meta( $order_id, '_woo_pp_txnData', $txnData );
 	} else {
 		$order->update_meta_data( '_woo_pp_txnData', $txnData );
+		$order->save();
 	}
 }


### PR DESCRIPTION
### Description
Refunds did not save to database with WC_versions over 3.0 due to missing code.
The method got updated but not saved to the database.

### Steps to test:
1. Place an order with paypal as payment method.
2. Check database table meta-data for _woo_pp_txnData -> refunded_amount (is 0)
3. Do a partial or complete paypal refund
4. Check database table meta-data for _woo_pp_txnData -> refunded_amount

Closes # .
