### PR TITLE
Remove broken Plugin URI

### DIFF
--- a/woocommerce-gateway-paypal-express-checkout.php
+++ b/woocommerce-gateway-paypal-express-checkout.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Plugin Name: WooCommerce PayPal Checkout Gateway
- * Plugin URI: https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/
  * Description: Accept all major credit and debit cards, plus Venmo and PayPal Credit in the US, presenting options in a customizable stack of payment buttons. Fast, seamless, and flexible.
  * Version: 2.1.2
  * Author: WooCommerce


### PR DESCRIPTION
Currently, the "Plugin URI" header points to a nonexistent page on woocommerce.com. This PR removes this broken URL.