### PR TITLE
Only ensure session on single product pages

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -675,7 +675,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 			return;
 		}
 
-		if ( ! empty( WC()->session ) && ! WC()->session->has_session() ) {
+		if ( ! empty( WC()->session ) && ! WC()->session->has_session() && is_product() ) {
 			WC()->session->set_customer_session_cookie( true );
 		}
 	}


### PR DESCRIPTION
**Issue**: #777 

---

### Description

This PR improves the session handling to prevent caching issues. It does this by only initializing the session (if needed) on single product pages. Since a session without adding anything to the cart is only required when checking out from single product pages, this should dramatically reduce the number of sessions that are created.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
0. Set up this gateway with the "Check out on single product" setting enabled.
1. Before applying this patch, in a new incognito window visit the site with the network inspector open. Observe a session starts on the first page load on the homepage:

<img width="393" alt="Screen Shot 2020-08-18 at 9 34 51 AM" src="https://user-images.githubusercontent.com/7317227/90541171-13ceeb00-e137-11ea-8b24-1a939efbb8ba.png">

2. Apply this patch. Start a fresh incognito window. Visit the site with the network inspector open. Observe no session is created on the homepage:

<img width="394" alt="Screen Shot 2020-08-18 at 9 35 35 AM" src="https://user-images.githubusercontent.com/7317227/90541180-16314500-e137-11ea-8e40-157ffb100e47.png">

3. Visit a single product page, observe the session is created:

<img width="397" alt="Screen Shot 2020-08-18 at 9 36 14 AM" src="https://user-images.githubusercontent.com/7317227/90541190-192c3580-e137-11ea-9515-422936eeada0.png">

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

Closes #777 .
