### PR TITLE
Bump WooCommerce requirement to 3.2.0

### DIFF
--- a/includes/abstracts/abstract-wc-gateway-ppec.php
+++ b/includes/abstracts/abstract-wc-gateway-ppec.php
@@ -226,9 +226,15 @@ abstract class WC_Gateway_PPEC extends WC_Payment_Gateway {
 			}
 
 			$expiry_date = new WC_DateTime( "@{$valid_until}", new DateTimeZone( 'UTC' ) );
-			$expiry_date->setTimezone( wp_timezone() );
+			$timestamp   = $expiry_date->getTimestamp();
 
-			$expires = sprintf( $expires, date_i18n( get_option( 'date_format' ), $expiry_date->getTimestamp() + $expiry_date->getOffset() ), $expiry_date->format( 'T' ) );
+			// If there's support for wp_timezone(), display the expiry date in server time. Otherwise, use UTC.
+			if ( function_exists( 'wp_timezone' ) ) {
+				$timestamp += $expiry_date->getOffset();
+				$expiry_date->setTimezone( wp_timezone() );
+			}
+
+			$expires = sprintf( $expires, date_i18n( get_option( 'date_format' ), $timestamp ), $expiry_date->format( 'T' ) );
 			// Translators: 1) is a certificate's CN, 2) is the expiration date.
 			$output = sprintf( __( 'Certificate belongs to API username %1$s; %2$s.', 'woocommerce-gateway-paypal-express-checkout' ), $cert_info['subject']['CN'], $expires );
 		} else {

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -279,8 +279,8 @@ class WC_Gateway_PPEC_Plugin {
 			throw new Exception( __( 'WooCommerce Gateway PayPal Checkout requires WooCommerce to be activated', 'woocommerce-gateway-paypal-express-checkout' ), self::DEPENDENCIES_UNSATISFIED );
 		}
 
-		if ( version_compare( WC()->version, '2.5', '<' ) ) {
-			throw new Exception( __( 'WooCommerce Gateway PayPal Checkout requires WooCommerce version 2.5 or greater', 'woocommerce-gateway-paypal-express-checkout' ), self::DEPENDENCIES_UNSATISFIED );
+		if ( version_compare( WC()->version, '3.2.0', '<' ) ) {
+			throw new Exception( __( 'WooCommerce Gateway PayPal Checkout requires WooCommerce version 3.2.0 or greater', 'woocommerce-gateway-paypal-express-checkout' ), self::DEPENDENCIES_UNSATISFIED );
 		}
 
 		if ( ! function_exists( 'curl_init' ) ) {

--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -12,7 +12,7 @@
  * Text Domain: woocommerce-gateway-paypal-express-checkout
  * Domain Path: /languages
  * WC tested up to: 5.3
- * WC requires at least: 2.6
+ * WC requires at least: 3.2.0
  */
 /**
  * Copyright (c) 2019 PayPal, Inc.


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
While looking into #855, I noticed that despite what our README says (the current min. requirement is WC 2.6), PPEC doesn't work correctly on WC < 3.2.0: we are already implicitly requiring 3.0.0 because our code uses `wc_get_price_including_tax()` and other similar functions. Also on WC < 3.2.0, the cart total is calculated as "0.0" which is not only incorrect but prevents the order from being created on PayPal's side (this makes sense given [various cart classes were refactored in 3.2.0](https://github.com/woocommerce/woocommerce/blob/1148fa39d4aeab04700075494929e67d808b36d7/readme.txt#L224)).

In this PR, the 3.2.0 requirement is made explicit, which is probably fine given it has been broken for a while and we haven't seen reports about it. Also, we were already [alerting merchants that the requirement was going to be bumped to 3.0.0](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/baaa74fa1d912078fe5ca73c7abf01a72deb4b2b/includes/class-wc-gateway-ppec-admin-handler.php#L364-L407) and this was supposed to happen in Q1 2020, so Q2 2021 seems safe...r.

This PR also adds a minor change to the way we display expiry information for API certificates. Code to display the expiry date in local time was added in #696, which makes use of `wp_timezone()`, a function introduced in WP 5.0. Instead of bumping this requirement too, given WC 3.2.0 [requires WP 4.4](https://github.com/woocommerce/woocommerce/blob/1148fa39d4aeab04700075494929e67d808b36d7/readme.txt#L4) (which is our current WP requirement), I believe displaying the time in UTC for those sites still on WP < 5.0 is a good compromise, and it's the approach I took in this PR.

### Steps to test:
Not much to test.

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Bump WooCommerce requirement to 3.2.0.
* Add compatibility fix for WordPress < 5.0.

Closes #855.
