### PR TITLE
Update PPCP upgrade notice

### DIFF
--- a/assets/css/admin/ppec-upgrade-notice.css
+++ b/assets/css/admin/ppec-upgrade-notice.css
@@ -1,4 +1,4 @@
-.plugins tr[data-slug=woocommerce-gateway-paypal-express-checkout] th, .plugins tr[data-slug=woocommerce-gateway-paypal-express-checkout] td {
+.plugins tr[data-slug=woocommerce-gateway-paypal-express-checkout].hide-border th, .plugins tr[data-slug=woocommerce-gateway-paypal-express-checkout].hide-border td {
   box-shadow: none !important;
 }
 
@@ -8,11 +8,9 @@
 #ppec-migrate-notice .ppec-notice-section {
   padding: 0 20px;
 }
-#ppec-migrate-notice .ppec-notice-title {
-  border-bottom: 1px solid #FFB900;
-}
 #ppec-migrate-notice .ppec-notice-title p {
-  line-height: 30px;
+	padding: 10px 0 0 0;
+	font-size: 110%;
 }
 #ppec-migrate-notice .ppec-notice-title p:before {
   vertical-align: middle;
@@ -31,6 +29,7 @@
   text-decoration: none;
   line-height: 34px;
   margin-right: 16px;
+	margin-top: 16px;
 }
 #ppec-migrate-notice .ppec-notice-buttons a:last-of-type {
   margin-right: 0;
@@ -38,6 +37,9 @@
 #ppec-migrate-notice .ppec-notice-buttons a:before {
   vertical-align: middle;
   margin: -2.5px 5px 0 0;
+}
+#ppec-migrate-notice .ppec-notice-buttons a.dismiss {
+	float: right;
 }
 #ppec-migrate-notice .ppec-notice-buttons a.updating-message:before {
   -webkit-animation: rotation 2s infinite linear;

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -1,50 +1,47 @@
 ;(function ( $, window, document ) {
 	'use strict';
 
+	// Plugin rows.
+	let $notice_row = $( 'tr#ppec-migrate-notice' );
+	let $ppec_row   = $notice_row.prev();
+	let $ppcp_row   = $( 'tr[data-slug="woocommerce-paypal-payments"]' );
+
+	$ppec_row.toggleClass( 'hide-border', true );
+
 	// Check whether PayPal Payments is installed.
-	let is_paypal_payments_installed = false,
-		is_paypal_payments_active = false;
+	let is_paypal_payments_installed = $ppcp_row.length > 0;
+	let is_paypal_payments_active    = is_paypal_payments_installed && $ppcp_row.hasClass( 'active' );
 
-	const targetElement = $( 'tr[data-slug="woocommerce-paypal-payments"]' );
-	if ( targetElement.length ) {
-		is_paypal_payments_installed = true;
-
-		if ( targetElement.hasClass( 'active' ) ) {
-			is_paypal_payments_active = true;
+	let updateUI = function() {
+		// Dynamically update plugin activation link to handle plugin folder renames.
+		if ( is_paypal_payments_installed > 0 ) {
+			$notice_row.find( 'a#ppec-activate-paypal-payments' ).attr( 'href', $ppcp_row.find( 'span.activate a' ).attr( 'href' ) );
 		}
 
-		// Dynamically update plugin activation link to handle plugin folder renames.
-		let activation_url = $( targetElement ).find( 'span.activate a' ).attr( 'href' );
-		$( 'a#ppec-activate-paypal-payments' ).attr( 'href', activation_url );
-	}
+		// Hide notice/buttons conditionally.
+		$notice_row.find( 'a#ppec-install-paypal-payments' ).toggle( ! is_paypal_payments_installed );
+		$notice_row.find( 'a#ppec-activate-paypal-payments' ).toggle( is_paypal_payments_installed && ! is_paypal_payments_active );
 
-	// Hide notice/buttons conditionally.
-	if ( is_paypal_payments_installed && is_paypal_payments_active ) {
-		$( 'tr#ppec-migrate-notice' ).hide();
-	} else if ( is_paypal_payments_installed ) {
-		$( 'a#ppec-install-paypal-payments' ).hide();
-	} else {
-		$( 'a#ppec-activate-paypal-payments' ).hide();
-	}
-
-	// Display buttons area
-	$( '#ppec-migrate-notice .ppec-notice-buttons' ).removeClass( 'hidden' );
+		// Display buttons area.
+		$notice_row.find( '.ppec-notice-buttons' ).removeClass( 'hidden' );
+	};
 
 	// Handle delete event for PayPal Payments.
 	$( document ).on( 'wp-plugin-delete-success', function( event, response ) {
-		if ( is_paypal_payments_installed && 'woocommerce-paypal-payments' === response.slug ) {
-			$( 'a#ppec-activate-paypal-payments' ).hide();
-			$( 'a#ppec-install-paypal-payments' ).show();
+		if ( 'woocommerce-paypal-payments' === response.slug ) {
+			is_paypal_payments_installed = false;
+			is_paypal_payments_active    = false;
+			updateUI();
 		}
 	} );
 
 	// Change button text when install link is clicked.
-	$( document ).on( 'click', '#ppec-install-paypal-payments', function( e ) {
+	$notice_row.find( '#ppec-install-paypal-payments' ).click( function( e ) {
 		e.preventDefault();
 		$( this ).addClass( 'updating-message' ).text( 'Installing...' );
 		const install_link = $( this ).attr('href');
 		setTimeout( function(){
 			window.location = install_link;
-		}, 100 );
-	});
+		}, 50 );
+	} );
 })( jQuery, window, document );

--- a/assets/js/admin/ppec-upgrade-notice.js
+++ b/assets/js/admin/ppec-upgrade-notice.js
@@ -44,4 +44,25 @@
 			window.location = install_link;
 		}, 50 );
 	} );
+
+	// Dismiss button.
+	$( document).on( 'click', '#ppec-migrate-notice button.notice-dismiss', function( e ) {
+		$.ajax(
+			{
+				url: ajaxurl,
+				method: 'POST',
+				data: {
+					action: 'ppec_dismiss_ppec_upgrade_notice',
+					_ajax_nonce: $notice_row.attr( 'data-dismiss-nonce' )
+				},
+				dataType: 'json',
+				success: function( res ) {
+					$ppec_row.removeClass( 'hide-border' );
+				}
+			}
+		);
+	} );
+
+	updateUI();
+
 })( jQuery, window, document );

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -170,9 +170,9 @@ class WC_Gateway_PPEC_Plugin {
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_ajax_ppec_dismiss_notice_message', array( $this, 'ajax_dismiss_notice' ) );
 
-		add_action( 'after_plugin_row_' . plugin_basename( $this->file ), array( $this, 'ppec_upgrade_notice' ), 10, 3 );
 		// Upgrade notice.
 		add_action( 'after_plugin_row_' . plugin_basename( $this->file ), array( $this, 'ppec_upgrade_notice' ), 0, 3 );
+		add_action( 'wp_ajax_ppec_dismiss_ppec_upgrade_notice', array( $this, 'ppec_upgrade_notice_dismiss_ajax' ) );
 	}
 
 	public function bootstrap() {
@@ -508,12 +508,22 @@ class WC_Gateway_PPEC_Plugin {
 	 * @param string $status Status filter currently applied to the plugin list.
 	 */
 	public function ppec_upgrade_notice( $plugin_file, $plugin_data, $status ) {
+		if ( 'yes' === get_transient( 'ppec-upgrade-notice-dismissed' ) ) {
+			return;
+		}
+
 		// Load styles & scripts required for the notice.
 		wp_enqueue_style( 'ppec-upgrade-notice', plugin_dir_url( __DIR__ ) . '/assets/css/admin/ppec-upgrade-notice.css', array(), WC_GATEWAY_PPEC_VERSION );
 		wp_enqueue_script( 'ppec-upgrade-notice-js', plugin_dir_url( __DIR__ ) . '/assets/js/admin/ppec-upgrade-notice.js', array(), WC_GATEWAY_PPEC_VERSION, false );
 
 		// Load notice template.
 		include_once $this->plugin_path . 'templates/paypal-payments-upgrade-notice.php';
+	}
+
+	public function ppec_upgrade_notice_dismiss_ajax() {
+		check_ajax_referer( 'ppec-upgrade-notice-dismiss' );
+		set_transient( 'ppec-upgrade-notice-dismissed', 'yes', MONTH_IN_SECONDS );
+		wp_send_json_success();
 	}
 
 	/* Deprecated Functions */

--- a/includes/class-wc-gateway-ppec-plugin.php
+++ b/includes/class-wc-gateway-ppec-plugin.php
@@ -171,6 +171,8 @@ class WC_Gateway_PPEC_Plugin {
 		add_action( 'wp_ajax_ppec_dismiss_notice_message', array( $this, 'ajax_dismiss_notice' ) );
 
 		add_action( 'after_plugin_row_' . plugin_basename( $this->file ), array( $this, 'ppec_upgrade_notice' ), 10, 3 );
+		// Upgrade notice.
+		add_action( 'after_plugin_row_' . plugin_basename( $this->file ), array( $this, 'ppec_upgrade_notice' ), 0, 3 );
 	}
 
 	public function bootstrap() {

--- a/templates/paypal-payments-upgrade-notice.php
+++ b/templates/paypal-payments-upgrade-notice.php
@@ -31,28 +31,22 @@ $paypal_payments_activate_link = wp_nonce_url(
 );
 ?>
 
-<tr class="plugin-update-tr active notice-warning notice-alt"  id="ppec-migrate-notice">
+<tr class="plugin-update-tr active notice-warning notice-alt"  id="ppec-migrate-notice" data-dismiss-nonce="<?php echo esc_attr( wp_create_nonce( 'ppec-upgrade-notice-dismiss' ) ); ?>">
 	<td colspan="4" class="plugin-update colspanchange">
-		<div class="update-message notice inline notice-warning notice-alt">
+		<div class="notice notice-error inline update-message notice-alt is-dismissible">
 			<div class='ppec-notice-title ppec-notice-section'>
-				<p>Upgrade to PayPal Payments: the best way to get paid with PayPal and WooCommerce</p>
+				<p><strong>Action Required: Switch to WooCommerce PayPal Payments</strong></p>
 			</div>
 			<div class='ppec-notice-content ppec-notice-section'>
-				<p><strong>WooCommerce PayPal Payments</strong> is a full-stack solution that offers powerful and flexible payment processing capabilities. Expand your business by connecting with over 370+ million active PayPal accounts around the globe. With PayPal, you can sell in 200+ markets and accept 100+ currencies. Plus, PayPal can automatically identify customer locations and offer country-specific, local payment methods.</p>
-
-				<p>Upgrade now and get access to these great features:</p>
-
-				<ul>
-					<li>Give your customers their preferred ways to pay with one checkout solution. Accept <strong>PayPal</strong>, <strong>PayPal Credit</strong>, <strong>Pay Later</strong> options (available in the US, UK, France, and Germany), <strong>credit & debit cards</strong>, and country-specific, <strong>local payment methods</strong> on any device.</li>
-					<li>Offer subscriptions and accept recurring payments as PayPal is compatible with <a target="_blank" href="https://woocommerce.com/products/woocommerce-subscriptions/"><strong>WooCommerce Subscriptions</strong></a>.</li>
-				</ul>
+				<p>As of 1 Sept 2021, PayPal Checkout is officially retired from WooCommerce.com, and support for this product will end as of 1 March 2022.</p>
+				<p>We highly recommend upgrading to <a href="https://woocommerce.com/products/woocommerce-paypal-payments/" target="_blank">PayPal Payments</a>, the latest, fully supported extension that includes all of the features of PayPal Checkout and more.</p>
 			</div>
 			<div class='ppec-notice-buttons ppec-notice-section hidden'>
 				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<a id="ppec-install-paypal-payments" href="<?php echo $paypal_payments_install_link; ?>" class="button button-primary woocommerce-save-button">Upgrade to PayPal Payments now</a>
+				<a id="ppec-install-paypal-payments" href="<?php echo $paypal_payments_install_link; ?>" class="button button-primary">Upgrade to PayPal Payments now</a>
 				<?php //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<a id="ppec-activate-paypal-payments" href="<?php echo $paypal_payments_activate_link; ?>" class="button button-primary woocommerce-save-button">Activate PayPal Payments now</a>
-				<a href="https://woocommerce.com/products/woocommerce-paypal-payments/" target="_blank" class="button woocommerce-save-button">Learn more</a>
+				<a id="ppec-activate-paypal-payments" href="<?php echo $paypal_payments_activate_link; ?>" class="button button-primary">Activate PayPal Payments now</a>
+				<a href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-upgrade-guide/" target="_blank" class="button woocommerce-save-button">Learn more</a>
 			</div>
 		</div>
 	</td>


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This PR updates the text for the PPCP upgrade notice on the Plugins screen to reflect the latest info available. Also, makes the notice dismissible (hiding it for a month).

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Uninstall PayPal Payments (if installed).
1. Go to the Plugins screen in your admin dashboard.
1. Take a look at the current notice under the "PayPal Checkout" plugin row.
1. Check out this branch (`fix-notice`).
1. Confirm that the text and notice colors have changed.
1. Play with the buttons (Upgrade/Activate/Learn More") and confirm they are working as expected:
   - The "upgrade" button should trigger an install of PayPal Payments.
   - The "activate" button should activate the PayPal Payments plugin (if installed but inactive).
   - Removing the PayPal Payments plugin should bring back the "upgrade" button.
1. Click the "X" to dismiss the message.
1. Confirm that the notice has disappeared.
1. Refresh the page and confirm that the notice is not displayed.
1. Remove from the `wp_options` table, rows with `option_name` equal to `_transient_timeout_ppec-upgrade-notice-dismissed` and `_transient_ppec-upgrade-notice-dismissed` to simulate a month has passed.
1. Refresh the page and see the notice again.

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Make upgrade notice dismissible and update it with new text.
