### PR TITLE
Make Mini-cart settings independent from cart

### DIFF
--- a/assets/js/wc-gateway-ppec-settings.js
+++ b/assets/js/wc-gateway-ppec-settings.js
@@ -267,37 +267,57 @@
 			var display =
 				$( '#woocommerce_ppec_paypal_cart_checkout_enabled' ).is( ':checked' ) ||
 				( $( '#woocommerce_ppec_paypal_checkout_on_single_product_enabled' ).is( ':checked' ) && ! $( '#woocommerce_ppec_paypal_single_product_settings_toggle' ).is( ':checked' ) ) ||
-				( $( '#woocommerce_ppec_paypal_mark_enabled' ).is( ':checked' ) && ! $( '#woocommerce_ppec_paypal_mark_settings_toggle' ).is( ':checked' ) );
+				( $( '#woocommerce_ppec_paypal_mark_enabled' ).is( ':checked' ) && ! $( '#woocommerce_ppec_paypal_mark_settings_toggle' ).is( ':checked' ) ) ||
+				( $( '#woocommerce_ppec_paypal_cart_checkout_enabled').is( ':checked' ) && ! $( '#woocommerce_ppec_paypal_cart_settings_toggle' ).is( ':checked' ) ) ||
+				( $( '#woocommerce_ppec_paypal_mini_cart_checkout_enabled').is( ':checked' ) && ! $( '#woocommerce_ppec_paypal_mini_cart_settings_toggle' ).is( ':checked' ) );
 
 			$( '#woocommerce_ppec_paypal_button_layout, #woocommerce_ppec_paypal_button_size, #woocommerce_ppec_paypal_hide_funding_methods, #woocommerce_ppec_paypal_credit_enabled' ).closest( 'tr' ).toggle( display );
 			display && $( '#woocommerce_ppec_paypal_button_layout' ).change();
 		}
 
-		// Toggle mini-cart section based on whether checkout on cart page is enabled
-		$( '#woocommerce_ppec_paypal_cart_checkout_enabled' ).change( function( event ) {
-			if ( ! $( '#woocommerce_ppec_paypal_use_spb' ).is( ':checked' ) ) {
+		// Toggle cart section
+		$('#woocommerce_ppec_paypal_cart_checkout_enabled, #woocommerce_ppec_paypal_cart_settings_toggle').change(function (event) {
+			if ( ! $(' #woocommerce_ppec_paypal_use_spb' ).is( ':checked' ) ) {
 				return;
 			}
 
-			var checked = $( event.target ).is( ':checked' );
-			$( '#woocommerce_ppec_paypal_mini_cart_settings_toggle, .woocommerce_ppec_paypal_mini_cart' )
-				.closest( 'tr' )
-				.add( '#woocommerce_ppec_paypal_mini_cart_settings' ) // Select title.
-					.next( 'p' ) // Select description if present.
-				.addBack()
-				.toggle( checked );
-			checked && $( '#woocommerce_ppec_paypal_mini_cart_settings_toggle' ).change();
+			if ( ! $('#woocommerce_ppec_paypal_cart_checkout_enabled' ).is( ':checked' ) ) {
+				// If cart page button is disabled, hide remaining settings in section.
+				$( '#woocommerce_ppec_paypal_cart_settings_toggle, .woocommerce_ppec_paypal_cart' ).closest( 'tr' ).hide();
+			} else if ( ! $( '#woocommerce_ppec_paypal_cart_settings_toggle' ).is( ':checked' ) ) {
+				// If cart page button is enabled but not configured to override global settings, hide remaining settings in section.
+				$( '#woocommerce_ppec_paypal_cart_settings_toggle' ).closest( 'tr' ).show();
+				$( '.woocommerce_ppec_paypal_cart, #woocommerce_ppec_paypal_cart_hide_funding_methods' ).closest( 'tr') .hide();
+			} else {
+				// Show all settings in section.
+				$( '#woocommerce_ppec_paypal_cart_settings_toggle, .woocommerce_ppec_paypal_cart' ).closest( 'tr' ).show();
+				$( '#woocommerce_ppec_paypal_cart_button_layout' ).change();
+			}
 			showHideDefaultButtonSettings();
 		} ).change();
 
-		$( '#woocommerce_ppec_paypal_mini_cart_settings_toggle' ).change( function( event ) {
-			// Only show settings specific to mini-cart if configured to override global settings.
-			var checked = $( event.target ).is( ':checked' );
-			$( '.woocommerce_ppec_paypal_mini_cart' ).closest( 'tr' ).toggle( checked );
-			checked && $( '#woocommerce_ppec_paypal_mini_cart_button_layout' ).change();
-			showHideDefaultButtonSettings();
-		} ).change();
+		// Toggle Mini-cart section
+		$('#woocommerce_ppec_paypal_mini_cart_checkout_enabled, #woocommerce_ppec_paypal_mini_cart_settings_toggle').change(function (event) {
+			if (!$(' #woocommerce_ppec_paypal_use_spb').is(':checked')) {
+				return;
+			}
 
+			if (!$('#woocommerce_ppec_paypal_mini_cart_checkout_enabled').is(':checked')) {
+				// If cart page button is disabled, hide remaining settings in section.
+				$('#woocommerce_ppec_paypal_mini_cart_settings_toggle, .woocommerce_ppec_paypal_mini_cart').closest('tr').hide();
+			} else if (!$('#woocommerce_ppec_paypal_mini_cart_settings_toggle').is(':checked')) {
+				// If cart page button is enabled but not configured to override global settings, hide remaining settings in section.
+				$('#woocommerce_ppec_paypal_mini_cart_settings_toggle').closest('tr').show();
+				$('.woocommerce_ppec_paypal_mini_cart, #woocommerce_ppec_paypal_mini_cart_hide_funding_methods').closest('tr').hide();
+			} else {
+				// Show all settings in section.
+				$('#woocommerce_ppec_paypal_mini_cart_settings_toggle, .woocommerce_ppec_paypal_mini_cart').closest('tr').show();
+				$('#woocommerce_ppec_paypal_mini_cart_button_layout').change();
+			}
+			showHideDefaultButtonSettings();
+		}).change();
+
+		// Toggle Single Product section
 		$( '#woocommerce_ppec_paypal_checkout_on_single_product_enabled, #woocommerce_ppec_paypal_single_product_settings_toggle' ).change( function( event ) {
 			if ( ! $( '#woocommerce_ppec_paypal_use_spb' ).is( ':checked' ) ) {
 				return;
@@ -318,6 +338,7 @@
 			showHideDefaultButtonSettings();
 		} ).change();
 
+		// Toggle Checkout Section
 		$( '#woocommerce_ppec_paypal_mark_enabled, #woocommerce_ppec_paypal_mark_settings_toggle' ).change( function() {
 			if ( ! $( '#woocommerce_ppec_paypal_use_spb' ).is( ':checked' ) ) {
 				return;

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -415,7 +415,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 		if ( 'woocommerce_widget_cart' === $widget_id ) {
 			$gateways = WC()->payment_gateways->get_available_payment_gateways();
 			$settings = wc_gateway_ppec()->settings;
-			if ( isset( $gateways['ppec_paypal'] ) && 'yes' === $settings->cart_checkout_enabled && 'yes' === $settings->use_spb ) {
+			if ( isset( $gateways['ppec_paypal'] ) && 'yes' === $settings->mini_cart_checkout_enabled && 'yes' === $settings->use_spb ) {
 				wp_enqueue_script( 'wc-gateway-ppec-smart-payment-buttons' );
 			}
 		}
@@ -523,6 +523,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 			if ( ! is_null( $page ) ) {
 				if ( 'product' === $page && 'yes' === $settings->single_product_settings_toggle ) {
 					$button_settings = $this->get_button_settings( $settings, 'single_product' );
+				} elseif ( 'cart' === $page && 'yes' === $settings->cart_settings_toggle ) {
+					$button_settings = $this->get_button_settings( $settings, 'cart' );
 				} elseif ( 'checkout' === $page && 'yes' === $settings->mark_settings_toggle ) {
 					$button_settings = $this->get_button_settings( $settings, 'mark' );
 				} else {
@@ -532,14 +534,15 @@ class WC_Gateway_PPEC_Cart_Handler {
 				$data = array_merge( $data, $button_settings );
 			}
 
+			// Load Mini Cart Settings if enabled
 			$settings_toggle = 'yes' === $settings->mini_cart_settings_toggle;
 			$mini_cart_data  = $this->get_button_settings( $settings, $settings_toggle ? 'mini_cart' : '' );
 			foreach ( $mini_cart_data as $key => $value ) {
 				unset( $mini_cart_data[ $key ] );
 				$mini_cart_data[ 'mini_cart_' . $key ] = $value;
 			}
-
 			$data = array_merge( $data, $mini_cart_data );
+
 			$data = apply_filters( 'woocommerce_paypal_express_checkout_payment_button_data', $data, $page );
 
 			if ( ! $settings->use_legacy_checkout_js() ) {
@@ -579,8 +582,8 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * Adds the data-namespace attribute when enqueuing the PayPal SDK script
 	 *
 	 * @since 2.0.1
-	 * @param string  $tag
-	 * @param string  $handle
+	 * @param string $tag
+	 * @param string $handle
 	 * @return string
 	 */
 	public function add_paypal_sdk_namespace_attribute( $tag, $handle ) {

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -317,9 +317,9 @@ $settings = array(
 	),
 
 	'button_settings' => array(
-		'title'       => __( 'Button Settings', 'woocommerce-gateway-paypal-express-checkout' ),
+		'title'       => __( 'Global Button Settings', 'woocommerce-gateway-paypal-express-checkout' ),
 		'type'        => 'title',
-		'description' => __( 'Customize the appearance of PayPal Checkout on your site.', 'woocommerce-gateway-paypal-express-checkout' ),
+		'description' => __( 'Customize the default appearance of PayPal Checkout on your site. If page specific customizations are not defined, these will be used by default. <br>For page specific customizations, use the configuration options inside <b>Cart / Mini-cart / Single Product / Regular Checkout</b>', 'woocommerce-gateway-paypal-express-checkout' ),
 	),
 	'use_spb' => array(
 		'title'       => __( 'Smart Payment Buttons', 'woocommerce-gateway-paypal-express-checkout' ),
@@ -452,13 +452,22 @@ $per_context_settings = array(
 	),
 );
 
+$per_context_settings['button_size']['class']    .= ' woocommerce_ppec_paypal_spb';
+$per_context_settings['credit_enabled']['class'] .= ' woocommerce_ppec_paypal_spb';
+
 /**
- * Cart / global button settings.
+ * Default button settings.
  */
 $settings = array_merge( $settings, $per_context_settings );
 
-$per_context_settings['button_size']['class']    .= ' woocommerce_ppec_paypal_spb';
-$per_context_settings['credit_enabled']['class'] .= ' woocommerce_ppec_paypal_spb';
+/**
+ * Cart / global button settings.
+ */
+$settings['cart_settings'] = array(
+	'title' => __( 'Cart Button Settings', 'woocommerce-gateway-paypal-express-checkout' ),
+	'type'  => 'title',
+	'class' => 'woocommerce_ppec_paypal_spb',
+);
 
 $settings['cart_checkout_enabled'] = array(
 	'title'       => __( 'Checkout on cart page', 'woocommerce-gateway-paypal-express-checkout' ),
@@ -470,6 +479,20 @@ $settings['cart_checkout_enabled'] = array(
 	'default'     => 'yes',
 );
 
+$settings['cart_settings_toggle'] = array(
+	'title'       => __( 'Configure Settings', 'woocommerce-gateway-paypal-express-checkout' ),
+	'label'       => __( 'Configure settings specific to cart', 'woocommerce-gateway-paypal-express-checkout' ),
+	'type'        => 'checkbox',
+	'class'       => 'woocommerce_ppec_paypal_spb woocommerce_ppec_paypal_visibility_toggle',
+	'default'     => 'no',
+	'desc_tip'    => true,
+	'description' => __( 'Optionally override global button settings above and configure buttons for this context.', 'woocommerce-gateway-paypal-express-checkout' ),
+);
+foreach ( $per_context_settings as $key => $value ) {
+	$value['class']            .= ' woocommerce_ppec_paypal_cart';
+	$settings[ 'cart_' . $key ] = $value;
+}
+
 /**
  * Mini-cart button settings.
  */
@@ -477,6 +500,16 @@ $settings['mini_cart_settings'] = array(
 	'title' => __( 'Mini-cart Button Settings', 'woocommerce-gateway-paypal-express-checkout' ),
 	'type'  => 'title',
 	'class' => 'woocommerce_ppec_paypal_spb',
+);
+
+$settings['mini_cart_checkout_enabled'] = array(
+	'title'       => __( 'Checkout on Mini-cart', 'woocommerce-gateway-paypal-express-checkout' ),
+	'type'        => 'checkbox',
+	'class'       => 'woocommerce_ppec_paypal_visibility_toggle',
+	'label'       => __( 'Enable PayPal Checkout on Mini-cart', 'woocommerce-gateway-paypal-express-checkout' ),
+	'description' => __( 'This shows or hides the PayPal Checkout button on the Mini-cart.', 'woocommerce-gateway-paypal-express-checkout' ),
+	'desc_tip'    => true,
+	'default'     => 'yes',
 );
 
 $settings['mini_cart_settings_toggle'] = array(


### PR DESCRIPTION
### Description
At the moment, the PPEC on Mini-cart is controlled by the cart option. There are no specific options to disable Mini-cart PPEC and requires PPEC on cart to be enabled to show up.

This PR adds the following changes.

1. Re-purposes existing button settings as Global Settings, which takes effect if context-specific configuration is not defined.
2. Added context-specific configuration for Cart
3. Added option to disabled PPEC on Mini-cart
4. Re-purposes context-specific Mini-cart settings to show up only if PPEC on Mini-cart is enabled 

Tested the changes on a new site & existing site that already uses PPEC. Couldn't find any compatibility issues and noticed that the existing settings are carried over.

### Testing Changes
- [ ] Compare the PR against a new WooCommerce installation with the WordPress.org repository version to see if the default options are set correctly. PR will check enable mini-cart by default since there was no option to turn off PPEC on Mini-cart previously.
- [ ] On an existing site that uses PPEC, remove the plugin and use the development version to see if the previous settings are carried over. 
- [ ] Test context-specific settings for Single Product / Mini-cart / Cart / Checkout along with the option to disable PPEC on specific pages (especially Mini-cart since it's a new feature).

### Question

Since Mini-cart is enabled based on cart settings, on existing sites when the plugin is updated to include this PR, "Enable PayPal Checkout on Mini-cart" (default field value set to "yes") doesn't take effect if the settings are not saved.

Should we add an admin notice to save the settings once the plugin is updated? Or set the value of "Enable PayPal Checkout on Mini-cart" to "no" by default?
 
Not sure about documenting the new Global Settings & Mini-cart sections.

Closes #745.
