### PR TITLE
Avoid fatal error when line_item is not an instance of WC_Product

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -839,7 +839,7 @@ class WC_Gateway_PPEC_Client {
 					'name'     => $order_item['name'],
 					'quantity' => $order_item['qty'],
 					'amount'   => $amount,
-					'sku'      => $product->get_sku(),
+					'sku'      => ( $product instanceof WC_Product ) ? $product->get_sku() : sanitize_title( $order_item['name'] ),
 				);
 			}
 


### PR DESCRIPTION
### Description
Sometimes plugins and snippets out there uses this code to add custom lines to the cart (not instance of WC_Product):
``` WC()->cart->add_to_cart( array );```

This is causing a fatal error on `$product->get_sku()`.

### Steps to test:
1. For instance, install LMS Masterstudy (free plugin from WordPress.org)
1. In options activate WC Checkout; then create a course and add it to the cart
1. Just complete the checkout and boom! Fatal error instead of the thank you page.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Closes nothing; issue not reported, preferred to send this pull request.
