### PR TITLE
Re-render the SPB buttons onError without emptying div first

### DIFF
--- a/assets/js/wc-gateway-ppec-smart-payment-buttons.js
+++ b/assets/js/wc-gateway-ppec-smart-payment-buttons.js
@@ -206,7 +206,6 @@
 			},
 
 			onError: function() {
-				jQuery( selector ).empty();
 				render();
 			},
 		};


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Ticket**: 4142422-zen
**Slack thread**: p1626405450393600-slack-C7U3Y3VMY

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

A customer is reporting an issue with how we are calling `JQuery( selector ).empty();` before re-rendering the SPB onError handling. In their report, they say the buttons aren't being rendered and that removing this line fixes the issues.

I went back through the history of where this line was added and it was added to fix this issue mentioned here: https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/668#issuecomment-609567900

I couldn't find anything in the PayPal docs saying we should remove SPB before calling render, and from my testing you don't need to do this either.

In the original PR, I shared a video of why we needed to re-render the buttons (ttps://d.pr/v/Kj4wgP), and I've tested this case with these changes and couldn't see any issues. I also modified the code to reject/throw an error `onAuthorize` and there were no issues with just calling `render();`

At first I was a little reluctant to make this change since we haven't received any reports of this error but if there's one, there's definitely others.

If we don't want to change this behaviour for all stores, another solution would be to add support for a new SDK arg that stores can add by filter to not empty the div before rendering.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Enable PPEC SPB
1. Add a product to the cart and visit the checkout
1. Invalidate the checkout process but emptying the first name field
2. Click on the SPB debit card button to trigger the `onError` handler
3. Notice form is rendered without issues

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Closes # .
