### PR TITLE
Do not force vaulting for non-subscription products even when there's a subscription in the cart

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -618,7 +618,7 @@ class WC_Gateway_PPEC_Cart_Handler {
 					'currency'    => get_woocommerce_currency(),
 				);
 
-				if ( ( 'product' === $page && class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $GLOBALS['post']->ID ) ) || wc_gateway_ppec()->checkout->needs_billing_agreement_creation( array() ) ) {
+				if ( ( 'product' === $page && class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $GLOBALS['post']->ID ) ) || ( 'product' !== $page && wc_gateway_ppec()->checkout->needs_billing_agreement_creation( array() ) ) ) {
 					$script_args['vault'] = 'true';
 				}
 


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
In #810 we forced `vault=true` in the SDK arguments when displaying PayPal buttons for subscription products or when there was a subscription in the cart.
The latter condition isn't actually correct, as you might have a subscription product in the cart but if you visit a non-subscription product you should be able to pay using non-vaulted methods given that clicking a PayPal button to start the payment workflow ignores whatever items the cart contains.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Checkout `trunk`.
1. Visit a non-subscription product page.
1. Confirm that the SDK script was loaded without a `vault` parameter.
1. Visit a subscription product page.
1. Confirm that the SDK script is loaded with a `vault='true'` argument.
1. Add the subscription product to the cart.
1. Confirm that the SDK script is loaded with a `vault='true'` argument on cart and checkout pages.
1. ❌ Check that the SDK script is loaded with a `vault='true'` argument even when visiting a non-subscription product page.
1. Checkout this branch (`vaulting-fix`).
1. Repeat all of the above steps and confirm the behavior is the same except for 8 above. You should see the SDK script being loaded with no `vault` argument even if there's a subscription in the cart  ✅.
