### PR TITLE
Ensure WC session when Single Product Checkout is not set

### DIFF
--- a/includes/class-wc-gateway-ppec-cart-handler.php
+++ b/includes/class-wc-gateway-ppec-cart-handler.php
@@ -35,6 +35,9 @@ class WC_Gateway_PPEC_Cart_Handler {
 			add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'display_paypal_button_product' ), 1 );
 			add_action( 'wc_ajax_wc_ppec_generate_cart', array( $this, 'wc_ajax_generate_cart' ) );
 			add_action( 'wp', array( $this, 'ensure_session' ) ); // Ensure there is a customer session so that nonce is not invalidated by new session created on AJAX POST request.
+		} else {
+			// We also have to ensure session when guests checkout via order-pay endpoint.
+			add_action( 'woocommerce_pay_order_after_submit', array( $this, 'ensure_session' ) );
 		}
 
 		add_action( 'wc_ajax_wc_ppec_update_shipping_costs', array( $this, 'wc_ajax_update_shipping_costs' ) );


### PR DESCRIPTION
**Issue**: #842 

---

### Description
This adds the [ensure_session](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/d93e8f3e7b90c0359a1f11b074419d5fea966874/includes/class-wc-gateway-ppec-cart-handler.php#L666-L678) callback to an order-pay hook when Single Product Checkout is disabled.

Previously, in cases where a guest checks out via the order-pay page (via a payment link sent from the merchant), and Single Product Checkout is not enabled, no session is set and so the method responsible for processing once we return from PayPal returned early, and guests ended up at an empty cart page (See https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/842#issuecomment-759990913 for details).

This PR fixes that by adding the ensure_session cb to a hook specific to the order-pay page. We avoid adding this when Single Product Checkout is enabled as this cb is already added to a more generic hook in this case.

### Steps to test:
1. Disable Checkout on Single Product in **WooCommerce > Settings > Payments > PayPal Checkout**
2. Create a manual order for a guest customer
3. Using the payment link, pay for this order in a private window using PPEC
4. On `trunk`, you will be redirected to an empty cart page. On this branch, the payment will be successful.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Fix - Ensures a session cookie is set when guests pay for manual orders.

Closes #842 
