### PR TITLE
Hide "Pay Later" funding method when "Credit" is disabled

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -45,12 +45,14 @@
 		}
 
 		var paypal_funding_methods = [];
-		for ( var i = 0; i < methods.length; i++ ) {
-			var method = paypal.FUNDING[ methods[ i ].toUpperCase() ];
+
+		$.each( methods, function( index, method_name ) {
+			var method = paypal.FUNDING[ method_name.toUpperCase() ];
 			if ( method ) {
 				paypal_funding_methods.push( method );
 			}
-		}
+		} );
+
 		return paypal_funding_methods;
 	}
 


### PR DESCRIPTION
# Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Pay Pal is rolling out a "Pay Later" button to replace the current "PayPal Credit" button. This change is already available in sandbox mode and will make it to the live environment soon.

<img width="647" alt="Screen Shot 2020-09-29 at 18 06 34" src="https://user-images.githubusercontent.com/184724/94616008-10269c00-027f-11eb-90d5-6646f478eef9.png">

This PR updates our code so that hiding "Credit" as a funding source results in "Pay Later" being hidden too. It also simplifies some of the code dealing with Credit in [`WC_Gateway_PPEC_Cart_Handler::get_button_settings()`](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/c4a6be036346646d1d7ea2c6d0bd3f1f249f9121/includes/class-wc-gateway-ppec-cart-handler.php#L438).

### Steps to test:
1. Check out `trunk`.
1. Go to WC > Settings > Payments > PayPal Checkout.
1. Uncheck all context specific settings toggles ("Configure settings specific to …"). This is not required but helps as you'd only need to test one set of settings.
1. Make sure your setup is compatible with PayPal Credit and that it is enabled:
   1. Store address must be in the US.
   1. You should be browsing from the US either by using a VPN or a snippet like this one:
      ```php
      add_filter( 'woocommerce_paypal_express_checkout_sdk_script_args', function( $settings ) {
      	$settings['buyer-country'] = 'US';
      	return $settings;
      } );
      ```
   1. If your button is using the vertical layout, Credit should not be a hidden funding method. If the layout is horizontal, the "Enable PayPal Credit to eligible customers" must be checked.
1. Go to the frontend (single product page, cart or checkout) and make sure you see the "Pay Later" button.
1. Disable the Credit button: do the opposite of 4-iii.
1. **Go to the frontend and make sure you still see the "Pay Later" button.** This is wrong but it's what this PR is fixing.
1. Check out this branch (`paylater`).
1. Make sure the "Pay Later" button no longer appears.
1. Toggle the Credit settings again (depending on layout) to re-enable Credit and make sure the "Pay Later" button appears.
2. Repeat the above with a different button layout.
1. Optionally, re-enable context specific settings and try a few combinations.

### Documentation
We might need to update screenshots referring to "PayPal Credit".

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Hide "Pay Later" funding method when "Credit" is disabled.
