### PR TITLE
Modified field description for Require Phone Number

### DIFF
--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -281,7 +281,7 @@ $settings = array(
 		'type'        => 'checkbox',
 		'label'       => __( 'Require Phone Number', 'woocommerce-gateway-paypal-express-checkout' ),
 		'default'     => 'no',
-		'description' => __( 'Require buyer to enter their telephone number during checkout if none is provided by PayPal. <br><strong>Note: Disabling this option doesn\'t affect direct Debit or Credit Card payments offered by PayPal.</strong>' , 'woocommerce-gateway-paypal-express-checkout' ),
+		'description' => __( 'Require buyer to enter their telephone number during checkout if none is provided by PayPal. <br><strong>Note: Disabling this option doesn\'t affect direct Debit or Credit Card payments offered by PayPal.</strong>', 'woocommerce-gateway-paypal-express-checkout' ),
 	),
 	'paymentaction' => array(
 		'title'       => __( 'Payment Action', 'woocommerce-gateway-paypal-express-checkout' ),

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -281,7 +281,7 @@ $settings = array(
 		'type'        => 'checkbox',
 		'label'       => __( 'Require Phone Number', 'woocommerce-gateway-paypal-express-checkout' ),
 		'default'     => 'no',
-		'description' => __( 'Require buyer to enter their telephone number during checkout if none is provided by PayPal', 'woocommerce-gateway-paypal-express-checkout' ),
+		'description' => __( 'Require buyer to enter their telephone number during checkout if none is provided by PayPal. <br><strong>Note: Disabling this option doesn\'t affect direct Debit or Credit Card payments offered by PayPal.</strong>' , 'woocommerce-gateway-paypal-express-checkout' ),
 	),
 	'paymentaction' => array(
 		'title'       => __( 'Payment Action', 'woocommerce-gateway-paypal-express-checkout' ),

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -281,7 +281,7 @@ $settings = array(
 		'type'        => 'checkbox',
 		'label'       => __( 'Require Phone Number', 'woocommerce-gateway-paypal-express-checkout' ),
 		'default'     => 'no',
-		'description' => __( 'Require buyer to enter their telephone number during checkout if none is provided by PayPal. <br><strong>Note: Disabling this option doesn\'t affect direct Debit or Credit Card payments offered by PayPal.</strong>', 'woocommerce-gateway-paypal-express-checkout' ),
+		'description' => __( 'Require buyer to enter their telephone number during checkout if none is provided by PayPal. Disabling this option doesn\'t affect direct Debit or Credit Card payments offered by PayPal.', 'woocommerce-gateway-paypal-express-checkout' ),
 	),
 	'paymentaction' => array(
 		'title'       => __( 'Payment Action', 'woocommerce-gateway-paypal-express-checkout' ),


### PR DESCRIPTION
PayPal doesn't support disabling mobile number field for direct
Debit or Credit Card Payments. Added a note to the field description
to indicate the same. I don't think a documentation change is required
for this change

**Issue**: #770 

Closes #770 
