### PR TITLE
Rename instances of master to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 branches:
   only:
-    - master
+    - main
 
 install:
   - composer install

--- a/readme.txt
+++ b/readme.txt
@@ -282,4 +282,4 @@ Please use this to inform us about bugs, or make contributions via PRs.
 * Fix - Compatibility with Subscriptions and Checkout from Single Product page.
 * Fix - Make sure session object exists before use to prevent fatal error.
 
-[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-paypal-express-checkout/master/changelog.txt).
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-paypal-express-checkout/main/changelog.txt).


### PR DESCRIPTION
### Description

This renames all references of "master" branch to "main" as part of our efforts
to rename master for all of our repos.

See pb0GrA-R4-p2