### PR TITLE
Replaces instances of main with trunk from main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 branches:
   only:
-    - main
+    - trunk
 
 install:
   - composer install

--- a/readme.txt
+++ b/readme.txt
@@ -282,4 +282,4 @@ Please use this to inform us about bugs, or make contributions via PRs.
 * Fix - Compatibility with Subscriptions and Checkout from Single Product page.
 * Fix - Make sure session object exists before use to prevent fatal error.
 
-[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-paypal-express-checkout/main/changelog.txt).
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-paypal-express-checkout/trunk/changelog.txt).


### PR DESCRIPTION
This replaces references to main with trunk per pb0GrA-R4-p2

These changes were accidentally applied to `main` branch before I set `trunk` as default. So this gets these changes added to `trunk` as well 😅
