### PR TITLE
Add validation checks for WC Product Addon required image fields

### DIFF
--- a/assets/js/wc-gateway-ppec-generate-cart.js
+++ b/assets/js/wc-gateway-ppec-generate-cart.js
@@ -55,6 +55,8 @@
 		// Check fields are valid and allow third parties to attach their own validation checks
 		fields_valid = form.get( 0 ).checkValidity() && $( document ).triggerHandler( 'wc_ppec_validate_product_form', [ fields_valid, form ] ) !== false;
 
+		// WC Product Addons Validation
+		fields_valid = validate_addon_image_fields();
 		update_button();
 	};
 
@@ -76,6 +78,34 @@
 	// Disable the button if there are invalid fields in the product page (like required fields from Product Addons)
 	form.on( 'change', 'select, input, textarea', function() {
 		// Hack: IE11 uses the previous field value for the checkValidity() check if it's called in the onChange handler
+		setTimeout( validate_form, 0 );
+	} );
+
+	// WC Product Addons: If image swatch is a required field, check whether it is selected. Disable PP button if false.
+	function validate_addon_image_fields() {
+		var swatch_select_count = 0;
+		var wc_pao_form_rows = $( '.wc-pao-required-addon > .form-row' ); // Only select required image fields.
+
+		for ( var j = 0; j < wc_pao_form_rows.length; j++ ) {
+			var item = wc_pao_form_rows[j];
+			var image_swatches = item.children;
+
+			for ( var i = 0; i < image_swatches.length-1; i++ ) {
+				var image_swatch = image_swatches[i];
+
+				if ( $( image_swatch ).hasClass( 'selected' ) ) {
+					swatch_select_count += 1;
+					break;
+				}
+			}
+		}
+
+		// Return true if at least one image swatch is selected in each image field.
+		return wc_pao_form_rows.length === swatch_select_count;
+	}
+
+	// WC Product Addons: Trigger validation when image fields are clicked.
+	$( '.wc-pao-addon-image-swatch' ).click( function() {
 		setTimeout( validate_form, 0 );
 	} );
 


### PR DESCRIPTION
## Summary

Closes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/788.

### 1. Issue Description

- When you use the PPEC plugin with the [WC Product Addon (WCPAO)](https://woocommerce.com/products/product-add-ons/) plugin, the validation check fails for "required image fields".
- If the image field is required and no image option is selected, the PPEC button should be disabled (as it is in case of radio buttons). But it isn't. And that's the issue.

### 2. Reproducing the issue

1. Install WC, PPEC and [WCPAO](https://woocommerce.com/products/product-add-ons/) plugins
2. Create two simple products in WC
3. The first one with a Radio Button Addon field as follows: https://d.pr/i/YCLRAk (PP button is disabled as expected).
4. The second one with two Image fields as follows: https://d.pr/i/KYVimx (PP button is enabled. This is an issue since you can checkout via the PP button without selecting the required image fields).

### 3. Without PPEC

1. Image fields: Ignoring PPEC validation for a moment, if we try to add the product (having image fields) to the cart, it does a PHP validation and returns an error (https://d.pr/i/ykLkaq). This is good.
2. Radio buttons: If we try doing this with radio buttons, it does a JS validation and asks us to select one of the radio buttons (https://d.pr/i/ZKNjsG). This is good.

### 4. Potential Solution in WCPAO
1. There's a hidden "select" element on the page: https://github.com/woocommerce/woocommerce-product-addons/blob/590c07b2b8f7c9c31239a75550cb466cc6297422/templates/addons/image.php#L52
2. We can make it required by adding this to it: `<?php //if ( WC_Product_Addons_Helper::is_addon_required( $addon ) ) { echo 'required'; } ?>`
3. But this breaks the "Add to cart" PHP validation mentioned in section 3, point 1 above. Instead a JS validation takes place and the button does nothing. Why? because the "select" element is hidden and there's no direct indication to the customer explaining why the "Add to cart" button isn't working.
4. This is the easiest fix (on WCPAO's side) but it creates bad UX.
5. Therefore it is best to solve this in PPEC as explained below.

## Solution
1. We add extra validation in PPEC to support the "required image fields" in the WCPAO plugin.
2. We create a new function `validate_addon_image_fields` which targets each "Image Field" containing "Image Swatches".
3. It then makes sure those "Image Fields" have at least one "Image Swatch" **selected**.
4. If that is the case, then the PPEC button will be enabled, otherwise, it'll stay disabled.
5. This check happens in the existing `validate_form` function.
6. An additional event is added to make sure the `validate_form` function is triggered whenever an image swatch is clicked.

## Tests
1. Switch to the feature branch
2. Open the product containing WCPAO Image Fields
3. Right off the bat, notice that PPEC button is disabled: https://d.pr/i/lt9Gcu
4. Try the "Add to cart" button. It will do a PHP validation and return an error as expected: https://d.pr/i/epDCvW (This has nothing to do with our new code but a good measure to ensure this button is working).
5. Now try selecting the "Image Swatches" in all the possible combinations you can imagine. You'll see the PPEC button is enabled only when there's at least one "Image Swatch" selected in each "Image Field": https://d.pr/i/2lnVVd

## Other

### Docs
- No documentation needed

### Changelog
- Fix: Add extra validation to support the image fields in WC Product Addon plugin.

