### PR TITLE
Add filters 

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -515,7 +515,7 @@ class WC_Gateway_PPEC_Client {
 				'sku'         => $values['data']->get_sku(),
 			);
 
-			$items[] = apply_filters( 'woocommerce_paypal_express_get_line_item_from_cart', $item, $values, $cart_item_key );
+			$items[] = apply_filters( 'woocommerce_paypal_express_checkout_get_line_item_from_cart', $item, $values, $cart_item_key );
 		}
 
 		foreach ( WC()->cart->get_fees() as $fee_key => $fee_values ) {
@@ -526,7 +526,7 @@ class WC_Gateway_PPEC_Client {
 				'amount'      => round( $fee_values->total, $decimals ),
 			);
 
-			$items[] = apply_filters( 'woocommerce_paypal_express_get_fee_from_cart', $item, $fee_values, $fee_key );
+			$items[] = apply_filters( 'woocommerce_paypal_express_checkout_get_fee_from_cart', $item, $fee_values, $fee_key );
 		}
 
 		return $items;
@@ -843,7 +843,7 @@ class WC_Gateway_PPEC_Client {
 				);
 			}
 
-			$items[] = apply_filters( 'woocommerce_paypal_express_get_line_item_from_order', $item, $order_item, $cart_item_key );
+			$items[] = apply_filters( 'woocommerce_paypal_express_checkout_get_line_item_from_order', $item, $order_item, $cart_item_key );
 		}
 
 		return $items;

--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -515,7 +515,7 @@ class WC_Gateway_PPEC_Client {
 				'sku'         => $values['data']->get_sku(),
 			);
 
-			$items[] = $item;
+			$items[] = apply_filters( 'woocommerce_paypal_express_get_line_item_from_cart', $item, $values, $cart_item_key );
 		}
 
 		foreach ( WC()->cart->get_fees() as $fee_key => $fee_values ) {
@@ -526,7 +526,7 @@ class WC_Gateway_PPEC_Client {
 				'amount'      => round( $fee_values->total, $decimals ),
 			);
 
-			$items[] = $item;
+			$items[] = apply_filters( 'woocommerce_paypal_express_get_fee_from_cart', $item, $fee_values, $fee_key );
 		}
 
 		return $items;
@@ -843,7 +843,7 @@ class WC_Gateway_PPEC_Client {
 				);
 			}
 
-			$items[] = $item;
+			$items[] = apply_filters( 'woocommerce_paypal_express_get_line_item_from_order', $item, $order_item, $cart_item_key );
 		}
 
 		return $items;


### PR DESCRIPTION
### Description

Added filters for retrieving the line items from cart and from orders. 

We stumbled upon a situation where we needed to alter the name of the line items sent to PayPal to take into account custom product fields added with another plugin. Just using the filter inside of "product->get_name()" is not enough since we needed to include the information stored in the custom product fields inside the actual line items. 

This was possible using WC's built-in PayPal integration (see filters "woocommerce_paypal_get_order_item_name" and "woocommerce_paypal_line_item" inside WooCommerce). This PR ensures parity in this regard with the built-in PayPal gateway.

### Steps to test:

This doesn't make any changes to the way the plugin works. It just enables users to filter the line items sent to PayPal to include their own custom logic for generating them.

### Documentation

Customers won't notice any changes.