### PR TITLE
Dev-dependency update - WooCommerce Sniffs v0.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"homepage": "https://woocommerce.com/products/woocommerce-gateway-paypal-checkout/",
 	"type": "wordpress-plugin",
 	"require-dev": {
-	  "woocommerce/woocommerce-sniffs": "0.0.10"
+	  "woocommerce/woocommerce-sniffs": "0.1.0"
 	},
 	"scripts": {
 	  "phpcs": [


### PR DESCRIPTION
### Description

Since Composer 2, Travis CI PHPCS checks using `woocommerce-sniffs` composer package `v0.0.10` fails since Travis self-updates Composer to v2. 

**Errors:**

```
Problem 1
199    - dealerdirect/phpcodesniffer-composer-installer v0.6.2 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
200    - woocommerce/woocommerce-sniffs 0.0.10 requires dealerdirect/phpcodesniffer-composer-installer 0.6.2 -> satisfiable by dealerdirect/phpcodesniffer-composer-installer[v0.6.2].
201    - Root composer.json requires woocommerce/woocommerce-sniffs 0.0.10 -> satisfiable by woocommerce/woocommerce-sniffs[0.0.10].
```

The newest version of `woocommerce-sniffs` package (v0.1.0) updates the version for `dealerdirect/phpcodesniffer-composer-installer` to `0.7.0` which is compatible with Composer 2. Changelog: https://github.com/woocommerce/woocommerce-sniffs/blob/master/CHANGELOG.md#010---2020-08-06