### PR TITLE
Preserve layout style setting when using standalone buttons

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -222,7 +222,7 @@
 						onError:       button_args.onError,
 						onCancel:      button_args.onCancel,
 						fundingSource: fundingSource,
-						style:         ( paypal.FUNDING.PAYPAL === fundingSource ) ? button_args.style : {}
+						style:         ( paypal.FUNDING.PAYPAL === fundingSource ) ? button_args.style : { layout: button_args.style.layout }
 					};
 
 					var button = paypal.Buttons( buttonSettings );


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
While investigating #759 I came across this issue: when the button layout is set to "Vertical" and at least one funding method needs to be hidden (including PayPal Credit), the buttons seem to "think" they're being rendered in a "horizontal" layout (as reflected by the CSS classes attached to the containers), even though they're actually being presented in a vertical one.

This is because we're rendering all eligible buttons using what PayPal calls "[standalone buttons](https://developer.paypal.com/docs/checkout/integration-features/standalone-buttons/)" and not passing the layout to the SDK except when taking care of the main PayPal button. We did this because not all style properties are supported by all buttons, but "layout" does seem to be supported in all scenarios.

This is probably a non-issue most of the time, but given that it is possible for funding methods to determine their eligibility by considering the layout they're in ([here's an example](https://github.com/paypal/paypal-checkout-components/blob/1b66936768c2430f41258537ae867904a612187a/src/funding/venmo/config.jsx#L48-L50)), it'd be better if we always explicitly indicate the layout.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Check out `master`.
1. Go to the extension settings (WC > Settings > Payment > PayPal Checkout):
   1. For simplicity, disable all context specific settings.
   1. Set "Button Layout" to "Vertical".
   1. Select at least one method inside the "Hide Funding Method(s)" field.
   1. Save changes.
1. Go the frontend, and add a product to the cart.
1. Visit the cart or checkout page.
1. Use your browser's devtools to inspect the "woo_pp_ec_button_cart" or the "woo_pp_ec_button_checkout" element (depending on which page you're looking at).
1. Confirm that all buttons (`<div role="button">`) except for the first one have a `paypal-buttons-layout-horizontal` CSS class. This is, despite the layout being "Vertical".
1. Check out this branch.
1. Reload the page and confirm that all buttons now have the correct CSS class: `paypal-buttons-layout-vertical`.

