### PR TITLE
Honor “shape” setting when rendering standalone buttons

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -248,7 +248,7 @@
 						onError:       button_args.onError,
 						onCancel:      button_args.onCancel,
 						fundingSource: fundingSource,
-						style:         ( paypal.FUNDING.PAYPAL === fundingSource ) ? button_args.style : { layout: button_args.style.layout }
+						style:         ( paypal.FUNDING.PAYPAL === fundingSource ) ? button_args.style : { layout: button_args.style.layout, shape: button_args.style.shape }
 					};
 
 					var button = paypal.Buttons( buttonSettings );


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #806

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
When rendering buttons in standalone mode (for instance, when some methods are hidden in certain contexts but not in others) the configured button shape is only applied to the main PayPal button and not the other buttons (such as Debit/Credit card or Pay Later). This PR fixes this problem by making sure all buttons are rendered using the same shape.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. For `master`, follow these steps to confirm the bug (adapted from #806):
   1. Go to: **WooCommerce > Settings > Payments > 'PayPal Checkout' > "Button Settings"**
   1. Set *Button Shape* to: **Pill**
   1. Ensure that _Credit or Debit Card_ is not a hidden funding method: https://d.pr/i/C6LlNY
   1. Ensure that at least one method _is_ hidden to force standalone rendering.
   1. Navigate to checkout to see that the 'PayPal' button is **Pill**, while 'Credit or Debit Card' is **Rectangle**: https://d.pr/i/CpSgGF
2. On this branch (`issue-806`) all buttons should have the same shape.
   1. Test standalone rendering by ensuring at least one method is hidden.
   2. Test default rendering by ensuring no method is hidden (and PayPal Credit is not disabled).

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Honor “shape” setting when rendering standalone buttons.

Closes #806.
