### PR TITLE
Adds an option for displaying WooCommerce Inbox notifications

### DIFF
--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -149,6 +149,10 @@ class WC_Gateway_PPEC_Plugin {
 			}
 		}
 
+		if ( function_exists( 'add_woocommerce_inbox_variant' ) ) {
+			add_woocommerce_inbox_variant();
+		}
+
 		update_option( 'wc_ppec_version', $new_version );
 	}
 

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -47,3 +47,19 @@ function wc_gateway_ppec() {
 }
 
 wc_gateway_ppec()->maybe_run();
+
+/**
+ * Adds the WooCommerce Inbox option on plugin activation
+ *
+ * @since 2.1.2
+ */
+if ( ! function_exists( 'add_woocommerce_inbox_variant' ) ) {
+	function add_woocommerce_inbox_variant() {
+		$option = 'woocommerce_inbox_variant_assignment';
+
+		if ( false === get_option( $option, false ) ) {
+			update_option( $option, wp_rand( 1, 12 ) );
+		}
+	}
+}
+register_activation_hook( __FILE__, 'add_woocommerce_inbox_variant' );


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
Internal link: paJDYF-1uJ-p2
Parent GH link: 10117-gh-Automattic/woocommerce.com

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This PR adds the WC Admin inbox notification option to PPXO as per: pb0GrA-1cH-p2#comment-2063

### Steps to test:
The option should be added on plugin activation and upgrade.

**Plugin Activation**
1. Checkout branch `wc_inbox_option`
2. Deactivate PayPal Checkout plugin
3. Delete `woocommerce_inbox_variant_assignment` from wp_options if it already exists
4. Activate PayPal Checkout
5. Check `woocommerce_inbox_variant_assignment` is a random value from 1-12

**Plugin Upgrade**

1. Delete `woocommerce_inbox_variant_assignment` from wp_options if it already exists
2. Go into wp_options table and edit `wc_ppec_version` to be 1 version behind (i.e. 2.1.0)
3. Reload an admin page to trigger an update
4. Check `woocommerce_inbox_variant_assignment` is a random value from 1-12