### PR TITLE
Fix Credit messaging placement on checkout page

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -70,7 +70,7 @@
 		}
 
 		// Add an element for messaging.
-		var messagingWrapper = $( '<div></div>' ).insertBefore( buttonSelector ).get( 0 );
+		var messagingWrapper = $( '<div id="woo-ppec-credit-messaging"></div>' ).prependTo( buttonSelector ).get( 0 );
 		paypal.Messages( wc_ppec_context.credit_messaging ).render( messagingWrapper );
 	}
 


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

When you have multiple payment options on the checkout and have selected a non PayPal Checkout method, the PayPal Credit Messaging shows up below the place order button:
![](https://d.pr/i/TsSgL5+)

Props @jorgeatorres for the fixes!

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Enable a second payment method (stripe/square) 
1. Enable PayPal Credit Messaging on checkout
1. Add a product to the cart and visit the checkout
1. On `trunk`, select the non-PayPal Checkout gateway and you should see the Credit Messaging under the place order button
1. On `bnpl-ui-fix` you shouldn't see the Credit Messaging until PayPal is selected.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

