### PR TITLE
Display correct image size in the PayPal Checkout window

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -559,6 +559,11 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		// For backwards compatibility (customers that already have set a url)
 		$value_is_url = filter_var( $value, FILTER_VALIDATE_URL ) !== false;
 
+		if ( function_exists( 'add_image_size' ) ) {
+			add_image_size( 'ppec_logo_image_size', 190, 60 );
+			add_image_size( 'ppec_header_image_size', 750, 90 );
+		}
+
 		if ( empty( $value ) || $value_is_url ) {
 			$maybe_hide_remove_style = 'display: none;';
 		} else {
@@ -576,7 +581,7 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 				<div class="image-preview-wrapper">
 					<?php
 					if ( ! $value_is_url ) {
-						echo wp_get_attachment_image( $value, 'thumbnail' );
+						echo wp_get_attachment_image( $value, 'logo_image_url' === $key ? 'ppec_logo_image_size' : 'ppec_header_image_size' );
 					} else {
 						// Translators: placeholder is an image's URL.
 						echo sprintf( esc_html__( 'Already using URL as image: %s', 'woocommerce-gateway-paypal-express-checkout' ), esc_attr( $value ) );

--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -72,6 +72,11 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 		}
 
 		add_filter( 'woocommerce_ajax_get_endpoint', array( $this, 'pass_return_args_to_ajax' ), 10, 2 );
+
+		if ( function_exists( 'add_image_size' ) ) {
+			add_image_size( 'ppec_logo_image_size', 190, 60 );
+			add_image_size( 'ppec_header_image_size', 750, 90 );
+		}
 	}
 
 	/**
@@ -558,11 +563,6 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 
 		// For backwards compatibility (customers that already have set a url)
 		$value_is_url = filter_var( $value, FILTER_VALIDATE_URL ) !== false;
-
-		if ( function_exists( 'add_image_size' ) ) {
-			add_image_size( 'ppec_logo_image_size', 190, 60 );
-			add_image_size( 'ppec_header_image_size', 750, 90 );
-		}
 
 		if ( empty( $value ) || $value_is_url ) {
 			$maybe_hide_remove_style = 'display: none;';

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -252,8 +252,8 @@ class WC_Gateway_PPEC_Client {
 		$params              = array();
 		$logo_url_or_id      = $settings->logo_image_url;
 		$header_url_or_id    = $settings->header_image_url;
-		$params['LOGOIMG']   = filter_var( $logo_url_or_id, FILTER_VALIDATE_URL ) ? $logo_url_or_id : wp_get_attachment_image_url( $logo_url_or_id, 'thumbnail' );
-		$params['HDRIMG']    = filter_var( $header_url_or_id, FILTER_VALIDATE_URL ) ? $header_url_or_id : wp_get_attachment_image_url( $header_url_or_id, 'thumbnail' );
+		$params['LOGOIMG']   = filter_var( $logo_url_or_id, FILTER_VALIDATE_URL ) ? $logo_url_or_id : wp_get_attachment_image_url( $logo_url_or_id, 'ppec_logo_image_size' );
+		$params['HDRIMG']    = filter_var( $header_url_or_id, FILTER_VALIDATE_URL ) ? $header_url_or_id : wp_get_attachment_image_url( $header_url_or_id, 'ppec_header_image_size' );
 		$params['PAGESTYLE'] = $settings->page_style;
 		$params['BRANDNAME'] = $settings->get_brand_name();
 		$params['RETURNURL'] = $this->_get_return_url( $args );


### PR DESCRIPTION
## Summary

This fixes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/416. 

- This defines image sizes for `ppec_logo_image_size` as 190x60 and `ppec_header_image_size` as 750x90 using [add_image_size](https://developer.wordpress.org/reference/functions/add_image_size/) function.
- Then renders the image based on this condition: `'logo_image_url' === $key ? 'ppec_logo_image_size' : 'ppec_header_image_size' `.

## Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Switch to the master/main branch.
1. Use the browser in full-screen (otherwise PayPal window will be too short to display the logo image).
1. Checkout using PPEC, you will see a cropped image.
1. Switch to the branch `issue_416`, try checking out again, you will see the image in proper width. Checkout the screenshots below for a before and after.

## Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- This PR does not need documentation.
<!-- For an extra 💯 include further details about which change requires documentation -->

## Questions

- Have I added the `add_image_size` function in the right place? Or is there a better place for it?
- Not directly related to the issue: When the browser isn't in full-screen mode, checking out will display a small PayPal window, hiding the image logo. We only see the logo when we resize the window or try checking out in full-screen mode. Is this intentional? If it isn't, any advice how could we increase the width and height of the PP popup window?


## Before the fix

<img width="650" alt="Screenshot 2020-06-24 at 10 32 23 PM" src="https://user-images.githubusercontent.com/20779676/85599900-96bd5300-b66a-11ea-918c-63693f2d1a8b.png">

## After the fix

<img width="589" alt="Screenshot 2020-06-24 at 10 32 55 PM" src="https://user-images.githubusercontent.com/20779676/85599970-a89ef600-b66a-11ea-9905-364541a98d3f.png">
