### PR TITLE
Upgrade to PayPal Payments Notice on Plugins Page

### DIFF
--- a/assets/css/admin/ppec-upgrade-notice.css
+++ b/assets/css/admin/ppec-upgrade-notice.css
@@ -1,0 +1,45 @@
+.plugins tr[data-slug=woocommerce-gateway-paypal-express-checkout] th, .plugins tr[data-slug=woocommerce-gateway-paypal-express-checkout] td {
+  box-shadow: none !important;
+}
+
+#ppec-migrate-notice .notice {
+  padding: 1px 0 20px 0;
+}
+#ppec-migrate-notice .ppec-notice-section {
+  padding: 0 20px;
+}
+#ppec-migrate-notice .ppec-notice-title {
+  border-bottom: 1px solid #FFB900;
+}
+#ppec-migrate-notice .ppec-notice-title p {
+  line-height: 30px;
+}
+#ppec-migrate-notice .ppec-notice-title p:before {
+  vertical-align: middle;
+}
+#ppec-migrate-notice .ppec-notice-content p:first-of-type {
+  margin-top: 20px;
+}
+#ppec-migrate-notice .ppec-notice-content p:before {
+  display: none;
+}
+#ppec-migrate-notice .ppec-notice-content ul {
+  list-style-type: disc;
+  margin-left: 30px;
+}
+#ppec-migrate-notice .ppec-notice-buttons a {
+  text-decoration: none;
+  line-height: 34px;
+  margin-right: 16px;
+}
+#ppec-migrate-notice .ppec-notice-buttons a:last-of-type {
+  margin-right: 0;
+}
+#ppec-migrate-notice .ppec-notice-buttons a:before {
+  vertical-align: middle;
+  margin: -2.5px 5px 0 0;
+}
+#ppec-migrate-notice .ppec-notice-buttons a.updating-message:before {
+  -webkit-animation: rotation 2s infinite linear;
+          animation: rotation 2s infinite linear;
+}

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -8,23 +8,21 @@
 	}
 
 	// Handle delete event for PayPal Payments.
-	$( document ).on( 'wp-plugin-delete-success', function( response ) {
-		setTimeout( function(){
-			if ( is_paypal_payments_installed && $( 'tr#woocommerce-paypal-payments-deleted' ).length ) {
-				is_paypal_payments_installed = false;
+	$( document ).on( 'wp-plugin-delete-success', function( event, response ) {
+		if ( is_paypal_payments_installed && 'woocommerce-paypal-payments' === response.slug ) {
+			is_paypal_payments_installed = false;
 
-				// Change PPEC notice activation button id, text & link.
-				const ppec_install_id   = $( '#ppec-activate-paypal-payments' ).data( 'install-id' );
-				const ppec_install_text = $( '#ppec-activate-paypal-payments' ).data( 'install-text' );
-				const ppec_install_link = $( '#ppec-activate-paypal-payments' ).data( 'install-link' );
+			// Change PPEC notice activation button id, text & link.
+			const ppec_install_id   = $( '#ppec-activate-paypal-payments' ).data( 'install-id' );
+			const ppec_install_text = $( '#ppec-activate-paypal-payments' ).data( 'install-text' );
+			const ppec_install_link = $( '#ppec-activate-paypal-payments' ).data( 'install-link' );
 
-				$( '#ppec-activate-paypal-payments' ).text( ppec_install_text );
-				$( '#ppec-activate-paypal-payments' ).attr({
-					href: ppec_install_link,
-					id: ppec_install_id
-				});
-			}
-		}, 500 );
+			$( '#ppec-activate-paypal-payments' ).text( ppec_install_text );
+			$( '#ppec-activate-paypal-payments' ).attr({
+				href: ppec_install_link,
+				id: ppec_install_id
+			});
+		}
 	} );
 
 	// Change button text when install link is clicked.

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -12,6 +12,10 @@
 		if ( targetElement.hasClass( 'active' ) ) {
 			is_paypal_payments_active = true;
 		}
+
+		// Dynamically update plugin activation link to handle plugin folder renames.
+		let activation_url = $( targetElement ).find( 'span.activate a' ).attr( 'href' );
+		$( 'a#ppec-activate-paypal-payments' ).attr( 'href', activation_url );
 	}
 
 	// Hide notice/buttons conditionally.

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -2,16 +2,26 @@
 	'use strict';
 
 	// Check whether PayPal Payments is installed.
-	let is_paypal_payments_installed = false;
-	if ( $( 'tr[data-slug="woocommerce-paypal-payments"]' ).length ) {
+	let is_paypal_payments_installed = false,
+		is_paypal_payments_active = false;
+
+	const targetElement = $( 'tr[data-slug="woocommerce-paypal-payments"]' );
+	if ( targetElement.length ) {
 		is_paypal_payments_installed = true;
+
+		if ( targetElement.hasClass( 'active' ) ) {
+			is_paypal_payments_active = true;
+		}
+	}
+
+	// Hide notice is PayPal Payments is installed and active.
+	if ( is_paypal_payments_installed && is_paypal_payments_active ) {
+		$( 'tr#ppec-migrate-notice' ).hide();
 	}
 
 	// Handle delete event for PayPal Payments.
 	$( document ).on( 'wp-plugin-delete-success', function( event, response ) {
 		if ( is_paypal_payments_installed && 'woocommerce-paypal-payments' === response.slug ) {
-			is_paypal_payments_installed = false;
-
 			// Change PPEC notice activation button id, text & link.
 			const ppec_install_id   = $( '#ppec-activate-paypal-payments' ).data( 'install-id' );
 			const ppec_install_text = $( '#ppec-activate-paypal-payments' ).data( 'install-text' );

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -14,24 +14,20 @@
 		}
 	}
 
-	// Hide notice is PayPal Payments is installed and active.
+	// Hide notice/buttons conditionally.
 	if ( is_paypal_payments_installed && is_paypal_payments_active ) {
 		$( 'tr#ppec-migrate-notice' ).hide();
+	} else if ( is_paypal_payments_installed ) {
+		$( 'a#ppec-install-paypal-payments' ).hide();
+	} else {
+		$( 'a#ppec-activate-paypal-payments' ).hide();
 	}
 
 	// Handle delete event for PayPal Payments.
 	$( document ).on( 'wp-plugin-delete-success', function( event, response ) {
 		if ( is_paypal_payments_installed && 'woocommerce-paypal-payments' === response.slug ) {
-			// Change PPEC notice activation button id, text & link.
-			const ppec_install_id   = $( '#ppec-activate-paypal-payments' ).data( 'install-id' );
-			const ppec_install_text = $( '#ppec-activate-paypal-payments' ).data( 'install-text' );
-			const ppec_install_link = $( '#ppec-activate-paypal-payments' ).data( 'install-link' );
-
-			$( '#ppec-activate-paypal-payments' ).text( ppec_install_text );
-			$( '#ppec-activate-paypal-payments' ).attr({
-				href: ppec_install_link,
-				id: ppec_install_id
-			});
+			$( 'a#ppec-activate-paypal-payments' ).hide();
+			$( 'a#ppec-install-paypal-payments' ).show();
 		}
 	} );
 

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -27,6 +27,9 @@
 		$( 'a#ppec-activate-paypal-payments' ).hide();
 	}
 
+	// Display buttons area
+	$( '#ppec-migrate-notice .ppec-notice-buttons' ).removeClass( 'hidden' );
+
 	// Handle delete event for PayPal Payments.
 	$( document ).on( 'wp-plugin-delete-success', function( event, response ) {
 		if ( is_paypal_payments_installed && 'woocommerce-paypal-payments' === response.slug ) {

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -1,0 +1,39 @@
+;(function ( $, window, document ) {
+	'use strict';
+
+	// Check whether PayPal Payments is installed.
+	let is_paypal_payments_installed = false;
+	if ( $( 'tr[data-slug="woocommerce-paypal-payments"]' ).length ) {
+		is_paypal_payments_installed = true;
+	}
+
+	// Handle delete event for PayPal Payments.
+	$( document ).on( 'wp-plugin-delete-success', function( response ) {
+		setTimeout( function(){
+			if ( is_paypal_payments_installed && $( 'tr#woocommerce-paypal-payments-deleted' ).length ) {
+				is_paypal_payments_installed = false;
+
+				// Change PPEC notice activation button id, text & link.
+				const ppec_install_id   = $( '#ppec-activate-paypal-payments' ).data( 'install-id' );
+				const ppec_install_text = $( '#ppec-activate-paypal-payments' ).data( 'install-text' );
+				const ppec_install_link = $( '#ppec-activate-paypal-payments' ).data( 'install-link' );
+
+				$( '#ppec-activate-paypal-payments' ).text( ppec_install_text );
+				$( '#ppec-activate-paypal-payments' ).attr({
+					href: ppec_install_link,
+					id: ppec_install_id
+				});
+			}
+		}, 500 );
+	} );
+
+	// Change button text when install link is clicked.
+	$( document ).on( 'click', '#ppec-install-paypal-payments', function( e ) {
+		e.preventDefault();
+		$( this ).addClass( 'updating-message' ).text( 'Installing...' );
+		const install_link = $( this ).attr('href');
+		setTimeout( function(){
+			window.location = install_link;
+		}, 100 );
+	});
+})( jQuery, window, document );

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -165,7 +165,8 @@ class WC_Gateway_PPEC_Plugin {
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->file ), array( $this, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_ajax_ppec_dismiss_notice_message', array( $this, 'ajax_dismiss_notice' ) );
-		add_action( 'after_plugin_row_' . WC_GATEWAY_PPEC_PLUGIN_BASE, array( $this, 'paypal_payments_upgrade_notice' ), 10, 3 );
+
+		add_action( 'after_plugin_row_' . WC_GATEWAY_PPEC_PLUGIN_BASE, array( $this, 'ppec_upgrade_notice' ), 10, 3 );
 	}
 
 	public function bootstrap() {
@@ -500,8 +501,19 @@ class WC_Gateway_PPEC_Plugin {
 	 * @param array $plugin_data An array of plugin data.
 	 * @param string $status Status filter currently applied to the plugin list.
 	 */
-	public function paypal_payments_upgrade_notice( $plugin_file, $plugin_data, $status ) {
+	public function ppec_upgrade_notice( $plugin_file, $plugin_data, $status ) {
+		// Return if not on installed plugins page.
+		global $pagenow;
+		if ( 'plugins.php' !== $pagenow ) {
+			return;
+		}
 
+		// Load styles & scripts required for the notice.
+		wp_enqueue_style( 'ppec-upgrade-notice', plugin_dir_url( __DIR__ ) . '/assets/css/admin/ppec-upgrade-notice.css' );
+		wp_enqueue_script( 'ppec-upgrade-notice-js', plugin_dir_url( __DIR__ ) . '/assets/js/admin/ppec-upgrade-notice.js', array(), WC_GATEWAY_PPEC_VERSION );
+
+		// Load notice template.
+		include_once( $this->plugin_path . 'templates/paypal-payments-upgrade-notice.php' );
 	}
 
 	/* Deprecated Functions */

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -502,6 +502,16 @@ class WC_Gateway_PPEC_Plugin {
 	 * @param string $status Status filter currently applied to the plugin list.
 	 */
 	public function ppec_upgrade_notice( $plugin_file, $plugin_data, $status ) {
+		// Check whether PayPal Payments is installed / Active.
+		$paypal_payments_path         = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
+		$is_installed_paypal_payments = array_key_exists( $paypal_payments_path, get_plugins() );
+		$is_active_paypal_payments    = is_plugin_active( $paypal_payments_path );
+
+		// Don't show the notice if PayPal Payments is installed and active.
+		if ( $is_installed_paypal_payments && $is_active_paypal_payments ) {
+			return;
+		}
+
 		// Load styles & scripts required for the notice.
 		wp_enqueue_style( 'ppec-upgrade-notice', plugin_dir_url( __DIR__ ) . '/assets/css/admin/ppec-upgrade-notice.css', array(), WC_GATEWAY_PPEC_VERSION );
 		wp_enqueue_script( 'ppec-upgrade-notice-js', plugin_dir_url( __DIR__ ) . '/assets/js/admin/ppec-upgrade-notice.js', array(), WC_GATEWAY_PPEC_VERSION, false );

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -166,7 +166,7 @@ class WC_Gateway_PPEC_Plugin {
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_ajax_ppec_dismiss_notice_message', array( $this, 'ajax_dismiss_notice' ) );
 
-		add_action( 'after_plugin_row_' . WC_GATEWAY_PPEC_PLUGIN_BASE, array( $this, 'ppec_upgrade_notice' ), 10, 3 );
+		add_action( 'after_plugin_row_' . plugin_basename( $this->file ), array( $this, 'ppec_upgrade_notice' ), 10, 3 );
 	}
 
 	public function bootstrap() {

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -509,11 +509,11 @@ class WC_Gateway_PPEC_Plugin {
 		}
 
 		// Load styles & scripts required for the notice.
-		wp_enqueue_style( 'ppec-upgrade-notice', plugin_dir_url( __DIR__ ) . '/assets/css/admin/ppec-upgrade-notice.css' );
-		wp_enqueue_script( 'ppec-upgrade-notice-js', plugin_dir_url( __DIR__ ) . '/assets/js/admin/ppec-upgrade-notice.js', array(), WC_GATEWAY_PPEC_VERSION );
+		wp_enqueue_style( 'ppec-upgrade-notice', plugin_dir_url( __DIR__ ) . '/assets/css/admin/ppec-upgrade-notice.css', array(), WC_GATEWAY_PPEC_VERSION );
+		wp_enqueue_script( 'ppec-upgrade-notice-js', plugin_dir_url( __DIR__ ) . '/assets/js/admin/ppec-upgrade-notice.js', array(), WC_GATEWAY_PPEC_VERSION, false );
 
 		// Load notice template.
-		include_once( $this->plugin_path . 'templates/paypal-payments-upgrade-notice.php' );
+		include_once $this->plugin_path . 'templates/paypal-payments-upgrade-notice.php';
 	}
 
 	/* Deprecated Functions */

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -165,7 +165,7 @@ class WC_Gateway_PPEC_Plugin {
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->file ), array( $this, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_ajax_ppec_dismiss_notice_message', array( $this, 'ajax_dismiss_notice' ) );
-		add_action( "after_plugin_row_" . WC_GATEWAY_PPEC_PLUGIN_BASE, array( $this, 'paypal_payments_upgrade_notice' ), 10, 3 );
+		add_action( 'after_plugin_row_' . WC_GATEWAY_PPEC_PLUGIN_BASE, array( $this, 'paypal_payments_upgrade_notice' ), 10, 3 );
 	}
 
 	public function bootstrap() {

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -165,6 +165,7 @@ class WC_Gateway_PPEC_Plugin {
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->file ), array( $this, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_ajax_ppec_dismiss_notice_message', array( $this, 'ajax_dismiss_notice' ) );
+		add_action( "after_plugin_row_" . WC_GATEWAY_PPEC_PLUGIN_BASE, array( $this, 'paypal_payments_upgrade_notice' ), 10, 3 );
 	}
 
 	public function bootstrap() {
@@ -490,6 +491,17 @@ class WC_Gateway_PPEC_Plugin {
 		}
 
 		return apply_filters( 'woocommerce_cart_needs_shipping', $needs_shipping );
+	}
+
+	/**
+	 * Displays notice to upgrade to PayPal Payments.
+	 *
+	 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+	 * @param array $plugin_data An array of plugin data.
+	 * @param string $status Status filter currently applied to the plugin list.
+	 */
+	public function paypal_payments_upgrade_notice( $plugin_file, $plugin_data, $status ) {
+
 	}
 
 	/* Deprecated Functions */

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -502,12 +502,6 @@ class WC_Gateway_PPEC_Plugin {
 	 * @param string $status Status filter currently applied to the plugin list.
 	 */
 	public function ppec_upgrade_notice( $plugin_file, $plugin_data, $status ) {
-		// Return if not on installed plugins page.
-		global $pagenow;
-		if ( 'plugins.php' !== $pagenow ) {
-			return;
-		}
-
 		// Load styles & scripts required for the notice.
 		wp_enqueue_style( 'ppec-upgrade-notice', plugin_dir_url( __DIR__ ) . '/assets/css/admin/ppec-upgrade-notice.css', array(), WC_GATEWAY_PPEC_VERSION );
 		wp_enqueue_script( 'ppec-upgrade-notice-js', plugin_dir_url( __DIR__ ) . '/assets/js/admin/ppec-upgrade-notice.js', array(), WC_GATEWAY_PPEC_VERSION, false );

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -502,16 +502,6 @@ class WC_Gateway_PPEC_Plugin {
 	 * @param string $status Status filter currently applied to the plugin list.
 	 */
 	public function ppec_upgrade_notice( $plugin_file, $plugin_data, $status ) {
-		// Check whether PayPal Payments is installed / Active.
-		$paypal_payments_path         = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
-		$is_installed_paypal_payments = array_key_exists( $paypal_payments_path, get_plugins() );
-		$is_active_paypal_payments    = is_plugin_active( $paypal_payments_path );
-
-		// Don't show the notice if PayPal Payments is installed and active.
-		if ( $is_installed_paypal_payments && $is_active_paypal_payments ) {
-			return;
-		}
-
 		// Load styles & scripts required for the notice.
 		wp_enqueue_style( 'ppec-upgrade-notice', plugin_dir_url( __DIR__ ) . '/assets/css/admin/ppec-upgrade-notice.css', array(), WC_GATEWAY_PPEC_VERSION );
 		wp_enqueue_script( 'ppec-upgrade-notice-js', plugin_dir_url( __DIR__ ) . '/assets/js/admin/ppec-upgrade-notice.js', array(), WC_GATEWAY_PPEC_VERSION, false );

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -48,7 +48,9 @@ $paypal_payments_activate_link = wp_nonce_url(
 				</ul>
 			</div>
 			<div class='ppec-notice-buttons ppec-notice-section'>
+				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<a id="ppec-install-paypal-payments" href="<?php echo $paypal_payments_install_link; ?>" class="button button-primary woocommerce-save-button">Upgrade to PayPal Payments now</a>
+				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<a id="ppec-activate-paypal-payments" href="<?php echo $paypal_payments_activate_link; ?>" class="button button-primary woocommerce-save-button">Activate PayPal Payments now</a>
 				<a href="https://woocommerce.com/products/woocommerce-paypal-payments/" target="_blank" class="button woocommerce-save-button">Learn more</a>
 			</div>

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -96,7 +96,7 @@ if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
 								return $key . '="' . $value . '"';
 							},
 							array_keys( $button_data['attributes'] ),
-							$button_data['attributes'],
+							$button_data['attributes']
 						)
 					);
 				}

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -5,6 +5,11 @@
  * @package woocommerce-paypal-express-checkout/templates
  */
 
+// Check whether PayPal Payments is installed / Active.
+$paypal_payments_path         = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
+$is_installed_paypal_payments = array_key_exists( $paypal_payments_path, get_plugins() );
+$is_active_paypal_payments    = is_plugin_active( $paypal_payments_path );
+
 // Generate Install / Activation / Config links.
 $paypal_payments_install_link = wp_nonce_url(
 	add_query_arg(

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -5,12 +5,9 @@
  * @package woocommerce-paypal-express-checkout/templates
  */
 
-// Check whether PayPal Payments is installed / Active.
-$paypal_payments_path         = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
-$is_installed_paypal_payments = array_key_exists( $paypal_payments_path, get_plugins() );
-$is_active_paypal_payments    = is_plugin_active( $paypal_payments_path );
 
 // Generate Install / Activation / Config links.
+$paypal_payments_path         = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
 $paypal_payments_install_link = wp_nonce_url(
 	add_query_arg(
 		array(
@@ -32,42 +29,6 @@ $paypal_payments_activate_link = wp_nonce_url(
 	),
 	'activate-plugin_' . $paypal_payments_path
 );
-
-// Template for rendering buttons.
-$button_data = array(
-	'id'         => null,
-	'href'       => null,
-	'text'       => null,
-	'attributes' => array(),
-);
-
-if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
-
-	// PayPal Payments installed and active.
-	$button_data['id']   = 'ppec-configure-paypal-payments';
-	$button_data['href'] = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' );
-	$button_data['text'] = 'Configure PayPal Payments now';
-
-} elseif ( $is_installed_paypal_payments ) {
-
-	// PayPal Payments installed, but inactive.
-	$button_data['id']         = 'ppec-activate-paypal-payments';
-	$button_data['href']       = $paypal_payments_activate_link;
-	$button_data['text']       = 'Activate PayPal Payments now';
-	$button_data['attributes'] = array(
-		'data-install-id'   => 'ppec-install-paypal-payments',
-		'data-install-text' => 'Upgrade to PayPal Payments now',
-		'data-install-link' => $paypal_payments_install_link,
-	);
-
-} else {
-
-	// PayPal Payments is not installed.
-	$button_data['id']   = 'ppec-install-paypal-payments';
-	$button_data['href'] = $paypal_payments_install_link;
-	$button_data['text'] = 'Upgrade to PayPal Payments now';
-
-}
 ?>
 
 <tr class="plugin-update-tr active notice-warning notice-alt"  id="ppec-migrate-notice">
@@ -87,23 +48,8 @@ if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
 				</ul>
 			</div>
 			<div class='ppec-notice-buttons ppec-notice-section'>
-				<?php
-				$extra_attributes = '';
-				if ( ! empty( $button_data['attributes'] ) ) {
-					$extra_attributes = implode(
-						' ',
-						array_map(
-							function ( $key, $value ) {
-								return $key . '="' . $value . '"';
-							},
-							array_keys( $button_data['attributes'] ),
-							$button_data['attributes']
-						)
-					);
-				}
-				?>
-				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<a id="<?php echo $button_data['id']; ?>" href="<?php echo $button_data['href']; ?>" <?php echo $extra_attributes; ?> class="button button-primary woocommerce-save-button"><?php echo $button_data['text']; ?></a>
+				<a id="ppec-install-paypal-payments" href="<?php echo $paypal_payments_install_link; ?>" class="button button-primary woocommerce-save-button">Upgrade to PayPal Payments now</a>
+				<a id="ppec-activate-paypal-payments" href="<?php echo $paypal_payments_activate_link; ?>" class="button button-primary woocommerce-save-button">Activate PayPal Payments now</a>
 				<a href="https://woocommerce.com/products/woocommerce-paypal-payments/" target="_blank" class="button woocommerce-save-button">Learn more</a>
 			</div>
 		</div>

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Show PayPal Payments upgrade notice on plugins page
+ *
+ * @author  WooCommerce
+ * @package woocommerce-paypal-express-checkout/templates
+ */
+
+$paypal_payments_path          = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
+$is_installed_paypal_payments  = array_key_exists( $paypal_payments_path, get_plugins() );
+$is_active_paypal_payments     = is_plugin_active( $paypal_payments_path );
+
+// Generate Install / Activation / Config links.
+$paypal_payments_install_link = wp_nonce_url(
+	add_query_arg(
+		array(
+			'action' => 'install-plugin',
+			'plugin' => 'woocommerce-paypal-payments'
+		),
+		admin_url( 'update.php' )
+	),
+	'install-plugin' . '_' . 'woocommerce-paypal-payments'
+);
+
+$paypal_payments_activate_link = wp_nonce_url(
+	add_query_arg(
+		array(
+			'action' => 'activate',
+			'plugin' => $paypal_payments_path
+		),
+		admin_url( 'plugins.php' )
+	),
+	'activate-plugin' . '_' . $paypal_payments_path
+);
+
+// Template for rendering buttons.
+$button_data = array(
+	'id'         => null,
+	'href'       => null,
+	'text'       => null,
+	'attributes' => array(),
+);
+
+if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
+
+	// PayPal Payments installed and active.
+	$button_data['id']   = 'ppec-configure-paypal-payments';
+	$button_data['href'] = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' );
+	$button_data['text'] = 'Configure PayPal Payments now';
+
+} elseif ( $is_installed_paypal_payments ) {
+
+	// PayPal Payments installed, but inactive.
+	$button_data['id']         = 'ppec-activate-paypal-payments';
+	$button_data['href']       = $paypal_payments_activate_link;
+	$button_data['text']       = 'Activate PayPal Payments now';
+	$button_data['attributes'] = array(
+		'data-install-id'   => 'ppec-install-paypal-payments',
+		'data-install-text' => 'Upgrade to PayPal Payments now',
+		'data-install-link' => $paypal_payments_install_link,
+	);
+
+} else {
+
+	// PayPal Payments is not installed.
+	$button_data['id']   = 'ppec-install-paypal-payments';
+	$button_data['href'] = $paypal_payments_install_link;
+	$button_data['text'] = 'Upgrade to PayPal Payments now';
+
+}
+?>
+
+<tr class="plugin-update-tr active notice-warning notice-alt"  id="ppec-migrate-notice">
+	<td colspan="4" class="plugin-update colspanchange">
+		<div class="update-message notice inline notice-warning notice-alt">
+			<div class='ppec-notice-title ppec-notice-section'>
+				<p>Upgrade to PayPal Payments: the best way to get paid with PayPal and WooCommerce</p>
+			</div>
+			<div class='ppec-notice-content ppec-notice-section'>
+				<p><strong>WooCommerce PayPal Payments</strong> is a full-stack solution that offers powerful and flexible payment processing capabilities. Expand your business by connecting with over 370+ million active PayPal accounts around the globe. With PayPal, you can sell in 200+ markets and accept 100+ currencies. Plus, PayPal can automatically identify customer locations and offer country-specific, local payment methods.</p>
+
+				<p>Upgrade now and get access to these great features:</p>
+
+				<ul>
+					<li>Give your customers their preferred ways to pay with one checkout solution. Accept <strong>PayPal</strong>, <strong>PayPal Credit</strong>, <strong>Pay Later</strong> options (available in the US, UK, France, and Germany), <strong>credit & debit cards</strong>, and country-specific, <strong>local payment methods</strong> on any device.</li>
+					<li>Offer subscriptions and accept recurring payments as PayPal is compatible with <a target="_blank" href="https://woocommerce.com/products/woocommerce-subscriptions/"><strong>WooCommerce Subscriptions</strong></a>.</li>
+				</ul>
+			</div>
+			<div class='ppec-notice-buttons ppec-notice-section'>
+				<?php
+				$extra_attributes = '';
+				if ( ! empty( $button_data['attributes'] ) ) {
+					$extra_attributes = implode( ' ', array_map(
+						function ( $key, $value ) {
+							return $key . '=' . '"' . $value . '"';
+						},
+						array_keys( $button_data['attributes'] ),
+						$button_data['attributes'],
+					) );
+				}
+				?>
+				<a id="<?php echo $button_data['id'];  ?>" href="<?php echo $button_data['href']; ?>" <?php echo $extra_attributes; ?> class="button button-primary woocommerce-save-button"><?php echo $button_data['text']; ?></a>
+				<a href="https://woocommerce.com/products/woocommerce-paypal-payments/" target="_blank" class="button woocommerce-save-button">Learn more</a>
+			</div>
+		</div>
+	</td>
+</tr>

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -89,10 +89,11 @@ if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
 				<?php
 				$extra_attributes = '';
 				if ( ! empty( $button_data['attributes'] ) ) {
-					$extra_attributes = implode( ' ',
+					$extra_attributes = implode(
+						' ',
 						array_map(
 							function ( $key, $value ) {
-								return $key . '=' . '"' . $value . '"';
+								return $key . '="' . $value . '"';
 							},
 							array_keys( $button_data['attributes'] ),
 							$button_data['attributes'],
@@ -100,6 +101,7 @@ if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
 					);
 				}
 				?>
+				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<a id="<?php echo $button_data['id']; ?>" href="<?php echo $button_data['href']; ?>" <?php echo $extra_attributes; ?> class="button button-primary woocommerce-save-button"><?php echo $button_data['text']; ?></a>
 				<a href="https://woocommerce.com/products/woocommerce-paypal-payments/" target="_blank" class="button woocommerce-save-button">Learn more</a>
 			</div>

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -2,35 +2,34 @@
 /**
  * Show PayPal Payments upgrade notice on plugins page
  *
- * @author  WooCommerce
  * @package woocommerce-paypal-express-checkout/templates
  */
 
-$paypal_payments_path          = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
-$is_installed_paypal_payments  = array_key_exists( $paypal_payments_path, get_plugins() );
-$is_active_paypal_payments     = is_plugin_active( $paypal_payments_path );
+$paypal_payments_path         = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
+$is_installed_paypal_payments = array_key_exists( $paypal_payments_path, get_plugins() );
+$is_active_paypal_payments    = is_plugin_active( $paypal_payments_path );
 
 // Generate Install / Activation / Config links.
 $paypal_payments_install_link = wp_nonce_url(
 	add_query_arg(
 		array(
 			'action' => 'install-plugin',
-			'plugin' => 'woocommerce-paypal-payments'
+			'plugin' => dirname( $paypal_payments_path ),
 		),
 		admin_url( 'update.php' )
 	),
-	'install-plugin' . '_' . 'woocommerce-paypal-payments'
+	'install-plugin_' . dirname( $paypal_payments_path )
 );
 
 $paypal_payments_activate_link = wp_nonce_url(
 	add_query_arg(
 		array(
 			'action' => 'activate',
-			'plugin' => $paypal_payments_path
+			'plugin' => $paypal_payments_path,
 		),
 		admin_url( 'plugins.php' )
 	),
-	'activate-plugin' . '_' . $paypal_payments_path
+	'activate-plugin_' . $paypal_payments_path
 );
 
 // Template for rendering buttons.
@@ -99,7 +98,7 @@ if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
 					) );
 				}
 				?>
-				<a id="<?php echo $button_data['id'];  ?>" href="<?php echo $button_data['href']; ?>" <?php echo $extra_attributes; ?> class="button button-primary woocommerce-save-button"><?php echo $button_data['text']; ?></a>
+				<a id="<?php echo $button_data['id']; ?>" href="<?php echo $button_data['href']; ?>" <?php echo $extra_attributes; ?> class="button button-primary woocommerce-save-button"><?php echo $button_data['text']; ?></a>
 				<a href="https://woocommerce.com/products/woocommerce-paypal-payments/" target="_blank" class="button woocommerce-save-button">Learn more</a>
 			</div>
 		</div>

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -5,10 +5,6 @@
  * @package woocommerce-paypal-express-checkout/templates
  */
 
-$paypal_payments_path         = 'woocommerce-paypal-payments/woocommerce-paypal-payments.php';
-$is_installed_paypal_payments = array_key_exists( $paypal_payments_path, get_plugins() );
-$is_active_paypal_payments    = is_plugin_active( $paypal_payments_path );
-
 // Generate Install / Activation / Config links.
 $paypal_payments_install_link = wp_nonce_url(
 	add_query_arg(

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -89,13 +89,15 @@ if ( $is_active_paypal_payments && $is_active_paypal_payments ) {
 				<?php
 				$extra_attributes = '';
 				if ( ! empty( $button_data['attributes'] ) ) {
-					$extra_attributes = implode( ' ', array_map(
-						function ( $key, $value ) {
-							return $key . '=' . '"' . $value . '"';
-						},
-						array_keys( $button_data['attributes'] ),
-						$button_data['attributes'],
-					) );
+					$extra_attributes = implode( ' ',
+						array_map(
+							function ( $key, $value ) {
+								return $key . '=' . '"' . $value . '"';
+							},
+							array_keys( $button_data['attributes'] ),
+							$button_data['attributes'],
+						)
+					);
 				}
 				?>
 				<a id="<?php echo $button_data['id']; ?>" href="<?php echo $button_data['href']; ?>" <?php echo $extra_attributes; ?> class="button button-primary woocommerce-save-button"><?php echo $button_data['text']; ?></a>

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -47,7 +47,7 @@ $paypal_payments_activate_link = wp_nonce_url(
 					<li>Offer subscriptions and accept recurring payments as PayPal is compatible with <a target="_blank" href="https://woocommerce.com/products/woocommerce-subscriptions/"><strong>WooCommerce Subscriptions</strong></a>.</li>
 				</ul>
 			</div>
-			<div class='ppec-notice-buttons ppec-notice-section'>
+			<div class='ppec-notice-buttons ppec-notice-section hidden'>
 				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<a id="ppec-install-paypal-payments" href="<?php echo $paypal_payments_install_link; ?>" class="button button-primary woocommerce-save-button">Upgrade to PayPal Payments now</a>
 				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -29,6 +29,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WC_GATEWAY_PPEC_VERSION', '2.1.1' );
 
+// Define plugin base
+define( 'WC_GATEWAY_PPEC_PLUGIN_BASE', plugin_basename( __FILE__ ) );
+
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.
  *

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -29,9 +29,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WC_GATEWAY_PPEC_VERSION', '2.1.1' );
 
-// Define plugin base
-define( 'WC_GATEWAY_PPEC_PLUGIN_BASE', plugin_basename( __FILE__ ) );
-
 /**
  * Return instance of WC_Gateway_PPEC_Plugin.
  *


### PR DESCRIPTION
### Description

As part of various efforts to drive adoption of PayPal Payments, this PR aims to add a notice on the WordPress plugins page suggesting users to upgrade from PayPal Checkout to PayPal Payments.

**Screenshot of the notice**

![Screenshot](https://d.pr/i/2C6A2J+)

**Screencast** - https://d.pr/v/Y24RUS


### Steps to test:
1. Checkout the branch `paypal-payments-upgrade-notice` & activate the plugin if not active.
2. On the installed plugins page, a new section is added just below PayPal Checkout suggesting upgrade to PayPal Payments.

- [ ] Confirm that `Learn more` button opens up product documentation on WooCommerce.com
- [ ] Confirm that `Upgrade to PayPal Payments now` button installs the plugins and redirects to activation page.
- [ ] Confirm that when `Upgrade to PayPal Payments now` button is clicked, the button text changes to `Installing...` with a spinning icon.
- [ ] Confirm that the button text is `Upgrade to PayPal Payments now` if plugin is not installed, `Activate PayPal Payments now` if plugin is installed but not active.
- [ ] Confirm that when the plugin is deleted, the notice button immediately changes to `Upgrade to PayPal Payments now` instead of `Activate PayPal Payments now`.

The SCSS code used can be found here - https://gist.github.com/achyuthajoy/06a2012495d2d2816678fe15e9860c05

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Adds notice on plugins page to upgrade to PayPal Payments.