### PR TITLE
Allow setting the paypal environment via a filter.

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -86,7 +86,7 @@ class WC_Gateway_PPEC_Client {
 			$environment = 'live';
 		}
 
-		$this->_environment = $environment;
+		$this->_environment = apply_filters( 'woocommerce_paypal_express_checkout_set_express_checkout_environment', $environment );
 	}
 
 	/**


### PR DESCRIPTION
Very helpful if you have a staging environment (i.e. the entire point of a sandbox feature), and dont want to keep manually changing the environment via wp-admin every time you do a database merge. 

### Example
```php
add_filter( 'woocommerce_paypal_express_checkout_set_express_checkout_environment', function ( $environment ) {
     $environment = defined( 'WP_ENV') && 'production === 'WP_ENV' ? 'live' : 'sandbox;
    return $environment;
}
```

### Note
I explicitly didn't add a filter for `$this->_credential`, as someone more qualified than myself should consider the security implications (e.g. a malicious plugin being able to hijack the gateway).