### PR TITLE
Get the package index dynamically

### DIFF
--- a/includes/class-wc-gateway-ppec-checkout-handler.php
+++ b/includes/class-wc-gateway-ppec-checkout-handler.php
@@ -992,12 +992,15 @@ class WC_Gateway_PPEC_Checkout_Handler {
 		$destination = $this->get_mapped_shipping_address( $checkout_details );
 
 		if ( ! empty( $destination ) ) {
-			$packages[0]['destination']['country']   = $destination['country'];
-			$packages[0]['destination']['state']     = $destination['state'];
-			$packages[0]['destination']['postcode']  = $destination['postcode'];
-			$packages[0]['destination']['city']      = $destination['city'];
-			$packages[0]['destination']['address']   = $destination['address_1'];
-			$packages[0]['destination']['address_2'] = $destination['address_2'];
+			// WC Subscriptions uses string package keys so we need to get the package key dynamically.
+			$package_key = key( $packages );
+
+			$packages[ $package_key ]['destination']['country']   = $destination['country'];
+			$packages[ $package_key ]['destination']['state']     = $destination['state'];
+			$packages[ $package_key ]['destination']['postcode']  = $destination['postcode'];
+			$packages[ $package_key ]['destination']['city']      = $destination['city'];
+			$packages[ $package_key ]['destination']['address']   = $destination['address_1'];
+			$packages[ $package_key ]['destination']['address_2'] = $destination['address_2'];
 		}
 
 		return $packages;


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: 4106-gh-woocommerce/woocommerce-subscriptions

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
In WC Subscriptions 3.1, the recurring cart package keys are now in the `{$recurring_cart_key}_{$package_index}` format (`2021_05_25_weekly_0`). When using the cart SPB, when you arrive on the complete PayPal order page, we copy the PayPal address data into the shipping packages, however we assumed the package index was always `0`. This PR changes that so we get the package index dynamically using `key()`. 

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. With WC Subscriptions 3.1 and above, place a subscription product in the cart. 
2. On the cart page, use the PPEC smart payment buttons.
1. Complete PayPal popup and when you arrive back on the _**Confirm your PayPal order**_ page:
     - On `trunk` there will be 2 shipping methods displayed for the recurring cart. You will also get a lot of PHP warnings and errors. 
     - On this branch, there's only 1 shipping method displayed and no errors. 

<img width="186.5" alt="Screen Shot 2021-05-31 at 1 56 38 pm" src="https://user-images.githubusercontent.com/8490476/120137625-1909ac00-c218-11eb-83cc-a9f7a596db33.png">

https://d.pr/i/lFCZea

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

```
* fix - [WC Subscriptions 3.1] Update the shipping packages address using a dynamic key rather than assuming a 0 index.  
```