### PR TITLE
Change the label and description of the PayPal Mark setting

### DIFF
--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -461,11 +461,10 @@ $per_context_settings['button_size']['class']    .= ' woocommerce_ppec_paypal_sp
 $per_context_settings['credit_enabled']['class'] .= ' woocommerce_ppec_paypal_spb';
 
 $settings['cart_checkout_enabled'] = array(
-	'title'       => __( 'Checkout on cart page', 'woocommerce-gateway-paypal-express-checkout' ),
+	'title'       => __( 'Enable on the cart page', 'woocommerce-gateway-paypal-express-checkout' ),
 	'type'        => 'checkbox',
 	'class'       => 'woocommerce_ppec_paypal_visibility_toggle',
-	'label'       => __( 'Enable PayPal Checkout on the cart page', 'woocommerce-gateway-paypal-express-checkout' ),
-	'description' => __( 'This shows or hides the PayPal Checkout button on the cart page.', 'woocommerce-gateway-paypal-express-checkout' ),
+	'label'       => __( 'Enable PayPal Checkout buttons on the cart page', 'woocommerce-gateway-paypal-express-checkout' ),
 	'desc_tip'    => true,
 	'default'     => 'yes',
 );
@@ -503,13 +502,12 @@ $settings['single_product_settings'] = array(
 );
 
 $settings['checkout_on_single_product_enabled'] = array(
-	'title'       => __( 'Checkout on Single Product', 'woocommerce-gateway-paypal-express-checkout' ),
+	'title'       => __( 'Enable on the single product page', 'woocommerce-gateway-paypal-express-checkout' ),
 	'type'        => 'checkbox',
 	'class'       => 'woocommerce_ppec_paypal_visibility_toggle',
-	'label'       => __( 'Checkout on Single Product', 'woocommerce-gateway-paypal-express-checkout' ),
+	'label'       => __( 'Enable PayPal Checkout buttons on the single product page', 'woocommerce-gateway-paypal-express-checkout' ),
 	'default'     => 'yes',
 	'desc_tip'    => true,
-	'description' => __( 'Enable PayPal Checkout on Single Product view.', 'woocommerce-gateway-paypal-express-checkout' ),
 );
 
 $settings['single_product_settings_toggle'] = array(
@@ -537,11 +535,10 @@ $settings['mark_settings'] = array(
 );
 
 $settings['mark_enabled'] = array(
-	'title'       => __( 'PayPal Mark', 'woocommerce-gateway-paypal-express-checkout' ),
+	'title'       => __( 'Enable on the checkout page', 'woocommerce-gateway-paypal-express-checkout' ),
 	'type'        => 'checkbox',
 	'class'       => 'woocommerce_ppec_paypal_visibility_toggle',
-	'label'       => __( 'Show PayPal Checkout payment option on the regular WooCommerce checkout page', 'woocommerce-gateway-paypal-express-checkout' ),
-	'description' => __( 'Disabling this will hide PayPal mark from the regular WooCommerce checkout page', 'woocommerce-gateway-paypal-express-checkout' ),
+	'label'       => __( 'Enable PayPal Checkout buttons on the regular checkout page', 'woocommerce-gateway-paypal-express-checkout' ),
 	'desc_tip'    => true,
 	'default'     => 'yes',
 );

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -540,8 +540,8 @@ $settings['mark_enabled'] = array(
 	'title'       => __( 'PayPal Mark', 'woocommerce-gateway-paypal-express-checkout' ),
 	'type'        => 'checkbox',
 	'class'       => 'woocommerce_ppec_paypal_visibility_toggle',
-	'label'       => __( 'Enable the PayPal Mark on regular checkout', 'woocommerce-gateway-paypal-express-checkout' ),
-	'description' => __( 'This enables the PayPal mark, which can be shown on regular WooCommerce checkout to use PayPal Checkout like a regular WooCommerce gateway.', 'woocommerce-gateway-paypal-express-checkout' ),
+	'label'       => __( 'Show PayPal Checkout payment option on the regular WooCommerce checkout page', 'woocommerce-gateway-paypal-express-checkout' ),
+	'description' => __( 'Disabling this will hide PayPal mark from the regular WooCommerce checkout page', 'woocommerce-gateway-paypal-express-checkout' ),
 	'desc_tip'    => true,
 	'default'     => 'yes',
 );


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/675. This is a simple change to the label and description of the "PayPal Mark" setting.

Previous:

> Label: Enable the PayPal Mark on regular checkout.
> Description: This enables the PayPal mark, which can be shown on regular WooCommerce checkout to use PayPal Checkout like a regular WooCommerce gateway.

New:

> Label: Show PayPal Checkout payment option on the regular WooCommerce checkout page.
> Description: Disabling this will hide PayPal mark from the regular WooCommerce checkout page.

I'm not sure whether I should call it `PayPal payment option` or `PayPal mark`. I think the `PayPal payment option` is much simpler to understand.



### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->
Currently, there's no mention of "PayPal Mark" in our documentation. We can include it here: https://docs.woocommerce.com/document/paypal-express-checkout

Closes #675 
