### PR TITLE
Avoid fatal error when a line item instance doesn’t have a `get_sku()` method

### DIFF
--- a/includes/class-wc-gateway-ppec-client.php
+++ b/includes/class-wc-gateway-ppec-client.php
@@ -839,7 +839,7 @@ class WC_Gateway_PPEC_Client {
 					'name'     => apply_filters( 'woocommerce_paypal_express_checkout_order_line_item_name', $order_item['name'], $order_item, $cart_item_key ),
 					'quantity' => $order_item['qty'],
 					'amount'   => $amount,
-					'sku'      => $product->get_sku(),
+					'sku'      => ( $product && is_callable( array( $product, 'get_sku' ) ) ) ? $product->get_sku() : '',
 				);
 			}
 


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #826

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This PR prevents a fatal error that might occur when trying to pay using PayPal Checkout for an order containing line items that are not `WC_Product` instances or that don't have the `get_sku()` method available.

The only difference from #856, is that this PR doesn't make any assumptions of what the SKU could or should be.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Create a product.
1. Create an order (on the backend) containing said product.
1. Copy the "Customer payment page" link.
   <img width="611" alt="Screen Shot 2021-06-01 at 16 55 25" src="https://user-images.githubusercontent.com/184724/120382655-85081500-c2e9-11eb-93f3-d458c395599a.png">
1. Delete the product created in step 1 and empty the trash.
1. Use the link from step 2 to pay for the order using PayPal Checkout.
1. 1. On `trunk`, you'll see a fatal error:
      > Uncaught Error: Call to a member function get_sku() on bool in /wp-content/plugins/woocommerce-gateway-paypal-express-checkout/includes/class-wc-gateway-ppec-client.php:842
   1. On this branch (`issue/826`) the order is processed correctly.

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Prevent fatal error when paying for an order containing products that are not in the catalog.

Closes #826.
