### PR TITLE
Use is_callable() instead of method_exists() in check

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -135,7 +135,7 @@ class WC_Gateway_PPEC_Checkout_Handler {
 			return $fields;
 		}
 
-		if ( method_exists( WC()->cart, 'needs_shipping' ) && ! WC()->cart->needs_shipping() && 'no' === wc_gateway_ppec()->settings->require_billing ) {
+		if ( is_callable( array( WC()->cart, 'needs_shipping' ) ) && ! WC()->cart->needs_shipping() && 'no' === wc_gateway_ppec()->settings->require_billing ) {
 			$not_required_fields = array( 'first_name', 'last_name', 'company', 'address_1', 'address_2', 'city', 'postcode', 'country' );
 			foreach ( $not_required_fields as $not_required_field ) {
 				if ( array_key_exists( $not_required_field, $fields ) ) {


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #829

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
After doing some [code analysis and smoke tests](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/829) I didn't notice any major problems with PHP 8 and PPEC.

The only change I'm pushing modifies a check so that it uses `is_callable()` instead of `method_exists()`. This is probably not necessary but better to err on the side of caution.

Closes #829.
