### PR TITLE
Fix the pricing issue with woo product add-ons ext

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -84,40 +84,45 @@
 	} );
 
 	var generate_cart = function( callback ) {
-		var data = {
-			'nonce': wc_ppec_generate_cart_context.generate_cart_nonce,
-			'attributes': {},
-		};
 
-		var field_pairs = form.serializeArray();
-
-		for ( var i = 0; i < field_pairs.length; i++ ) {
-			// Prevent the default WooCommerce PHP form handler from recognizing this as an "add to cart" call
-			if ( 'add-to-cart' === field_pairs[ i ].name ) {
-				field_pairs[ i ].name = 'ppec-add-to-cart';
+		var formData = new FormData(),
+		formParams = form.serializeArray();
+		
+		for ( var i = 0; i < formParams.length; i++ ) {
+			// Prevent the default WooCommerce PHP form handler from recognizing this as an "add to cart" call.
+			if ( 'add-to-cart' === formParams[ i ].name ) {
+				formParams[ i ].name = 'ppec-add-to-cart';
 			}
 
-			// Save attributes as a separate prop in `data` object,
-			// so that `attributes` can be used later on when adding a variable product to cart
-			if ( -1 !== field_pairs[ i ].name.indexOf( 'attribute_' ) ) {
-				data.attributes[ field_pairs[ i ].name ] = field_pairs[ i ].value;
+			// Save attributes in a nested array,
+			// so that `attributes` can be used later on when adding a variable product to cart.
+			if ( -1 !== formParams[ i ].name.indexOf( 'attribute_' ) ) {
+				formData.append( "attributes[" + formParams[ i ].name + "]" , formParams[ i ].value );
 				continue;
 			}
 
-			if ( -1 !== field_pairs[ i ].name.indexOf( 'addon-' ) ) {
-				field_pairs[ i ].name = field_pairs[ i ].name + field_pairs[ i ].value;
-			}
+			formData.append( formParams[ i ].name, formParams[ i ].value );
+		}
+		
+		$.each( form.find( 'input[ type="file" ]' ), function( i, tag ) {
+			$.each( $( tag )[ 0 ].files, function( i, file ) {
+				formData.append( tag.name, file );
+			} );
+		} );
 
-			data[ field_pairs[ i ].name ] = field_pairs[ i ].value;
+		formData.append( 'nonce', wc_ppec_generate_cart_context.generate_cart_nonce );
+		
+		if ( ! formData.has('ppec-add-to-cart') ) {
+			formData.append( 'ppec-add-to-cart', $( '[name=add-to-cart]' ).val() );
 		}
 
-		// If this is a simple product, the "Submit" button has the product ID as "value", we need to include it explicitly
-		data[ 'ppec-add-to-cart' ] = $( '[name=add-to-cart]' ).val();
-
 		$.ajax( {
-			type:    'POST',
-			data:    data,
-			url:     wc_ppec_generate_cart_context.ajaxurl,
+			url: wc_ppec_generate_cart_context.ajaxurl,
+			cache: false,
+			contentType: false,
+			processData: false,
+			data: formData,
+			type: 'POST',
 			success: callback,
 		} );
 	};

--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -104,6 +104,10 @@
 				continue;
 			}
 
+			if ( -1 !== field_pairs[ i ].name.indexOf( 'addon-' ) ) {
+				field_pairs[ i ].name = field_pairs[ i ].name + field_pairs[ i ].value;
+			}
+
 			data[ field_pairs[ i ].name ] = field_pairs[ i ].value;
 		}
 


### PR DESCRIPTION
## Summary

Closes #606.

Before PPEC only picked up the price of the last checked add-on in the total price calculation. Now it picks up the prices of all the checked add-ons in the total price.

## Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Install Woo + PPEC + [Woo Product Add-Ons](https://woocommerce.com/products/product-add-ons/)
1. **Set up add-ons** by creating a simple product > going to product-data > add-ons > adding a checkbox field with 3 options with different flat prices. Example: https://d.pr/i/dGeblB (also available as a inline screenshot-1 below).
1. Switch to the master / main branch 
1. Go to the product page (having add-ons), try purchasing the product via PPEC button with 2 checked add-ons. 
1. **Current behavior:** The total price =  main product price + last add-on price. It does **NOT** include prices for every checked add-on in the total price. **Expected behavior:** The total should include prices for every checked add-on.
1. Switch to the branch issue_606
1. Try purchasing a product via PPEC with 2 checked add-ons. 
1. The total price = main product price + prices of **ALL** the checked add-ons.

## Documentation
This doesn't need documentation. The customer does not see any change. 

## Tests for PPEC 

- [x] Checkout a single product with no add-ons 
- [x] Checkout a single product with add-ons, by selecting at least 2 or more add-ons (expected behavior: total price = main product price + price of each checked add-on).
- [x] Checkout from cart page
- [x] Checkout from checkout page

## Screenshot

Screenshot-1
<img width="1543" alt="Screenshot 2020-06-25 at 4 47 58 PM" src="https://user-images.githubusercontent.com/20779676/85720740-56171580-b70e-11ea-8c56-7a55dd8e97d4.png">

## Questions

Previously the data sent to PayPal only contained one add-on item (example: `c`) even when the checked items were more (example: `b` and `c`). 

<img width="465" alt="Screenshot 2020-06-25 at 4 18 00 PM" src="https://user-images.githubusercontent.com/20779676/85721575-1d2b7080-b70f-11ea-8ff9-1f1c32e3ab55.png">

In this PR, I have made the field name's unique, such that each checked item is included in the data sent to PayPal. Is this the correct approach?

Closes #606.
