### PR TITLE
Don't always redirect the customer to the cart page after closing PayPal modal

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -177,7 +177,7 @@
 			},
 
 			onCancel: function( data, actions ) {
-				if ( 'orderID' in data ) {
+				if ( cancel_url && 'orderID' in data ) {
 					const query_args = '?woo-paypal-cancel=true&token=' + data.orderID;
 					return actions.redirect( cancel_url + query_args );
 				}

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -516,7 +516,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 				'start_checkout_nonce' => wp_create_nonce( '_wc_ppec_start_checkout_nonce' ),
 				'start_checkout_url'   => WC_AJAX::get_endpoint( 'wc_ppec_start_checkout' ),
 				'return_url'           => wc_get_checkout_url(),
-				'cancel_url'           => wc_get_cart_url(),
+				'cancel_url'           => '',
 				'generic_error_msg'    => wp_kses( __( 'An error occurred while processing your PayPal payment. Please contact the store owner for assistance.', 'woocommerce-gateway-paypal-express-checkout' ), array() ),
 			);
 


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #757 

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
In 2.0 we changed the behaviour so that when a customer closes/cancels the PayPal modal they're now always redirected to the cart page.

There are a few instances where this change feels a bit odd from a customer's perspective. Some examples:
 - you have filled in the checkout address forms, selected shipping, click the PayPal button, decide you wanted to pay with Stripe, close the PayPal window and are redirected to the cart page.
 - you are browsing a product page and click the PayPal button, decide you don't want to go ahead with the order, close the window and get redirected to the cart page.

This also feels a bit weird if your store doesn't use a cart page (i.e. empty Cart page in *WooCommerce > Settings > Advanced*) and customers are redirected back to stores home page.

Looking at 1.6.21, when you closed/cancelled the PayPal modal, you would land back the same page which feels a bit more natural.

**In this PR**, I'm passing an empty `cancel_url` and have updated the `onCancel` handler so that we will now only redirect the customer to a `cancel_url` if it's set using the `woocommerce_paypal_express_checkout_payment_button_data` filter.

The default behaviour will now return the customer back to the same page they clicked on the PayPal Buttons (as per in 1.6.21 and previous versions)

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Visit a product page
1. Click on the PayPal button
1. Close the pop-up window
1. On `master`, redirected to the cart page
1. On this branch, redirected back to the product page. 

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #757  .
