### PR TITLE
Add support for PayPal Credit messaging

### DIFF
--- a/assets/js/wc-gateway-ppec-settings.js
+++ b/assets/js/wc-gateway-ppec-settings.js
@@ -240,6 +240,71 @@
 			} );
 		}
 
+		// Handle Credit settings.
+		var creditSettings = {
+			init: function() {
+				var refreshOnChange = [ 'button_layout', 'hide_funding_methods[]', 'credit_enabled', 'credit_message_enabled', 'credit_message_layout', 'credit_message_logo' ];
+				var selector        = $.map( refreshOnChange, function( val ) { return '[name^="woocommerce_ppec_paypal_"][name$="' + val + '"]'; } ).join( ', ' );
+
+				$( selector ).change( this.refreshUI );
+
+				// Trigger this to configure initial state for cart settings.
+				$( '#woocommerce_ppec_paypal_credit_enabled' ).change();
+				$( '#woocommerce_ppec_paypal_hide_funding_methods' ).change();
+			},
+
+			refreshUI: function( event ) {
+				var $contextSettings = $( event.target ).closest( 'table' );
+				var $creditSettings  = $contextSettings.find( '[name*="credit_"]' );
+				var $creditToggle    = $creditSettings.filter( '[name$="credit_enabled"]' );
+				var $messageToggle   = $creditSettings.filter( '[name$="credit_message_enabled"]' );
+				var $messageSettings = $creditSettings.filter( '[name*="credit_message"]' );
+				var $messageLayout   = $creditSettings.filter( '[name$="credit_message_layout"]' );
+				var $messageLogo     = $creditSettings.filter( '[name$="credit_message_logo"]' );
+				var creditEnabled    = false;
+
+				if ( 'horizontal' === $contextSettings.find( '[name$="button_layout"]' ).val() ) {
+					creditEnabled = $creditToggle.is( ':checked' ) && ! $creditToggle.is(':disabled');
+				} else {
+					creditEnabled = ( -1 === $.inArray( 'CREDIT', $contextSettings.find( '[name$="hide_funding_methods[]"]' ).val() ) );
+				}
+
+				// Hide Credit settings if Credit is not enabled.
+				if ( ! creditEnabled ) {
+					$creditSettings.not( $creditToggle ).closest( 'tr' ).hide();
+					return;
+				}
+
+				// Show the Credit message toggle.
+				$messageToggle.closest( 'tr' ).show();
+
+				// Hide messaging related settings if Credit message is not enabled.
+				if ( ! $messageToggle.is( ':checked' ) ) {
+					$messageSettings.not( $messageToggle ).closest( 'tr' ).hide();
+					return;
+				}
+
+				// Display layout setting.
+				$messageLayout.closest( 'tr' ).show();
+
+				// Display layout specific settings.
+				switch ( $messageLayout.val() ) {
+					case 'flex':
+						$messageSettings.not( $messageToggle ).not( $messageLayout ).not( '[name*="_flex_"]' ).closest( 'tr' ).hide();
+						$messageSettings.filter( '[name*="_flex_"]' ).closest( 'tr' ).show();
+						break;
+					case 'text':
+					default:
+						$messageSettings.filter( '[name*="_flex_"] ').closest( 'tr' ).hide();
+						$messageLogo.closest( 'tr' ).show();
+						$messageSettings.filter( '[name$="logo_position"]' ).closest( 'tr' ).toggle( 'primary' === $messageLogo.val() || 'alternative' === $messageLogo.val() );
+						$messageSettings.filter( '[name$="text_color"]' ).closest( 'tr' ).show();
+						break;
+				}
+			}
+		};
+		creditSettings.init();
+
 		$( '.woocommerce_ppec_paypal_button_layout' ).change( function( event ) {
 			if ( ! $( '#woocommerce_ppec_paypal_use_spb' ).is( ':checked' ) ) {
 				return;
@@ -314,6 +379,7 @@
 				// Show all settings in section.
 				$( '#woocommerce_ppec_paypal_single_product_settings_toggle, .woocommerce_ppec_paypal_single_product' ).closest( 'tr' ).show();
 				$( '#woocommerce_ppec_paypal_single_product_button_layout' ).change();
+				$( '#woocommerce_ppec_paypal_single_product_credit_enabled' ).change();
 			}
 			showHideDefaultButtonSettings();
 		} ).change();
@@ -334,6 +400,7 @@
 				// Show all settings in section.
 				$( '#woocommerce_ppec_paypal_mark_settings_toggle, .woocommerce_ppec_paypal_mark' ).closest( 'tr' ).show();
 				$( '#woocommerce_ppec_paypal_mark_button_layout' ).change();
+				$( '#woocommerce_ppec_paypal_mark_credit_enabled' ).change();
 			}
 			showHideDefaultButtonSettings();
 		} ).change();

--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -56,6 +56,24 @@
 		return paypal_funding_methods;
 	}
 
+	var renderCreditMessaging = function( buttonSelector ) {
+		if ( 'undefined' === typeof wc_ppec_context.credit_messaging || ! wc_ppec_context.credit_messaging || 'undefined' === typeof paypal.Messages ) {
+			return;
+		}
+
+		if ( 'undefined' != typeof paypal.isFundingEligible && ! paypal.isFundingEligible( paypal.FUNDING.CREDIT ) && ! paypal.isFundingEligible( paypal.FUNDING.PAYLATER ) ) {
+			return;
+		}
+
+		if ( 0 === $( buttonSelector ).length ) {
+			return;
+		}
+
+		// Add an element for messaging.
+		var messagingWrapper = $( '<div></div>' ).insertBefore( buttonSelector ).get( 0 );
+		paypal.Messages( wc_ppec_context.credit_messaging ).render( messagingWrapper );
+	}
+
 	var render = function( isMiniCart ) {
 		var prefix        = isMiniCart ? 'mini_cart_' : '';
 		var button_size   = wc_ppec_context[ prefix + 'button_size' ];
@@ -194,6 +212,10 @@
 		};
 
 		if ( ! wc_ppec_context.use_checkout_js ) {
+			if ( ! isMiniCart ) {
+				renderCreditMessaging( selector );
+			}
+
 			// 'payment()' and 'onAuthorize()' callbacks from checkout.js are now 'createOrder()' and 'onApprove()'.
 			Object.defineProperty( button_args, 'createOrder', Object.getOwnPropertyDescriptor( button_args, 'payment' ) );
 			Object.defineProperty( button_args, 'onApprove', Object.getOwnPropertyDescriptor( button_args, 'onAuthorize' ) );

--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -644,7 +644,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 	}
 
 	/**
-	 * Adds the data-namespace attribute when enqueuing the PayPal SDK script
+	 * Adds the data-namespace and data-partner-attribution-id attributes when enqueuing the PayPal SDK script.
 	 *
 	 * @since 2.0.1
 	 * @param string  $tag
@@ -652,7 +652,11 @@ class WC_Gateway_PPEC_Cart_Handler {
 	 * @return string
 	 */
 	public function add_paypal_sdk_namespace_attribute( $tag, $handle ) {
-		return ( 'paypal-checkout-sdk' === $handle ) ? str_replace( ' src', ' data-namespace="paypal_sdk" src', $tag ) : $tag;
+		if ( 'paypal-checkout-sdk' === $handle ) {
+			$tag = str_replace( ' src=', ' data-namespace="paypal_sdk" data-partner-attribution-id="WooThemes_EC" src=', $tag );
+		}
+
+		return $tag;
 	}
 
 	/**

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -128,10 +128,25 @@ class WC_Gateway_PPEC_Plugin {
 			delete_option( 'pp_woo_enabled' );
 		}
 
+		$previous_version = get_option( 'wc_ppec_version' );
+
 		// Check the the WC version on plugin update to determine if we need to display a warning.
 		// The option was added in 1.6.19 so we only need to check stores updating from before that version. Updating from 1.6.19 or greater would already have it set.
-		if ( version_compare( get_option( 'wc_ppec_version' ), '1.6.19', '<' ) && version_compare( WC_VERSION, '3.0', '<' ) ) {
+		if ( version_compare( $previous_version, '1.6.19', '<' ) && version_compare( WC_VERSION, '3.0', '<' ) ) {
 			update_option( 'wc_ppec_display_wc_3_0_warning', 'true' );
+		}
+
+		// Credit messaging is disabled by default for merchants upgrading from < 2.0.4.
+		if ( $previous_version && version_compare( $previous_version, '2.0.4', '<' ) ) {
+			$settings = get_option( 'woocommerce_ppec_paypal_settings', array() );
+
+			if ( is_array( $settings ) ) {
+				$settings['credit_message_enabled']                = 'no';
+				$settings['single_product_credit_message_enabled'] = 'no';
+				$settings['mark_credit_message_enabled']           = 'no';
+
+				update_option( 'woocommerce_ppec_paypal_settings', $settings );
+			}
 		}
 
 		update_option( 'wc_ppec_version', $new_version );

--- a/includes/settings/settings-ppec.php
+++ b/includes/settings/settings-ppec.php
@@ -450,7 +450,108 @@ $per_context_settings = array(
 		'desc_tip'    => true,
 		'description' => $credit_enabled_description,
 	),
+
+	'credit_message_enabled' => array(
+		'title'       => 'Enable PayPal Credit messages',
+		'type'        => 'checkbox',
+		'class'       => '',
+		'disabled'    => ! wc_gateway_ppec_is_credit_supported(),
+		'default'     => 'yes',
+		'label'       => __( 'Enable PayPal Credit messages', 'woocommerce-gateway-paypal-express-checkout' ),
+		'desc_tip'    => true,
+		'description' => __( 'Display credit messages on your website to promote special financing offers, which help increase sales.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),
+	'credit_message_layout' => array(
+		'title'   => __( 'Credit Messaging Layout', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type'    => 'select',
+		'class'   => 'wc-enhanced-select',
+		'default' => 'text',
+		'options' => array(
+			'text' => __( 'Text', 'woocommerce-gateway-paypal-express-checkout' ),
+			'flex' => __( 'Graphic', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+		'disabled' => ! wc_gateway_ppec_is_credit_supported(),
+		'desc_tip' => true,
+		'description' => __( 'The layout of the message.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),
+	'credit_message_logo' => array(
+		'title'   => __( 'Credit Messaging logo', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type'    => 'select',
+		'class'   => 'wc-enhanced-select',
+		'default' => 'primary',
+		'options' => array(
+			'primary'     => __( 'Primary', 'woocommerce-gateway-paypal-express-checkout' ),
+			'alternative' => __( 'Alternative', 'woocommerce-gateway-paypal-express-checkout' ),
+			'inline'      => __( 'In-Line', 'woocommerce-gateway-paypal-express-checkout' ),
+			'none'        => __( 'None', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+		'disabled' => ! wc_gateway_ppec_is_credit_supported(),
+		'desc_tip' => true,
+		'description' => __( 'PayPal Credit logo used in the message.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),
+	'credit_message_logo_position' => array(
+		'title'  => __( 'Credit Messaging logo position', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type'   => 'select',
+		'class'   => 'wc-enhanced-select',
+		'default' => 'left',
+		'options' => array(
+			'left'  => __( 'Left', 'woocommerce-gateway-paypal-express-checkout' ),
+			'right' => __( 'Right', 'woocommerce-gateway-paypal-express-checkout' ),
+			'top'   => __( 'Top', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+		'disabled' => ! wc_gateway_ppec_is_credit_supported(),
+		'desc_tip' => true,
+		'description' => __( 'Position of the PayPal logo in the message.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),
+	'credit_message_text_color' => array(
+		'title'   => __( 'Credit Messaging text color', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type'    => 'select',
+		'class'   => 'wc-enhanced-select',
+		'default' => 'black',
+		'options' => array(
+			'black'      => __( 'Black', 'woocommerce-gateway-paypal-express-checkout' ),
+			'white'      => __( 'White', 'woocommerce-gateway-paypal-express-checkout' ),
+			'monochrome' => __( 'Monochrome', 'woocommerce-gateway-paypal-express-checkout' ),
+			'grayscale'  => __( 'Grayscale', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+		'disabled' => ! wc_gateway_ppec_is_credit_supported(),
+		'desc_tip' => true,
+		'description' => __( 'Text and logo color of the message.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),
+	'credit_message_flex_color' => array(
+		'title' => __( 'Credit Messaging color', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type' => 'select',
+		'class' => 'wc-enhanced-select',
+		'default' => 'black',
+		'options' => array(
+			'blue'            => __( 'Blue', 'woocommerce-gateway-paypal-express-checkout' ),
+			'black'           => __( 'Black', 'woocommerce-gateway-paypal-express-checkout' ),
+			'white'           => __( 'White', 'woocommerce-gateway-paypal-express-checkout' ),
+			'white-no-border' => __( 'White no border', 'woocommerce-gateway-paypal-express-checkout' ),
+			'gray'            => __( 'Gray', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+		'disabled' => ! wc_gateway_ppec_is_credit_supported(),
+		'desc_tip' => true,
+		'description' => __( 'Color of the message.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),
+	'credit_message_flex_ratio' => array(
+		'title' => __( 'Credit Messaging ratio', 'woocommerce-gateway-paypal-express-checkout' ),
+		'type' => 'select',
+		'class' => 'wc-enhanced-select',
+		'default' => '1x1',
+		'options' => array(
+			'1x1'  => __( '1x1', 'woocommerce-gateway-paypal-express-checkout' ),
+			'1x4'  => __( '1x4', 'woocommerce-gateway-paypal-express-checkout' ),
+			'8x1'  => __( '8x1', 'woocommerce-gateway-paypal-express-checkout' ),
+			'20x1' => __( '20x1', 'woocommerce-gateway-paypal-express-checkout' ),
+		),
+		'disabled' => ! wc_gateway_ppec_is_credit_supported(),
+		'desc_tip' => true,
+		'description' => __( 'Shape and size of the message.', 'woocommerce-gateway-paypal-express-checkout' ),
+	),
+
 );
+
 
 /**
  * Cart / global button settings.
@@ -489,6 +590,11 @@ $settings['mini_cart_settings_toggle'] = array(
 	'description' => __( 'Optionally override global button settings above and configure buttons for this context.', 'woocommerce-gateway-paypal-express-checkout' ),
 );
 foreach ( $per_context_settings as $key => $value ) {
+	// No PayPal Credit messaging settings for mini-cart.
+	if ( 0 === strpos( $key, 'credit_message_' ) ) {
+		continue;
+	}
+
 	$value['class']                 .= ' woocommerce_ppec_paypal_mini_cart';
 	$settings[ 'mini_cart_' . $key ] = $value;
 }


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This PR adds [PayPal Credit messaging](https://developer.paypal.com/docs/business/checkout/add-capabilities/credit-messaging/) support to the PayPal Checkout plugin.

These messages are displayed in the form of banners with text/graphics promoting special offers from PayPal Credit. They are meant to be displayed in several places including home and/or category pages*, as well as alongside PayPal (Credit) buttons on the product, cart and checkout pages.

These are some examples of how these banners can look like:

<img width="623" alt="Screen Shot 2020-09-15 at 21 39 18" src="https://user-images.githubusercontent.com/184724/93278761-ed36bb00-f79b-11ea-83ed-ee1f99936230.png">

<img width="452" alt="Screen Shot 2020-09-15 at 19 59 37" src="https://user-images.githubusercontent.com/184724/93278721-d4c6a080-f79b-11ea-8617-2cba18ffd80e.png">

(*) Per pb0GrA-Ud-p2, this PR doesn't include support for displaying the banners on home/category pages.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Check out this branch (`credit-bnpl`).
1. Make sure your setup supports PayPal Credit: store address must be in the US and you should either be browsing in the US (or through a VPN in the US) or simulate this by using a snippet such as this one:
   ```php
   add_filter( 'woocommerce_paypal_express_checkout_sdk_script_args', function( $settings ) {
       $settings['buyer-country'] = 'US';
       return $settings;
   } );
   ```
1. **Test basic functionality:**
   1. Go to WC > Settings > Payments > PayPal Checkout.
   1. There should be a new "Enable PayPal Credit message" setting and a section of related settings (as in the screenshot below) both globally and per context (single product & checkout, if context specific settings are enabled).
   
      <img width="670" alt="Screen Shot 2020-09-15 at 19 59 56" src="https://user-images.githubusercontent.com/184724/93279301-4c48ff80-f79d-11ea-9c6b-77a3e8cae739.png">
   1. Enable the checkbox above and confirm that the Credit message appears on the cart page or the single product/checkout page if enabled in the context-specific settings section.
   1. Test various configurations of settings both globally and/or per context. The full matrix of possible styles is as follows:
      - Layout:
         - Text
            - Logo type: Primary, Alternative, In-line, None
            - Logo position (only when type is either "primary" or "alternative"): left, right, top. 
            - Text color: black, white, monochrome, grayscale
         - Graphic
            - Color: blue, black, white, white no border, gray
            - Ratio: 1x1, 1x4, 8x1, 20x1
1. **Test the upgrade routine:**
   1. Copy the current value of your `woocommerce_ppec_paypal_settings` row in the options table, and save it in a safe place.
   1. Simulate a clean install by removing `wc_ppec_version` and `woocommerce_ppec_paypal_settings` from the options table.
   1. Go to the Settings screen and confirm that PayPal Credit messaging is on by default.
   1. Restore your previous settings by updating the value of `woocommerce_ppec_paypal_settings` in the options table with the value you saved before.
   1. Simulate a plugin upgrade by changing `WC_GATEWAY_PPEC_VERSION` in `woocommerce-gateway-paypal-express-checkout.php` to `2.0.4`.
   1. Make sure PayPal Credit messaging is off by default. (Feature is opt-in for existing merchants).
1. **Test with Subscriptions:**
   1. Disable the WooCommerce Subscriptions plugin.
   1. Make sure Credit messaging is enabled.
   1. Go to the product page of a product that costs more than $100 or add more than $100 worth of items to your cart.
   1. Credit messaging on such pages should reflect the price. Instead of a generic message you should get a message specific to the price of your item/cart, such as "Pay in 4 interest-free payments of $25.00". (For less expensive items, messaging is still generic).
   1. Enable the WooCommerce Subscriptions plugin.
   1. Messaging should now be generic across all pages on your site.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [X] This PR needs documentation (has the "Documentation" label).
   Several new settings are added that affect frontend screens (when said settings are enabled)
